### PR TITLE
Add support for DR-HPF001S (PolyFan 311S)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Currently supported models are listed below.
 -   DR-HAF003S
 -   DR-HAF004S
 -   DR-HPF002S
+-   DR-HPF001S
 
 
 #### Humidifiers

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -83,15 +83,15 @@ SUPPORTED_FANS = {
     "DR-HTF008S": DreoDeviceDetails(
         preset_modes=[FAN_MODE_NORMAL, FAN_MODE_NATURAL, FAN_MODE_SLEEP, FAN_MODE_AUTO],
         range = {SPEED_RANGE: (1, 5)}
-    ),   
+    ),
     "DR-HTF009S": DreoDeviceDetails(
-    preset_modes=[FAN_MODE_NORMAL, FAN_MODE_NATURAL, FAN_MODE_SLEEP, FAN_MODE_AUTO],
-    range = {SPEED_RANGE: (1, 9)}
-    ), 
+        preset_modes=[FAN_MODE_NORMAL, FAN_MODE_NATURAL, FAN_MODE_SLEEP, FAN_MODE_AUTO],
+        range = {SPEED_RANGE: (1, 9)}
+    ),
     "DR-HAF001S": DreoDeviceDetails(
         preset_modes=[FAN_MODE_NORMAL, FAN_MODE_NATURAL, FAN_MODE_SLEEP, FAN_MODE_AUTO, FAN_MODE_TURBO],
         range = {SPEED_RANGE: (1, 4)}
-    ),    
+    ),
     "DR-HAF003S": DreoDeviceDetails(
         preset_modes=[FAN_MODE_NORMAL, FAN_MODE_NATURAL, FAN_MODE_SLEEP, FAN_MODE_AUTO, FAN_MODE_TURBO],
         range = {SPEED_RANGE: (1, 8)}
@@ -103,7 +103,11 @@ SUPPORTED_FANS = {
     "DR-HPF002S": DreoDeviceDetails(
         preset_modes=[FAN_MODE_NORMAL, FAN_MODE_NATURAL, FAN_MODE_SLEEP, FAN_MODE_AUTO, FAN_MODE_TURBO],
         range = {SPEED_RANGE: (1, 8)}
-    )
+    ),
+    "DR-HPF001S": DreoDeviceDetails(
+        preset_modes=[FAN_MODE_NORMAL, FAN_MODE_NATURAL, FAN_MODE_SLEEP, FAN_MODE_AUTO, FAN_MODE_TURBO],
+        range = {SPEED_RANGE: (1, 9)}
+    ),
 }
 
 


### PR DESCRIPTION
This add support for this fan https://www.amazon.com/Dreo-Oscillating-Standing-Circulator-Adjustable/dp/B0CTCWLV35?th=1
It actually has 9 speeds (one more than advertised on Amazon).

Working for me as expected in HA 2024.7.1. This model does not have vertical oscillation control but I was unsure on how to disable those vars. (If you can point me to the place to add an override I can update my PR)

Proof:
![image](https://github.com/user-attachments/assets/c066c97c-3a9d-4581-aa0c-33404de078f8)
