### PR TITLE
Support integration unload and reload

### DIFF
--- a/custom_components/dreo/__init__.py
+++ b/custom_components/dreo/__init__.py
@@ -10,6 +10,7 @@ from .const import (
     DREO_HEATERS,
     DREO_ACS,
     DREO_MANAGER,
+    DREO_PLATFORMS,
     CONF_AUTO_RECONNECT
 )
 
@@ -80,10 +81,24 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         platforms.add(Platform.SWITCH)
         platforms.add(Platform.NUMBER)
 
+    hass.data[DOMAIN][DREO_PLATFORMS] = platforms
+
     _LOGGER.debug("Platforms are: %s", platforms)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, platforms)
     return True
+
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    manager = hass.data[DOMAIN][DREO_MANAGER]
+    if unload_ok := await hass.config_entries.async_unload_platforms(
+        config_entry,
+        hass.data[DOMAIN][DREO_PLATFORMS],
+    ):
+        hass.data.pop(DOMAIN)
+
+    manager.stop_transport()
+    return unload_ok
 
 def process_devices(manager) -> dict:
     """Assign devices to proper component."""

--- a/custom_components/dreo/__init__.py
+++ b/custom_components/dreo/__init__.py
@@ -86,6 +86,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     _LOGGER.debug("Platforms are: %s", platforms)
 
     await hass.config_entries.async_forward_entry_setups(config_entry, platforms)
+
+    async def _update_listener(hass: HomeAssistant, config_entry: ConfigEntry):
+        """Handle options update."""
+        await hass.config_entries.async_reload(config_entry.entry_id)
+
+    ## Create update listener
+    config_entry.async_on_unload(config_entry.add_update_listener(_update_listener))
+
     return True
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/custom_components/dreo/const.py
+++ b/custom_components/dreo/const.py
@@ -9,5 +9,6 @@ DREO_HEATERS = "heaters"
 DREO_ACS = "acs"
 DREO_SENSORS = "sensors"
 DREO_MANAGER = "manager"
+DREO_PLATFORMS = "platforms"
 
 CONF_AUTO_RECONNECT = "auto_reconnect"

--- a/custom_components/dreo/pydreo/commandtransport.py
+++ b/custom_components/dreo/pydreo/commandtransport.py
@@ -120,6 +120,12 @@ class CommandTransport:
         _LOGGER.debug("CommandTransport::_ws_handler - WebSocket appears closed.")
         for task in pending:
             task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        for task in done:
+            task.exception()
         
     async def _ws_consumer_handler(self, ws):
         _LOGGER.debug("CommandTransport::_ws_consumer_handler")

--- a/custom_components/dreo/strings.json
+++ b/custom_components/dreo/strings.json
@@ -22,8 +22,7 @@
           "title": "Dreo Options",
           "data": {
             "auto_reconnect": "Automatically reconnect if the websocket drops."
-          },
-          "description": "Restart Home Assistant after changing these options."
+          }
         }
       }
     }

--- a/custom_components/dreo/translations/en.json
+++ b/custom_components/dreo/translations/en.json
@@ -22,8 +22,7 @@
           "title": "Dreo Options",
           "data": {
             "auto_reconnect": "Automatically reconnect if the websocket drops."
-          },
-          "description": "Restart Home Assistant after changing these options."
+          }
         }
       }
     }


### PR DESCRIPTION
* Add `async_unload_entry` to allow integration to be unloaded and reloaded
* Reload integration on options flow form submit, form hint to reload HA removed
* Retrieve task exceptions during cancellation to avoid exceptions on `stop_transport`
