### PR TITLE
Restore hass.config_entries.async_forward_entry_setups removed in #105

### DIFF
--- a/custom_components/dreo/__init__.py
+++ b/custom_components/dreo/__init__.py
@@ -82,9 +82,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     _LOGGER.debug("Platforms are: %s", platforms)
 
-    for platform in platforms:
-        await hass.config_entries.async_forward_entry_setup(config_entry, platform)
-
+    await hass.config_entries.async_forward_entry_setups(config_entry, platforms)
     return True
 
 def process_devices(manager) -> dict:


### PR DESCRIPTION
Restore use of `hass.config_entries.async_forward_entry_setups` in `async_setup_entry` as described in https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/. This was removed in #105. Fixes #130