### PR TITLE
Update models.py for DR-HAF001S

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -89,9 +89,9 @@ SUPPORTED_FANS = {
     range = {SPEED_RANGE: (1, 9)}
     ), 
     "DR-HAF001S": DreoDeviceDetails(
-        preset_modes=[FAN_MODE_NORMAL, FAN_MODE_NATURAL, FAN_MODE_SLEEP, FAN_MODE_AUTO, FAN_MODE_TURBO],
+        preset_modes=[FAN_MODE_NORMAL, FAN_MODE_NATURAL, FAN_MODE_SLEEP, FAN_MODE_AUTO],
         range = {SPEED_RANGE: (1, 4)}
-    ),    
+    ),
     "DR-HAF003S": DreoDeviceDetails(
         preset_modes=[FAN_MODE_NORMAL, FAN_MODE_NATURAL, FAN_MODE_SLEEP, FAN_MODE_AUTO, FAN_MODE_TURBO],
         range = {SPEED_RANGE: (1, 8)}


### PR DESCRIPTION
## DR-HAF001S does not support Turbo Mode.

Using this preset in Home Assistant results in the fan operating with no fan speed(fan will still oscillate and appear to be on, but with no fan blade movement).

DR-HAF001S fully works as expected in Home Assistant after this change has been made and Home Assistant reloaded.