### PR TITLE
Update basedevice.py

### DIFF
--- a/custom_components/dreo/basedevice.py
+++ b/custom_components/dreo/basedevice.py
@@ -44,12 +44,11 @@ class DreoBaseDeviceHA(Entity):
     def should_poll(self):
         return False
 
-    async def async_added_to_hass(self):
+    def async_added_to_hass(self):
         """Register callbacks."""
 
-        @callback
         def update_state():
             # Tell HA we're ready to update
-            self.async_schedule_update_ha_state(True)
+            self.schedule_update_ha_state(True)
 
         self.device.add_attr_callback(update_state)


### PR DESCRIPTION
⚒️: Fix: DREO State
🐞: After restarting the server / home assistant, the Dreo entities are displayed as unknown. However, as soon as they are switched on or off directly in the DREO app, the entity will be displayed correctly again in Home Assistant until the next restart