### PR TITLE
Fix speed detection for some fans.

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -91,12 +91,7 @@ SUPPORTED_FANS = {
     "DR-HTF": DreoDeviceDetails(),
     "DR-HAF": DreoDeviceDetails(),
     "DR-HPF": DreoDeviceDetails(),
-    "DR-HCF": DreoDeviceDetails(),
-    "DR-HTF005S": DreoDeviceDetails(
-        range={
-            SPEED_RANGE: (1, 12)
-        }
-    ),
+    "DR-HCF": DreoDeviceDetails()
 }
 
 SUPPORTED_HEATERS = {

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -91,7 +91,12 @@ SUPPORTED_FANS = {
     "DR-HTF": DreoDeviceDetails(),
     "DR-HAF": DreoDeviceDetails(),
     "DR-HPF": DreoDeviceDetails(),
-    "DR-HCF": DreoDeviceDetails()
+    "DR-HCF": DreoDeviceDetails(),
+    "DR-HTF005S": DreoDeviceDetails(
+        range={
+            SPEED_RANGE: (1, 12)
+        }
+    ),
 }
 
 SUPPORTED_HEATERS = {

--- a/custom_components/dreo/pydreo/pydreofan.py
+++ b/custom_components/dreo/pydreo/pydreofan.py
@@ -81,19 +81,39 @@ class PyDreoFan(PyDreoBaseDevice):
 
     def parse_speed_range(self, details: Dict[str, list]) -> tuple[int, int]:
         """Parse the speed range from the details."""
+        # There are a bunch of different places this could be, so we're going to look in
+        # multiple places.
+        speed_range : tuple[int, int] = None
         controls_conf = details.get("controlsConf", None)
         if controls_conf is not None:
-            control = controls_conf.get("control", None)
-            if (control is not None):
-                for control_item in control:
-                    if (control_item is not None):
-                        if control_item.get("type", None) == "Speed":
-                            lowSpeed = control_item.get("items", None)[0].get("value", None)
-                            highSpeed = control_item.get("items", None)[1].get("value", None)
-                            speed_range = (lowSpeed, highSpeed)
-                            _LOGGER.debug("PyDreoFan:Detected speed range - %s", speed_range)
+            extra_configs = controls_conf.get("extraConfigs")
+            if (extra_configs is not None):
+                _LOGGER.debug("PyDreoFan:Detected extraConfigs")
+                for extra_config_item in extra_configs:
+                    if extra_config_item.get("key", None) == "control":
+                        _LOGGER.debug("PyDreoFan:Detected extraConfigs/control")
+                        speed_range = self.parse_speed_range_from_control_node(extra_config_item.get("value", None))
+                        if (speed_range is not None):
+                            _LOGGER.debug("PyDreoFan:Detected speed range from extraConfig - %s", speed_range)
                             return speed_range
 
+            control_node = controls_conf.get("control", None)
+            if (control_node is not None):
+                speed_range = self.parse_speed_range_from_control_node(control_node)
+                _LOGGER.debug("PyDreoFan:Detected speed range from controlsConf - %s", speed_range)
+                return speed_range
+        return None
+
+    def parse_speed_range_from_control_node(self, control_node) -> tuple[int, int]:
+        """Parse the speed range from a control node"""
+        for control_item in control_node:
+            if control_item.get("type", None) == "Speed":
+                speed_low = control_item.get("items", None)[0].get("value", None)
+                speed_high = control_item.get("items", None)[1].get("value", None)
+                speed_range = (speed_low, speed_high)
+                return speed_range
+        return None
+    
     def parse_preset_modes(self, details: Dict[str, list]) -> tuple[str, int]:
         """Parse the preset modes from the details."""
         preset_modes = []
@@ -102,12 +122,11 @@ class PyDreoFan(PyDreoBaseDevice):
             control = controls_conf.get("control", None)
             if (control is not None):
                 for control_item in control:
-                    if (control_item is not None):
-                        if control_item.get("type", None) == "Mode":
-                            for mode_item in control_item.get("items", None):
-                                text = mode_item.get("image", None).split("_")[1]
-                                value = mode_item.get("value", None)
-                                preset_modes.append((text, value))
+                    if control_item.get("type", None) == "Mode":
+                        for mode_item in control_item.get("items", None):
+                            text = mode_item.get("image", None).split("_")[1]
+                            value = mode_item.get("value", None)
+                            preset_modes.append((text, value))
             schedule = controls_conf.get("schedule", None)
             if (schedule is not None):
                 modes = schedule.get("modes", None)

--- a/tests/pydreo/api_responses/get_device_state_HTF005S_1.json
+++ b/tests/pydreo/api_responses/get_device_state_HTF005S_1.json
@@ -1,0 +1,103 @@
+{
+    "code": 0,
+    "msg": "OK",
+    "data": {
+      "mixed": {
+        "wifi_ssid": "**REDACTED**",
+        "mcu_hardware_model": {
+          "state": "SC95F8613B-2/US",
+          "timestamp": 1724948724
+        },
+        "windlevel": {
+          "state": 1,
+          "timestamp": 1724986532
+        },
+        "wifi_rssi": {
+          "state": -25,
+          "timestamp": 1724948724
+        },
+        "windtype": {
+          "state": 1,
+          "timestamp": 1724948724
+        },
+        "poweron": {
+          "state": true,
+          "timestamp": 1724979904
+        },
+        "scheid": {
+          "state": 0,
+          "timestamp": 1724948724
+        },
+        "timeron": {
+          "state": {
+            "du": 0,
+            "ts": 0
+          },
+          "timestamp": null
+        },
+        "scheon": {
+          "state": false,
+          "timestamp": 1724948724
+        },
+        "voiceon": {
+          "state": true,
+          "timestamp": 1724948724
+        },
+        "wrong": {
+          "state": 0,
+          "timestamp": 1724948724
+        },
+        "module_firmware_version": {
+          "state": "3.2.6",
+          "timestamp": 1724948724
+        },
+        "mcuon": {
+          "state": true,
+          "timestamp": 1724948724
+        },
+        "connected": {
+          "state": true,
+          "timestamp": 1724948724
+        },
+        "timeroff": {
+          "state": {
+            "du": 0,
+            "ts": 0
+          },
+          "timestamp": null
+        },
+        "shakehorizon": {
+          "state": true,
+          "timestamp": 1724948724
+        },
+        "network_latency": {
+          "state": 34,
+          "timestamp": 1724948724
+        },
+        "_ota": {
+          "state": 0,
+          "timestamp": 1724948724
+        },
+        "module_hardware_model": {
+          "state": "HeFi",
+          "timestamp": 1724948724
+        },
+        "mcu_firmware_version": {
+          "state": "1.1.3",
+          "timestamp": 1724948724
+        },
+        "temperature": {
+          "state": 79,
+          "timestamp": 1724987317
+        },
+        "module_hardware_mac": "**REDACTED**",
+        "ledalwayson": {
+          "state": false,
+          "timestamp": 1724948724
+        }
+      },
+      "sn": "**REDACTED**",
+      "productId": "1514165925956890625",
+      "region": "us-east-2/emq"
+    }
+}

--- a/tests/pydreo/api_responses/get_devices_HTF005S.json
+++ b/tests/pydreo/api_responses/get_devices_HTF005S.json
@@ -1,0 +1,422 @@
+{
+    "code": 0,
+    "msg": "OK",
+    "data": {
+    "currentPage": 1,
+    "pageSize": 100,
+    "totalNum": 1,
+    "totalPage": 1,
+    "familyRooms": null,
+    "list": [
+        {
+        "deviceId": "1828558438380138498",
+        "sn": "HTF005S_1",
+        "brand": "Dreo",
+        "model": "DR-HTF005S",
+        "productId": "1514165925956890625",
+        "productName": "Tower Fan",
+        "deviceName": "Pilot Pro S",
+        "shared": false,
+        "series": null,
+        "seriesName": "Pilot Pro S",
+        "type": 0,
+        "owner": true,
+        "familyId": null,
+        "familyName": null,
+        "roomId": null,
+        "roomName": null,
+        "roomNameI18Key": "",
+        "color": "s",
+        "controlsConf": {
+            "template": "DR-HTF005S",
+            "lottie": {
+            "key": "poweron",
+            "frames": [
+                {
+                "value": 0,
+                "frame": [
+                    0
+                ]
+                },
+                {
+                "value": 1,
+                "frame": [
+                    2
+                ]
+                }
+            ]
+            },
+            "schedule": {
+            "modes": [
+                {
+                "icon": "ic_normal_wind_color",
+                "title": "device_fans_mode_straight",
+                "cmd": "windtype",
+                "value": 1,
+                "valueType": 1,
+                "isSelected": true,
+                "attention": [
+                    "windtype",
+                    "windlevel",
+                    "poweron",
+                    "shakehorizon"
+                ],
+                "controls": [
+                    {
+                    "type": 0,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": [
+                        "windlevel"
+                    ],
+                    "value": 7,
+                    "valueType": 1,
+                    "startValue": 1,
+                    "endValue": 9,
+                    "groupId": 0,
+                    "icon": "ic_sch_wind_speed",
+                    "isSelected": false
+                    }
+                ]
+                },
+                {
+                "icon": "ic_natural_wind_color",
+                "title": "device_fans_mode_natural",
+                "cmd": "windtype",
+                "value": 2,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": [
+                    "windtype",
+                    "windlevel",
+                    "poweron",
+                    "shakehorizon",
+                    "shakehorizonangle"
+                ],
+                "controls": [
+                    {
+                    "type": 0,
+                    "valueType": 1,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": [
+                        "windlevel"
+                    ],
+                    "value": 7,
+                    "startValue": 1,
+                    "endValue": 9,
+                    "groupId": 0,
+                    "icon": "ic_sch_wind_speed",
+                    "isSelected": false
+                    }
+                ]
+                },
+                {
+                "icon": "ic_sleep_wind_color",
+                "title": "device_fans_mode_sleep",
+                "cmd": "windtype",
+                "value": 3,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": [
+                    "windtype",
+                    "windlevel",
+                    "poweron",
+                    "shakehorizon",
+                    "shakehorizonangle"
+                ],
+                "controls": [
+                    {
+                    "type": 0,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": [
+                        "windlevel"
+                    ],
+                    "value": 7,
+                    "valueType": 1,
+                    "startValue": 1,
+                    "endValue": 9,
+                    "groupId": 0,
+                    "isSelected": false,
+                    "icon": "ic_sch_wind_speed"
+                    }
+                ]
+                },
+                {
+                "icon": "ic_auto_wind_color",
+                "title": "device_control_mode_auto",
+                "cmd": "windtype",
+                "value": 4,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": [
+                    "windtype",
+                    "windlevel",
+                    "poweron",
+                    "shakehorizon",
+                    "shakehorizonangle"
+                ],
+                "controls": [
+                    {
+                    "type": 0,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": [
+                        "windlevel"
+                    ],
+                    "value": 7,
+                    "valueType": 1,
+                    "startValue": 1,
+                    "endValue": 9,
+                    "groupId": 0,
+                    "isSelected": false,
+                    "icon": "ic_sch_wind_speed"
+                    }
+                ]
+                }
+            ]
+            },
+            "cards": [
+            {
+                "type": 2,
+                "title": "device_control_temp",
+                "icon": "",
+                "image": "",
+                "url": "",
+                "show": true
+            },
+            {
+                "type": 8,
+                "title": "",
+                "icon": "",
+                "image": "",
+                "url": "dreo://nav/device/schedule?deviceSn={sn}",
+                "show": true,
+                "key": "",
+                "minVersion": "2.5.0"
+            },
+            {
+                "type": 6,
+                "title": "device_settings_title",
+                "icon": "ic_setting",
+                "image": "",
+                "url": "dreo://nav/device/setting?deviceSn=${sn}",
+                "show": true,
+                "key": "setting"
+            },
+            {
+                "type": 6,
+                "title": "base_clean_tutorial",
+                "icon": "https://resources.dreo-cloud.com/app/202312/4/c06d58240e114f019c92abf5d3bd6f8c.png",
+                "image": "",
+                "url": "https://fe.dreo.com/guides/product-clean/pilot-pro-s",
+                "show": true,
+                "minVersion": "2.6.8"
+            }
+            ],
+            "feature": {
+            "schedule": {
+                "enable": true,
+                "localSupport": true,
+                "module": [
+                {
+                    "type": "HeFi",
+                    "version": "3.2.2"
+                }
+                ]
+            }
+            },
+            "preference": [
+            {
+                "id": "200",
+                "type": "Panel Sound",
+                "title": "device_control_panelsound",
+                "image": "ic_mute",
+                "reverse": false,
+                "cmd": "voiceon"
+            },
+            {
+                "id": "210",
+                "type": "Display Auto Off",
+                "title": "device_fans_mode_auto_display",
+                "image": "ic_display",
+                "reverse": true,
+                "cmd": "ledalwayson"
+            },
+            {
+                "id": "230",
+                "type": "Temperature Unit",
+                "title": "device_control_temp_unit",
+                "image": "ic_temp_unit"
+            },
+            {
+                "id": "250",
+                "type": "Temperature Calibration",
+                "title": "device_control_temp_calibration",
+                "image": "ic_temp_cal"
+            }
+            ],
+            "extraConfigs": [
+            {
+                "key": "control",
+                "value": [
+                {
+                    "id": "110",
+                    "type": "Speed",
+                    "title": "device_control_speed",
+                    "items": [
+                    {
+                        "text": "1",
+                        "cmd": "windlevel",
+                        "value": 1
+                    },
+                    {
+                        "text": "12",
+                        "cmd": "windlevel",
+                        "value": 12
+                    }
+                    ]
+                }
+                ],
+                "firmware": {
+                "minMcuVer": "",
+                "minModuleVer": "",
+                "mcuModel": "SC95F8613B-2/US",
+                "moduleModel": ""
+                }
+            }
+            ],
+            "control": [
+            {
+                "id": "100",
+                "type": "Mode",
+                "title": "device_mode",
+                "items": [
+                {
+                    "text": "device_fans_mode_straight",
+                    "textColors": [
+                    "#D5D6D7",
+                    "#D5D6D7"
+                    ],
+                    "image": "ic_normal_wind",
+                    "imageColors": [
+                    "#D5D6D7",
+                    "#25D7E4"
+                    ],
+                    "cmd": "windtype",
+                    "value": 1
+                },
+                {
+                    "text": "device_fans_mode_natural",
+                    "textColors": [
+                    "#D5D6D7",
+                    "#D5D6D7"
+                    ],
+                    "image": "ic_natural_wind",
+                    "imageColors": [
+                    "#D5D6D7",
+                    "#2CDD96"
+                    ],
+                    "cmd": "windtype",
+                    "value": 2
+                },
+                {
+                    "text": "device_control_mode_sleep",
+                    "textColors": [
+                    "#D5D6D7",
+                    "#D5D6D7"
+                    ],
+                    "image": "ic_sleep_wind",
+                    "imageColors": [
+                    "#D5D6D7",
+                    "#6249DF"
+                    ],
+                    "cmd": "windtype",
+                    "value": 3
+                },
+                {
+                    "text": "device_control_mode_auto",
+                    "textColors": [
+                    "#D5D6D7",
+                    "#D5D6D7"
+                    ],
+                    "image": "ic_auto_wind",
+                    "imageColors": [
+                    "#D5D6D7",
+                    "#0A80F5"
+                    ],
+                    "cmd": "windtype",
+                    "value": 4
+                }
+                ]
+            },
+            {
+                "id": "110",
+                "type": "Speed",
+                "title": "device_control_speed",
+                "items": [
+                {
+                    "text": "1",
+                    "cmd": "windlevel",
+                    "value": 1
+                },
+                {
+                    "text": "9",
+                    "cmd": "windlevel",
+                    "value": 9
+                }
+                ]
+            },
+            {
+                "id": "120",
+                "type": "Oscillation",
+                "title": "device_control_oscillation",
+                "items": [],
+                "cmd": "shakehorizon"
+            }
+            ],
+            "category": "Tower Fan",
+            "setting": [
+            {
+                "text": "Firmware Version",
+                "image": "image.png",
+                "value": "1.0.0",
+                "url": "dreo://control"
+            }
+            ]
+        },
+        "mainConf": {
+            "isSmart": true,
+            "isWifi": true,
+            "isBluetooth": true,
+            "isVoiceControl": true
+        },
+        "resourcesConf": {
+            "imageSmallSrc": "https://resources.dreo-cloud.com/app/preSigned202405/2302bbcd1232ac4326ae312abaa1cc6d70.png",
+            "imageFullSrc": "https://resources.dreo-cloud.com/app/202309/863baa919beea413783c2c6400029eb39.zip",
+            "imageSmallDarkSrc": "",
+            "imageFullDarkSrc": ""
+        },
+        "servicesConf": [
+            {
+            "key": "user_manual",
+            "value": "https://resources.dreo-cloud.com/app/202310/123555bd6d00ab4ce6bb86c14a98d99204.pdf"
+            }
+        ],
+        "userManuals": [
+            {
+            "url": "https://resources.dreo-cloud.com/app/202310/123555bd6d00ab4ce6bb86c14a98d99204.pdf",
+            "icon": null,
+            "desc": "User Manual",
+            "lang": "en"
+            }
+        ]
+        }
+    ]
+    }
+}

--- a/tests/pydreo/test_pydreofan.py
+++ b/tests/pydreo/test_pydreofan.py
@@ -50,6 +50,35 @@ class TestPyDreoFan(TestBase):
         with pytest.raises(ValueError):
             fan.fan_speed = 10
 
+
+    def test_HTF005S(self):  # pylint: disable=invalid-name
+        """Load fan and test sending commands."""
+
+        self.get_devices_file_name = "get_devices_HTF005S.json"
+        self.manager.load_devices()
+        assert len(self.manager.fans) == 1
+        fan = self.manager.fans[0]
+        assert fan.speed_range == (1, 12)
+        assert fan.preset_modes == ['normal', 'natural', 'sleep', 'auto']
+
+        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+            fan.is_on = True
+            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: True})
+
+        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+            fan.preset_mode = 'normal'
+            mock_send_command.assert_called_once_with(fan, {WINDTYPE_KEY: 1})
+
+        with pytest.raises(ValueError):
+            fan.preset_mode = 'not_a_mode'
+
+        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+            fan.fan_speed = 3
+            mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 3})
+
+        with pytest.raises(ValueError):
+            fan.fan_speed = 13
+
     def test_circulator_load_and_send_commands(self):
         """Load circulator fan and test sending commands."""
         self.get_devices_file_name = "get_devices_HAF004S.json"


### PR DESCRIPTION
This pull request includes significant changes to the `custom_components/dreo/pydreo/pydreofan.py` file and adds new tests and JSON responses to improve the functionality and testing of the Dreo fan component. The most important changes include refactoring the speed range parsing logic, adding new test cases, and including a new JSON response file for device state.

### Refactoring and Enhancements:

* [`custom_components/dreo/pydreo/pydreofan.py`](diffhunk://#diff-478a06427460acfdb3b48f9dc29f71faabc40c530abf9eea086ab181d3bcb4cdR84-R115): Refactored the `parse_speed_range` method to handle multiple configurations and added a helper method `parse_speed_range_from_control_node` to streamline the parsing logic.
* [`custom_components/dreo/pydreo/pydreofan.py`](diffhunk://#diff-478a06427460acfdb3b48f9dc29f71faabc40c530abf9eea086ab181d3bcb4cdL105): Simplified the `parse_preset_modes` method by removing unnecessary checks.

### Testing Improvements:

* [`tests/pydreo/test_pydreofan.py`](diffhunk://#diff-2a578b78115001bd2be7a88bc3d20f44bd6e7d06b6aab5b1d6ea227bbcb6955cR53-R81): Added a new test case `test_HTF005S` to verify the loading and command-sending functionality for the HTF005S fan model.
* [`tests/pydreo/api_responses/get_device_state_HTF005S_1.json`](diffhunk://#diff-82dfb455d3eca8cf5a1530500f62829737dc4af1acf1eda8310285b399f3d3d2R1-R103): Added a new JSON response file to mock the device state for the HTF005S fan model.