### PR TITLE
Improve WebSocket logging and error handling

### DIFF
--- a/custom_components/dreo/pydreo/__init__.py
+++ b/custom_components/dreo/pydreo/__init__.py
@@ -303,8 +303,14 @@ class PyDreo:  # pylint: disable=function-redefined
 
     def _ws_consume_message(self, message) :
         messageDeviceSn = message["devicesn"]
-        device : PyDreoBaseDevice = self._deviceListBySn[messageDeviceSn] 
-        device.handle_server_update_base(message)
+
+        if (messageDeviceSn in self._deviceListBySn):
+            device = self._deviceListBySn[messageDeviceSn]
+            device.handle_server_update_base(message)
+        else:
+            # Message is to an unknown device, log it out just in case...
+            _LOGGER.debug("Received message for unknown or unsupported device. SN: {0}".format(messageDeviceSn))
+            _LOGGER.debug("Message: {0}".format(message))
 
     def send_command(self, device : PyDreoBaseDevice, params):
         fullParams = {


### PR DESCRIPTION
- Log out WebSocket calls to unknown devices for debugging.
- Don't fail if we receive a call for an unknown device SN.