### PR TITLE
HA Layer Unit-Tests

### DIFF
--- a/custom_components/dreo/fan.py
+++ b/custom_components/dreo/fan.py
@@ -14,6 +14,7 @@ from .const import (
     DREO_MANAGER
 )
 
+from .pydreo import PyDreo
 from .pydreo.pydreofan import PyDreoFan
 
 _LOGGER = logging.getLogger(LOGGER)
@@ -27,9 +28,9 @@ async def async_setup_entry(
 ) -> None:
     """Set up the Dreo fan platform."""
     _LOGGER.info("Starting Dreo Fan Platform")
-    _LOGGER.debug("Dreo Fan:async_setup_platform")
+    _LOGGER.debug("Dreo Fan:async_setup_entry")
 
-    manager = hass.data[DOMAIN][DREO_MANAGER]
+    manager : PyDreo = hass.data[DOMAIN][DREO_MANAGER]
 
     fan_entities_ha = []
     for fan_entity_ha in manager.fans:

--- a/custom_components/dreo/number.py
+++ b/custom_components/dreo/number.py
@@ -104,18 +104,18 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
 )
 
 
-def add_entries(devices) -> []:
+def add_entries(pydreo_devices : list) -> []:
     number_ha_collection = []
     
-    for de in devices:
-        _LOGGER.debug("Number:add_entries: Adding Numbers for %s", de.name)
+    for pydreo_device in pydreo_devices:
+        _LOGGER.debug("Number:add_entries: Adding Numbers for %s", pydreo_device.name)
         for number_definition in NUMBERS:
-            _LOGGER.debug("Number:add_entries: checking attribute: %s on %s", number_definition.attr_name, de.name)
-            if de.is_feature_supported(number_definition.attr_name):
+            _LOGGER.debug("Number:add_entries: checking attribute: %s on %s", number_definition.attr_name, pydreo_device.name)
+            if pydreo_device.is_feature_supported(number_definition.attr_name):
                 _LOGGER.debug("Number:add_entries: Adding Number %s for %s", number_definition.key, number_definition.attr_name)
-                if hasattr(de.device_definition.range, number_definition.attr_name + "_range") and \
-                        de.device_definition.range[number_definition.attr_name + "_range"] is not None:
-                    n_range = de.device_definition.range[number_definition.attr_name + "_range"]
+                if hasattr(pydreo_device.device_definition.range, number_definition.attr_name + "_range") and \
+                        pydreo_device.device_definition.range[number_definition.attr_name + "_range"] is not None:
+                    n_range = pydreo_device.device_definition.range[number_definition.attr_name + "_range"]
                     _LOGGER.debug("Number:add_entries: range %s is %s", number_definition.attr_name + "_range", n_range)
                     if isinstance(n_range, tuple):
                         dned = DreoNumberEntityDescription(key=number_definition.key,
@@ -124,9 +124,9 @@ def add_entries(devices) -> []:
                                                            icon=number_definition.icon,
                                                            min_value=n_range[0],
                                                            max_value=n_range[1])
-                        number_ha_collection.append(DreoNumberHA(de, dned))
+                        number_ha_collection.append(DreoNumberHA(pydreo_device, dned))
                 else:
-                    number_ha_collection.append(DreoNumberHA(de,number_definition))
+                    number_ha_collection.append(DreoNumberHA(pydreo_device,number_definition))
     
     return number_ha_collection
     

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-pythonpath = tests/pydreo custom_components/dreo/pydreo
+#pythonpath = tests/pydreo custom_components/dreo/pydreo
 log_cli = 1
 log_cli_level = DEBUG
 log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,4 +1,5 @@
 # Strictly for tests
 pytest
 pytest-cov
+pytest-mock
 pyyaml

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -1,5 +1,4 @@
 # Strictly for tests
 pytest
 pytest-cov
-pytest-homeassistant-custom-component
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 websockets
 strenum
+requests
+voluptuous
+homeassistant

--- a/tests/dreo/__init__.py
+++ b/tests/dreo/__init__.py
@@ -1,0 +1,1 @@
+"""Empty file needed for pytest to find tests directory."""

--- a/tests/dreo/conftest.py
+++ b/tests/dreo/conftest.py
@@ -5,24 +5,6 @@ import pytest
 from custom_components.dreo.pydreo import PyDreo
 
 
-@pytest.fixture
-def mocked_pydreo(mocker, mocked_dreo):
-    #mocker.patch("homeassistant.helpers.entity.Entity.async_write_ha_state")
-    pydreo_mock = mocker.patch.object(
-        PyDreo, "HubSpaceDataUpdateCoordinator", autospec=True
-    )
-    pydreo_mock.conn = mocked_dreo
-    pydreo_mock.data = defaultdict(dict)
-    yield pydreo_mock
-
-
-@pytest.fixture
-def mocked_pydreo(mocker):
-    """Mock all HubSpace functionality but ensure the class is correct"""
-    hs_mock = mocker.patch.object(pydreo_async, "HubSpaceConnection", autospec=True)
-    yield hs_mock
-
-
 @pytest.fixture(autouse=True)
 def set_debug_mode(caplog):
     # Force capture of all debug logging. This is useful if you want to verify

--- a/tests/dreo/conftest.py
+++ b/tests/dreo/conftest.py
@@ -1,0 +1,31 @@
+import logging
+from collections import defaultdict
+import pytest
+
+from custom_components.dreo.pydreo import PyDreo
+
+
+@pytest.fixture
+def mocked_pydreo(mocker, mocked_dreo):
+    #mocker.patch("homeassistant.helpers.entity.Entity.async_write_ha_state")
+    pydreo_mock = mocker.patch.object(
+        PyDreo, "HubSpaceDataUpdateCoordinator", autospec=True
+    )
+    pydreo_mock.conn = mocked_dreo
+    pydreo_mock.data = defaultdict(dict)
+    yield pydreo_mock
+
+
+@pytest.fixture
+def mocked_pydreo(mocker):
+    """Mock all HubSpace functionality but ensure the class is correct"""
+    hs_mock = mocker.patch.object(pydreo_async, "HubSpaceConnection", autospec=True)
+    yield hs_mock
+
+
+@pytest.fixture(autouse=True)
+def set_debug_mode(caplog):
+    # Force capture of all debug logging. This is useful if you want to verify
+    # log messages with `<message> in caplog.text`. If you run
+    # pytest -rP it will display all log messages, including passing tests.
+    caplog.set_level(logging.DEBUG)

--- a/tests/dreo/data/DR-HTF008S.json
+++ b/tests/dreo/data/DR-HTF008S.json
@@ -1,0 +1,1467 @@
+    {
+    "deviceId": "1669136175370137602",
+    "sn": "REDACTED",
+    "brand": "Dreo",
+    "model": "DR-HTF008S",
+    "productId": "1582290393341964289",
+    "productName": "Tower Fan",
+    "deviceName": "Main Bedroom Fan",
+    "shared": false,
+    "series": null,
+    "seriesName": "Cruiser Pro T3 S",
+    "type": 0,
+    "owner": true,
+    "familyId": null,
+    "familyName": null,
+    "roomId": null,
+    "roomName": null,
+    "roomNameI18Key": "",
+    "color": "b",
+    "controlsConf": {
+        "template": "DR-HTF008S",
+        "lottie": {
+        "key": "poweron",
+        "frames": [
+            {
+            "value": 0,
+            "frame": [
+                0
+            ]
+            },
+            {
+            "value": 1,
+            "frame": [
+                2
+            ]
+            }
+        ]
+        },
+        "schedule": {
+        "modes": [
+            {
+            "icon": "ic_normal_wind_color",
+            "title": "device_fans_mode_straight",
+            "cmd": "windtype",
+            "value": 1,
+            "valueType": 1,
+            "isSelected": true,
+            "attention": [
+                "windtype",
+                "windlevel",
+                "poweron",
+                "shakehorizon"
+            ],
+            "controls": [
+                {
+                "type": 0,
+                "title": "device_control_mode_manual_level",
+                "startColor": "#1FD3E0",
+                "endColor": "#4663F7",
+                "cmd": [
+                    "windlevel"
+                ],
+                "value": 4,
+                "valueType": 1,
+                "startValue": 1,
+                "endValue": 5,
+                "groupId": 0,
+                "icon": "ic_sch_wind_speed",
+                "isSelected": false
+                }
+            ]
+            },
+            {
+            "icon": "ic_natural_wind_color",
+            "title": "device_fans_mode_natural",
+            "cmd": "windtype",
+            "value": 2,
+            "valueType": 1,
+            "isSelected": false,
+            "attention": [
+                "windtype",
+                "windlevel",
+                "poweron",
+                "shakehorizon"
+            ],
+            "controls": [
+                {
+                "type": 0,
+                "valueType": 1,
+                "title": "device_control_mode_manual_level",
+                "startColor": "#1FD3E0",
+                "endColor": "#4663F7",
+                "cmd": [
+                    "windlevel"
+                ],
+                "value": 4,
+                "startValue": 1,
+                "endValue": 5,
+                "groupId": 0,
+                "icon": "ic_sch_wind_speed",
+                "isSelected": false
+                }
+            ]
+            },
+            {
+            "icon": "ic_sleep_wind_color",
+            "title": "device_fans_mode_sleep",
+            "cmd": "windtype",
+            "value": 3,
+            "valueType": 1,
+            "isSelected": false,
+            "attention": [
+                "windtype",
+                "windlevel",
+                "poweron",
+                "shakehorizon"
+            ],
+            "controls": [
+                {
+                "type": 0,
+                "title": "device_control_mode_manual_level",
+                "startColor": "#1FD3E0",
+                "endColor": "#4663F7",
+                "cmd": [
+                    "windlevel"
+                ],
+                "value": 4,
+                "valueType": 1,
+                "startValue": 1,
+                "endValue": 5,
+                "groupId": 0,
+                "isSelected": false,
+                "icon": "ic_sch_wind_speed"
+                }
+            ]
+            },
+            {
+            "icon": "ic_auto_wind_color",
+            "title": "device_control_mode_auto",
+            "cmd": "windtype",
+            "value": 4,
+            "valueType": 1,
+            "isSelected": false,
+            "attention": [
+                "windtype",
+                "windlevel",
+                "poweron",
+                "shakehorizon"
+            ],
+            "controls": [
+                {
+                "type": 0,
+                "title": "device_control_mode_manual_level",
+                "startColor": "#1FD3E0",
+                "endColor": "#4663F7",
+                "cmd": [
+                    "windlevel"
+                ],
+                "value": 4,
+                "valueType": 1,
+                "startValue": 1,
+                "endValue": 5,
+                "groupId": 0,
+                "isSelected": false,
+                "icon": "device_control_wind"
+                }
+            ]
+            }
+        ]
+        },
+        "cards": [
+        {
+            "type": 2,
+            "title": "device_control_temp",
+            "icon": "",
+            "image": "",
+            "url": "",
+            "show": true
+        },
+        {
+            "type": 8,
+            "title": "",
+            "icon": "",
+            "image": "",
+            "url": "dreo://nav/device/schedule?deviceSn={sn}",
+            "show": true,
+            "key": "",
+            "minVersion": "2.5.0"
+        },
+        {
+            "type": 6,
+            "title": "device_settings_title",
+            "icon": "ic_setting",
+            "image": "",
+            "url": "dreo://nav/device/setting?deviceSn=${sn}",
+            "show": true,
+            "key": "setting"
+        },
+        {
+            "type": 6,
+            "title": "base_clean_tutorial",
+            "icon": "https://resources.dreo-cloud.com/app/202312/4/c06d58240e114f019c92abf5d3bd6f8c.png",
+            "image": "",
+            "url": "https://fe.dreo.com/guides/product-clean/cruiser-pro-t3s",
+            "show": true,
+            "minVersion": "2.6.8"
+        }
+        ],
+        "feature": {
+        "schedule": {
+            "enable": true,
+            "localSupport": true,
+            "module": [
+            {
+                "type": "HeFi",
+                "version": "3.2.2"
+            }
+            ]
+        }
+        },
+        "preference": [
+        {
+            "id": "200",
+            "type": "Panel Sound",
+            "title": "device_control_panelsound",
+            "image": "ic_mute",
+            "reverse": false,
+            "cmd": "voiceon"
+        },
+        {
+            "id": "210",
+            "type": "Display Auto Off",
+            "title": "device_fans_mode_auto_display",
+            "image": "ic_display",
+            "reverse": true,
+            "cmd": "ledalwayson"
+        },
+        {
+            "id": "230",
+            "type": "Temperature Unit",
+            "title": "device_control_temp_unit",
+            "image": "ic_temp_unit"
+        },
+        {
+            "id": "250",
+            "type": "Temperature Calibration",
+            "title": "device_control_temp_calibration",
+            "image": "ic_temp_cal"
+        }
+        ],
+        "control": [
+        {
+            "id": "100",
+            "type": "Mode",
+            "title": "device_mode",
+            "items": [
+            {
+                "text": "device_fans_mode_straight",
+                "textColors": [
+                "#D5D6D7",
+                "#D5D6D7"
+                ],
+                "image": "ic_normal_wind",
+                "imageColors": [
+                "#D5D6D7",
+                "#25D7E4"
+                ],
+                "cmd": "windtype",
+                "value": 1
+            },
+            {
+                "text": "device_fans_mode_natural",
+                "textColors": [
+                "#D5D6D7",
+                "#D5D6D7"
+                ],
+                "image": "ic_natural_wind",
+                "imageColors": [
+                "#D5D6D7",
+                "#2CDD96"
+                ],
+                "cmd": "windtype",
+                "value": 2
+            },
+            {
+                "text": "device_control_mode_sleep",
+                "textColors": [
+                "#D5D6D7",
+                "#D5D6D7"
+                ],
+                "image": "ic_sleep_wind",
+                "imageColors": [
+                "#D5D6D7",
+                "#6249DF"
+                ],
+                "cmd": "windtype",
+                "value": 3
+            },
+            {
+                "text": "device_control_mode_auto",
+                "textColors": [
+                "#D5D6D7",
+                "#D5D6D7"
+                ],
+                "image": "ic_auto_wind",
+                "imageColors": [
+                "#D5D6D7",
+                "#0A80F5"
+                ],
+                "cmd": "windtype",
+                "value": 4
+            }
+            ]
+        },
+        {
+            "id": "110",
+            "type": "Speed",
+            "title": "device_control_speed",
+            "items": [
+            {
+                "text": "1",
+                "cmd": "windlevel",
+                "value": 1
+            },
+            {
+                "text": "5",
+                "cmd": "windlevel",
+                "value": 5
+            }
+            ]
+        },
+        {
+            "id": "120",
+            "type": "Oscillation",
+            "title": "device_control_oscillation",
+            "items": [],
+            "cmd": "shakehorizon"
+        }
+        ],
+        "category": "Tower Fan",
+        "setting": [
+        {
+            "text": "Firmware Version",
+            "image": "image.png",
+            "value": "1.0.0",
+            "url": "dreo://control"
+        }
+        ]
+    },
+    "mainConf": {
+        "isSmart": true,
+        "isWifi": true,
+        "isBluetooth": true,
+        "isVoiceControl": true
+    },
+    "resourcesConf": {
+        "imageSmallSrc": "https://resources.dreo-cloud.com/app/preSigned202405/23c882f6b9447346098e969f510df9a671.png",
+        "imageFullSrc": "https://resources.dreo-cloud.com/app/202309/79995154d962047b896f09618c2d3a08c.zip",
+        "imageSmallDarkSrc": "",
+        "imageFullDarkSrc": ""
+    },
+    "servicesConf": [
+        {
+        "key": "user_manual",
+        "value": "https://resources.dreo-cloud.com/app/202310/123e61ee7e41bb4ecd889bbf45e42368e0.pdf"
+        }
+    ],
+    "userManuals": [
+        {
+        "url": "https://resources.dreo-cloud.com/app/202310/123e61ee7e41bb4ecd889bbf45e42368e0.pdf",
+        "icon": null,
+        "desc": "User Manual",
+        "lang": "en"
+        }
+    ]
+    },
+    {
+    "deviceId": "1692009631610630146",
+    "sn": "1572127914365333506-cfc1eb539b1a0f89:001:0000000000s",
+    "brand": "Dreo",
+    "model": "DR-HAF004S",
+    "productId": "1572127914365333506",
+    "productName": "Air Circulator",
+    "deviceName": "Bonus Room Fan",
+    "shared": false,
+    "series": null,
+    "seriesName": "CF714S/CF814S",
+    "type": 0,
+    "owner": true,
+    "familyId": null,
+    "familyName": null,
+    "roomId": null,
+    "roomName": null,
+    "roomNameI18Key": "",
+    "color": "s",
+    "controlsConf": {
+        "template": "DR-HAF004S",
+        "lottie": {
+        "key": "poweron",
+        "frames": [
+            {
+            "value": 0,
+            "frame": [
+                0
+            ]
+            },
+            {
+            "value": 1,
+            "frame": [
+                2
+            ]
+            }
+        ]
+        },
+        "cards": [
+        {
+            "type": 2,
+            "title": "device_control_temp",
+            "icon": "",
+            "image": "",
+            "url": "",
+            "show": true
+        },
+        {
+            "type": 8,
+            "title": "",
+            "icon": "",
+            "image": "",
+            "url": "dreo://nav/device/schedule?deviceSn={sn}",
+            "show": true,
+            "key": ""
+        },
+        {
+            "type": 6,
+            "title": "device_settings_title",
+            "icon": "ic_setting",
+            "image": "",
+            "url": "dreo://nav/device/setting?deviceSn=${sn}",
+            "show": true,
+            "key": "setting"
+        },
+        {
+            "type": 6,
+            "title": "base_clean_tutorial",
+            "icon": "https://resources.dreo-cloud.com/app/202312/4/c06d58240e114f019c92abf5d3bd6f8c.png",
+            "image": "",
+            "url": "https://m.dreo.com/guides/product-clean/air-circulator-fan/cf714s?utm_source=device_card",
+            "show": true,
+            "minVersion": "2.6.8"
+        }
+        ],
+        "resource": {
+        "shakeImageFiles": "https://resources.dreo-cloud.com/app/202312/19/8a475a5ef6fe40368d961209ca2ac935.zip"
+        },
+        "extraConfigs": [
+        {
+            "key": "preference",
+            "value": [
+            {
+                "id": "210",
+                "type": "Light Detection",
+                "title": "dev_ctrl_display",
+                "image": "ic_display",
+                "reverse": false,
+                "cmd": "lightmode"
+            }
+            ],
+            "firmware": {
+            "minMcuVer": "1.0.4",
+            "minModuleVer": "3.2.9",
+            "mcuModel": "",
+            "moduleModel": ""
+            }
+        },
+        {
+            "key": "schedule",
+            "value": {
+            "modes": [
+                {
+                "icon": "ic_normal_wind_color",
+                "title": "device_fans_mode_straight",
+                "cmd": "mode",
+                "value": 1,
+                "valueType": 1,
+                "isSelected": true,
+                "attention": [
+                    "mode",
+                    "windlevel",
+                    "poweron",
+                    "cruiseconf",
+                    "oscmode"
+                ],
+                "controls": [
+                    {
+                    "type": 0,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": [
+                        "windlevel"
+                    ],
+                    "value": 7,
+                    "valueType": 1,
+                    "startValue": 1,
+                    "endValue": 9,
+                    "groupId": 0,
+                    "icon": "ic_sch_wind_speed",
+                    "isSelected": false
+                    }
+                ]
+                },
+                {
+                "icon": "ic_natural_wind_color",
+                "title": "device_fans_mode_natural",
+                "cmd": "mode",
+                "value": 2,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": [
+                    "mode",
+                    "windlevel",
+                    "poweron",
+                    "cruiseconf",
+                    "oscmode"
+                ],
+                "controls": [
+                    {
+                    "type": 0,
+                    "valueType": 1,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": [
+                        "windlevel"
+                    ],
+                    "value": 7,
+                    "startValue": 1,
+                    "endValue": 9,
+                    "groupId": 0,
+                    "icon": "ic_sch_wind_speed",
+                    "isSelected": false
+                    }
+                ]
+                },
+                {
+                "icon": "ic_sleep_wind_color",
+                "title": "device_fans_mode_sleep",
+                "cmd": "mode",
+                "value": 3,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": [
+                    "mode",
+                    "windlevel",
+                    "poweron",
+                    "cruiseconf",
+                    "oscmode"
+                ],
+                "controls": [
+                    {
+                    "type": 0,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": [
+                        "windlevel"
+                    ],
+                    "value": 7,
+                    "valueType": 1,
+                    "startValue": 1,
+                    "endValue": 9,
+                    "groupId": 0,
+                    "isSelected": false,
+                    "icon": "ic_sch_wind_speed"
+                    }
+                ]
+                },
+                {
+                "icon": "ic_auto_wind_color",
+                "title": "device_control_mode_auto",
+                "cmd": "mode",
+                "value": 4,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": [
+                    "mode",
+                    "windlevel",
+                    "poweron",
+                    "cruiseconf",
+                    "oscmode"
+                ],
+                "controls": [
+                    {
+                    "type": 0,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": [
+                        "windlevel"
+                    ],
+                    "value": 7,
+                    "valueType": 1,
+                    "startValue": 1,
+                    "endValue": 9,
+                    "groupId": 0,
+                    "isSelected": false,
+                    "icon": "ic_sch_wind_speed"
+                    }
+                ]
+                },
+                {
+                "icon": "ic_turbo_wind_color",
+                "title": "device_control_mode_turbo",
+                "cmd": "mode",
+                "value": 5,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": [
+                    "mode",
+                    "poweron",
+                    "cruiseconf",
+                    "oscmode"
+                ],
+                "controls": []
+                },
+                {
+                "icon": "ic_custom_wind",
+                "title": "device_control_custom",
+                "cmd": "mode",
+                "value": 6,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": [
+                    "mode",
+                    "windlevel",
+                    "poweron",
+                    "cruiseconf",
+                    "oscmode"
+                ],
+                "controls": []
+                }
+            ]
+            },
+            "firmware": {
+            "minMcuVer": "",
+            "minModuleVer": "",
+            "mcuModel": "",
+            "moduleModel": "HeFi"
+            }
+        }
+        ],
+        "preference": [
+        {
+            "id": "200",
+            "type": "Panel Sound",
+            "title": "device_control_panelsound",
+            "image": "ic_mute",
+            "reverse": true,
+            "cmd": "muteon"
+        },
+        {
+            "id": "210",
+            "type": "Light Detection",
+            "title": "device_control_lightdetection",
+            "image": "ic_lightsensoron",
+            "reverse": false,
+            "cmd": "lightsensoron"
+        },
+        {
+            "id": "220",
+            "type": "Child Lock",
+            "title": "device_control_childlock",
+            "image": "ic_child_lock",
+            "reverse": false,
+            "cmd": "childlockon"
+        },
+        {
+            "id": "230",
+            "type": "Oscillation Calibration",
+            "title": "device_control_calibration",
+            "image": "ic_osc_cal"
+        },
+        {
+            "id": "240",
+            "type": "Temperature Unit",
+            "title": "device_control_temp_unit",
+            "image": "ic_temp_unit"
+        }
+        ],
+        "control": [
+        {
+            "id": "100",
+            "type": "Mode",
+            "title": "device_mode",
+            "items": [
+            {
+                "text": "device_fans_mode_straight",
+                "textColors": [
+                "#D5D6D7",
+                "#D5D6D7"
+                ],
+                "image": "ic_normal_wind",
+                "imageColors": [
+                "#D5D6D7",
+                "#25D7E4"
+                ],
+                "cmd": "mode",
+                "value": 1
+            },
+            {
+                "text": "device_control_mode_auto",
+                "textColors": [
+                "#D5D6D7",
+                "#D5D6D7"
+                ],
+                "image": "ic_auto_wind",
+                "imageColors": [
+                "#D5D6D7",
+                "#0A80F5"
+                ],
+                "cmd": "mode",
+                "value": 4
+            },
+            {
+                "text": "device_control_mode_sleep",
+                "textColors": [
+                "#D5D6D7",
+                "#D5D6D7"
+                ],
+                "image": "ic_sleep_wind",
+                "imageColors": [
+                "#D5D6D7",
+                "#6249DF"
+                ],
+                "cmd": "mode",
+                "value": 3
+            },
+            {
+                "text": "device_fans_mode_natural",
+                "textColors": [
+                "#D5D6D7",
+                "#D5D6D7"
+                ],
+                "image": "ic_natural_wind",
+                "imageColors": [
+                "#D5D6D7",
+                "#2CDD96"
+                ],
+                "cmd": "mode",
+                "value": 2
+            }
+            ]
+        },
+        {
+            "id": "110",
+            "type": "Speed",
+            "title": "device_control_speed",
+            "items": [
+            {
+                "text": "1",
+                "cmd": "windlevel",
+                "value": 1
+            },
+            {
+                "text": "9",
+                "cmd": "windlevel",
+                "value": 9
+            }
+            ]
+        },
+        {
+            "id": "130",
+            "type": "DPad",
+            "step": 5
+        }
+        ],
+        "version": {
+        "minControlVer": "2.6.10",
+        "minPairingVer": "2.0.7"
+        },
+        "updateMcuVersion": "0.6.6",
+        "schedule": {
+        "modes": [
+            {
+            "icon": "ic_normal_wind_color",
+            "title": "device_fans_mode_straight",
+            "cmd": "mode",
+            "value": 1,
+            "valueType": 1,
+            "isSelected": true,
+            "attention": [
+                "windlevel",
+                "poweron",
+                "mode"
+            ],
+            "controls": [
+                {
+                "type": 0,
+                "title": "device_control_mode_manual_level",
+                "startColor": "#0051CF",
+                "endColor": "#0051CF",
+                "cmd": [
+                    "windlevel"
+                ],
+                "value": 2,
+                "valueType": 1,
+                "startValue": 1,
+                "endValue": 9,
+                "groupId": 0,
+                "isSelected": false,
+                "icon": ""
+                }
+            ]
+            },
+            {
+            "icon": "ic_natural_wind_color",
+            "title": "device_fans_mode_natural",
+            "cmd": "mode",
+            "value": 2,
+            "valueType": 1,
+            "isSelected": false,
+            "attention": [
+                "windlevel",
+                "poweron",
+                "mode"
+            ],
+            "controls": [
+                {
+                "type": 0,
+                "title": "device_control_mode_manual_level",
+                "startColor": "#0051CF",
+                "endColor": "#0051CF",
+                "cmd": [
+                    "windlevel"
+                ],
+                "value": 2,
+                "valueType": 1,
+                "startValue": 1,
+                "endValue": 9,
+                "groupId": 0,
+                "isSelected": false,
+                "icon": ""
+                }
+            ]
+            },
+            {
+            "icon": "ic_sleep_wind_color",
+            "title": "device_fans_mode_sleep",
+            "cmd": "mode",
+            "value": 3,
+            "valueType": 1,
+            "isSelected": false,
+            "attention": [
+                "windlevel",
+                "poweron",
+                "mode"
+            ],
+            "controls": [
+                {
+                "type": 0,
+                "title": "device_control_mode_manual_level",
+                "startColor": "#0051CF",
+                "endColor": "#0051CF",
+                "cmd": [
+                    "windlevel"
+                ],
+                "value": 2,
+                "valueType": 1,
+                "startValue": 1,
+                "endValue": 9,
+                "groupId": 0,
+                "isSelected": false,
+                "icon": ""
+                }
+            ]
+            },
+            {
+            "icon": "ic_auto_wind_color",
+            "title": "device_fans_mode_auto",
+            "cmd": "mode",
+            "value": 4,
+            "valueType": 1,
+            "isSelected": false,
+            "attention": [
+                "windlevel",
+                "poweron",
+                "mode"
+            ],
+            "controls": [
+                {
+                "type": 0,
+                "title": "device_control_mode_manual_level",
+                "startColor": "#0051CF",
+                "endColor": "#0051CF",
+                "cmd": [
+                    "windlevel"
+                ],
+                "value": 2,
+                "valueType": 1,
+                "startValue": 1,
+                "endValue": 9,
+                "groupId": 0,
+                "isSelected": false,
+                "icon": ""
+                }
+            ]
+            },
+            {
+            "icon": "ic_turbo_wind_color",
+            "title": "device_control_mode_turbo",
+            "cmd": "mode",
+            "value": 5,
+            "valueType": 1,
+            "isSelected": false,
+            "attention": [
+                "poweron",
+                "mode"
+            ],
+            "controls": []
+            },
+            {
+            "icon": "ic_custom_wind",
+            "title": "device_control_custom",
+            "cmd": "mode",
+            "value": 6,
+            "valueType": 1,
+            "isSelected": false,
+            "attention": [
+                "poweron",
+                "mode"
+            ],
+            "controls": []
+            }
+        ]
+        },
+        "feature": {
+        "schedule": {
+            "enable": "",
+            "localSupport": true,
+            "module": [
+            {
+                "type": "HeFi",
+                "version": "0.0.1"
+            }
+            ]
+        }
+        },
+        "swingAngle": {
+        "fixedAngle": {
+            "verAngle": 120,
+            "horAngle": 120,
+            "verZeroAngle": 30,
+            "horZeroAngle": 60,
+            "imgColumn": 9,
+            "imgRow": 9
+        },
+        "horSwingAngle": {
+            "angle": 120,
+            "dottedLines": [
+            30,
+            150
+            ],
+            "quickStep": [
+            30,
+            60,
+            90,
+            120
+            ]
+        },
+        "verSwingAngle": {
+            "startAngle": 150,
+            "sweepAngle": 120,
+            "stepAngle": 5,
+            "dottedLines": [
+            150,
+            270
+            ],
+            "quickStep": [
+            30,
+            60,
+            90,
+            120
+            ]
+        }
+        },
+        "category": "Air Circulators"
+    },
+    "mainConf": {
+        "isSmart": true,
+        "isWifi": true,
+        "isBluetooth": true,
+        "isVoiceControl": true
+    },
+    "resourcesConf": {
+        "imageSmallSrc": "https://resources.dreo-cloud.com/app/202302/15b4a846f9849144729e6d3a9fe6592d95.png",
+        "imageFullSrc": "https://resources.dreo-cloud.com/app/202307/25b3cedbbe8ec14cb29fe4a24b99c1be65.zip",
+        "imageSmallDarkSrc": "",
+        "imageFullDarkSrc": ""
+    },
+    "servicesConf": [
+        {
+        "key": "user_manual",
+        "value": "https://resources.dreo-cloud.com/app/202404/10/945c492652a2470a93157b0958152de2.pdf"
+        }
+    ],
+    "userManuals": [
+        {
+        "url": "https://resources.dreo-cloud.com/app/202404/10/945c492652a2470a93157b0958152de2.pdf",
+        "icon": null,
+        "desc": "User Manual",
+        "lang": "en"
+        }
+    ]
+    }
+]
+}
+}
+},
+"devices": {
+"fans": [
+{
+"_device_definition": {
+    "__type": "<class 'custom_components.dreo.pydreo.models.DreoDeviceDetails'>",
+    "repr": "DreoDeviceDetails(preset_modes=None, range=None, hvac_modes=None, swing_modes=None, cooking_modes=None, cooking_range=None)"
+},
+"_name": "Main Bedroom Fan",
+"_device_id": "1669136175370137602",
+"_sn": "**REDACTED**",
+"_brand": "Dreo",
+"_model": "DR-HTF008S",
+"_product_id": "1582290393341964289",
+"_product_name": "Tower Fan",
+"_device_name": "Main Bedroom Fan",
+"_shared": false,
+"_series": null,
+"_series_name": "Cruiser Pro T3 S",
+"_color": "b",
+"_dreo": {
+    "__type": "<class 'custom_components.dreo.pydreo.PyDreo'>",
+    "repr": "<custom_components.dreo.pydreo.PyDreo object at 0xffff77510590>"
+},
+"_is_on": true,
+"_feature_key_names": {},
+"raw_state": {
+    "code": 0,
+    "msg": "OK",
+    "data": {
+    "mixed": {
+        "wifi_ssid": "**REDACTED**",
+        "mcu_hardware_model": {
+        "state": "SC95F8613B",
+        "timestamp": 1724497220
+        },
+        "windlevel": {
+        "state": 2,
+        "timestamp": 1724653301
+        },
+        "wifi_rssi": {
+        "state": -40,
+        "timestamp": 1724497220
+        },
+        "windtype": {
+        "state": 1,
+        "timestamp": 1724497220
+        },
+        "poweron": {
+        "state": false,
+        "timestamp": 1724697416
+        },
+        "scheid": {
+        "state": 0,
+        "timestamp": 1724497220
+        },
+        "timeron": {
+        "state": {
+            "du": 0,
+            "ts": 0
+        },
+        "timestamp": null
+        },
+        "scheon": {
+        "state": false,
+        "timestamp": 1724497220
+        },
+        "voiceon": {
+        "state": false,
+        "timestamp": 1724497220
+        },
+        "wrong": {
+        "state": 0,
+        "timestamp": 1724497220
+        },
+        "module_firmware_version": {
+        "state": "3.0.9",
+        "timestamp": 1724497220
+        },
+        "mcuon": {
+        "state": true,
+        "timestamp": 1724497220
+        },
+        "connected": {
+        "state": true,
+        "timestamp": 1724497220
+        },
+        "timeroff": {
+        "state": {
+            "du": 0,
+            "ts": 0
+        },
+        "timestamp": null
+        },
+        "shakehorizon": {
+        "state": false,
+        "timestamp": 1724497220
+        },
+        "network_latency": {
+        "state": 33,
+        "timestamp": 1724497220
+        },
+        "_ota": {
+        "state": 0,
+        "timestamp": 1724497220
+        },
+        "module_hardware_model": {
+        "state": "HeFi",
+        "timestamp": 1724497220
+        },
+        "mcu_firmware_version": {
+        "state": "1.0.21",
+        "timestamp": 1724497220
+        },
+        "temperature": {
+        "state": 77,
+        "timestamp": 1724696749
+        },
+        "module_hardware_mac": "**REDACTED**",
+        "ledalwayson": {
+        "state": false,
+        "timestamp": 1724497220
+        }
+    },
+    "sn": "**REDACTED**",
+    "productId": "1582290393341964289",
+    "region": "us-east-2/emq"
+    }
+},
+"_attr_cbs": [
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bcae0>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bcc20>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bd620>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bd6c0>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bd8a0>"
+    }
+],
+"_lock": {
+    "__type": "<class '_thread.lock'>",
+    "repr": "<unlocked _thread.lock object at 0xffff60320b00>"
+},
+"_speed_range": [
+    1,
+    5
+],
+"_preset_modes": [
+    [
+    "normal",
+    1
+    ],
+    [
+    "natural",
+    2
+    ],
+    [
+    "sleep",
+    3
+    ],
+    [
+    "auto",
+    4
+    ]
+],
+"_fan_speed": 1,
+"_wind_type": 1,
+"_wind_mode": null,
+"_shakehorizon": false,
+"_shakehorizonangle": null,
+"_osc_mode": null,
+"_cruise_conf": null,
+"_horizontally_oscillating": null,
+"_vertically_oscillating": null,
+"_temperature": 75,
+"_led_always_on": false,
+"_voice_on": false,
+"_light_sensor_on": null,
+"_mute_on": null,
+"_fixed_conf": null
+},
+{
+"_device_definition": {
+    "__type": "<class 'custom_components.dreo.pydreo.models.DreoDeviceDetails'>",
+    "repr": "DreoDeviceDetails(preset_modes=None, range=None, hvac_modes=None, swing_modes=None, cooking_modes=None, cooking_range=None)"
+},
+"_name": "Bonus Room Fan",
+"_device_id": "1692009631610630146",
+"_sn": "**REDACTED**",
+"_brand": "Dreo",
+"_model": "DR-HAF004S",
+"_product_id": "1572127914365333506",
+"_product_name": "Air Circulator",
+"_device_name": "Bonus Room Fan",
+"_shared": false,
+"_series": null,
+"_series_name": "CF714S/CF814S",
+"_color": "s",
+"_dreo": {
+    "__type": "<class 'custom_components.dreo.pydreo.PyDreo'>",
+    "repr": "<custom_components.dreo.pydreo.PyDreo object at 0xffff77510590>"
+},
+"_is_on": false,
+"_feature_key_names": {},
+"raw_state": {
+    "code": 0,
+    "msg": "OK",
+    "data": {
+    "mixed": {
+        "wifi_rssi": {
+        "state": -46,
+        "timestamp": 1724349717
+        },
+        "poweron": {
+        "state": false,
+        "timestamp": 1724697409
+        },
+        "hoscadj": {
+        "state": 5,
+        "timestamp": 1720935176
+        },
+        "cruiseconf": {
+        "state": "60,45,0,-45",
+        "timestamp": 1724349717
+        },
+        "timeron": {
+        "state": {
+            "du": 0,
+            "ts": 1724349717
+        },
+        "timestamp": null
+        },
+        "fixedconf": {
+        "state": "0,0",
+        "timestamp": 1724349717
+        },
+        "mode": {
+        "state": 1,
+        "timestamp": 1724697393
+        },
+        "mcuon": {
+        "state": true,
+        "timestamp": 1724349717
+        },
+        "network_latency": {
+        "state": 238,
+        "timestamp": 1724349717
+        },
+        "module_hardware_model": {
+        "state": "PAI-051",
+        "timestamp": 1724349717
+        },
+        "turboon": {
+        "state": false,
+        "timestamp": 1724349717
+        },
+        "mcu_firmware_version": {
+        "state": "0.6.8",
+        "timestamp": 1724349717
+        },
+        "lightsensoron": {
+        "state": true,
+        "timestamp": 1724349717
+        },
+        "customconf": {
+        "state": "temp:23333334444446666668888889",
+        "timestamp": 1724349717
+        },
+        "oscmode": {
+        "state": 2,
+        "timestamp": 1724349717
+        },
+        "temperature": {
+        "state": 75,
+        "timestamp": 1724725868
+        },
+        "module_hardware_mac": "**REDACTED**",
+        "alignon": {
+        "state": true,
+        "timestamp": 1724349717
+        },
+        "muteon": {
+        "state": true,
+        "timestamp": 1724349717
+        },
+        "mcu_hardware_model": {
+        "state": "SC95F8613B",
+        "timestamp": 1724349717
+        },
+        "wifi_ssid": "**REDACTED**",
+        "windlevel": {
+        "state": 4,
+        "timestamp": 1724697404
+        },
+        "wrong": {
+        "state": 0,
+        "timestamp": 1724349717
+        },
+        "module_firmware_version": {
+        "state": "1.2.17",
+        "timestamp": 1724349717
+        },
+        "connected": {
+        "state": true,
+        "timestamp": 1724349717
+        },
+        "timeroff": {
+        "state": {
+            "du": 0,
+            "ts": 1724349717
+        },
+        "timestamp": null
+        },
+        "voscadj": {
+        "state": -5,
+        "timestamp": 1723859101
+        },
+        "childlockon": {
+        "state": false,
+        "timestamp": 1724349717
+        }
+    },
+    "sn": "**REDACTED**",
+    "productId": "1572127914365333506",
+    "region": "us-east-2"
+    }
+},
+"_attr_cbs": [
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bca40>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bce00>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bcea0>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bcfe0>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bd120>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bd260>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bd3a0>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bd4e0>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bd9e0>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bdb20>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bdc60>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bdda0>"
+    },
+    {
+    "__type": "<class 'function'>",
+    "repr": "<function DreoBaseDeviceHA.async_added_to_hass.<locals>.update_state at 0xffff567bdee0>"
+    }
+],
+"_lock": {
+    "__type": "<class '_thread.lock'>",
+    "repr": "<unlocked _thread.lock object at 0xffff58cac780>"
+},
+"_speed_range": [
+    1,
+    9
+],
+"_preset_modes": [
+    [
+    "normal",
+    1
+    ],
+    [
+    "natural",
+    2
+    ],
+    [
+    "sleep",
+    3
+    ],
+    [
+    "auto",
+    4
+    ],
+    [
+    "turbo",
+    5
+    ],
+    [
+    "custom",
+    6
+    ]
+],
+"_fan_speed": 4,
+"_wind_type": null,
+"_wind_mode": 1,
+"_shakehorizon": null,
+"_shakehorizonangle": null,
+"_osc_mode": 2,
+"_cruise_conf": "60,45,0,-45",
+"_horizontally_oscillating": null,
+"_vertically_oscillating": null,
+"_temperature": 74,
+"_led_always_on": null,
+"_voice_on": null,
+"_light_sensor_on": true,
+"_mute_on": true,
+"_fixed_conf": "0,0"
+}
+],
+"heaters": [],
+"acs": [],
+"cookers": []
+}
+}
+}

--- a/tests/dreo/test_fan.py
+++ b/tests/dreo/test_fan.py
@@ -1,7 +1,5 @@
-import pytest
 from unittest.mock import patch
 #from homeassistant.helpers import Entity
-from homeassistant.components.fan import FanEntityFeature
 
 from custom_components.dreo import fan
 

--- a/tests/dreo/test_fan.py
+++ b/tests/dreo/test_fan.py
@@ -1,0 +1,225 @@
+from contextlib import suppress
+
+import pytest
+from homeassistant.components.fan import FanEntityFeature
+
+from custom_components.dreo import fan
+
+from .utils import create_devices_from_data
+
+fan_zandra = create_devices_from_data("fan-ZandraFan.json")
+
+
+process_functions_expected = (
+    FanEntityFeature.PRESET_MODE
+    | FanEntityFeature.SET_SPEED
+    | FanEntityFeature.DIRECTION
+)
+# Added in 2024.8.0
+with suppress(AttributeError):
+    process_functions_expected |= FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+
+
+@pytest.fixture
+def empty_fan(mocked_coordinator):
+    yield fan.DreoFanHA(mocked_coordinator, "test fan")
+
+
+@pytest.fixture
+def speed_fan(mocked_coordinator):
+    test_fan = fan.DreoFanHA(mocked_coordinator, "test fan")
+    test_fan._supported_features = process_functions_expected
+    test_fan._fan_speeds = [
+        "fan-speed-6-016",
+        "fan-speed-6-033",
+        "fan-speed-6-050",
+        "fan-speed-6-066",
+        "fan-speed-6-083",
+        "fan-speed-6-100",
+    ]
+    yield test_fan
+
+
+class Test_DreoTowerFan:
+
+    @pytest.mark.parametrize(
+        "functions, expected_attrs",
+        [
+            (
+                fan_zandra[0].functions,
+                {
+                    "_instance_attrs": {
+                        "fan-speed": "fan-speed",
+                        "fan-reverse": "fan-reverse",
+                        "power": "fan-power",
+                    },
+                    "_supported_features": process_functions_expected,
+                    "_preset_modes": {"comfort-breeze"},
+                    "_fan_speeds": [
+                        "fan-speed-6-016",
+                        "fan-speed-6-033",
+                        "fan-speed-6-050",
+                        "fan-speed-6-066",
+                        "fan-speed-6-083",
+                        "fan-speed-6-100",
+                    ],
+                },
+            )
+        ],
+    )
+    def test_process_functions(self, functions, expected_attrs, empty_fan):
+        empty_fan.process_functions(functions)
+        for key, val in expected_attrs.items():
+            assert getattr(empty_fan, key) == val
+
+    @pytest.mark.parametrize(
+        "states, expected_attrs, extra_attrs",
+        [
+            (
+                fan_zandra[0].states,
+                {
+                    "_preset_mode": "comfort-breeze",
+                    "_fan_speed": "fan-speed-6-050",
+                    "_current_direction": "reverse",
+                    "_state": "on",
+                    "_availability": True,
+                },
+                {
+                    "model": None,
+                    "deviceId": None,
+                    "Child ID": None,
+                    "wifi-ssid": "71e7209f-b932-44b9-ba2f-a8179f68c3ac",
+                    "wifi-mac-address": "e1119e0a-688d-45df-9882-a76549db9bc3",
+                    "ble-mac-address": "07346a23-350b-4606-8d86-67217ec7a688",
+                },
+            ),
+        ],
+    )
+    
+    def test_update_states(self, states, expected_attrs, extra_attrs, empty_fan):
+        empty_fan.states = states
+        empty_fan.coordinator.data[ENTITY_FAN][empty_fan._child_id] = empty_fan
+        empty_fan.update_states()
+        assert empty_fan.extra_state_attributes == extra_attrs
+        for key, val in expected_attrs.items():
+            assert getattr(empty_fan, key) == val
+
+    def test_name(self, empty_fan):
+        assert empty_fan.name == "test fan"
+
+    def test_unique_id(self, empty_fan):
+        empty_fan._child_id = "beans"
+        assert empty_fan.unique_id == "beans"
+
+    @pytest.mark.parametrize(
+        "state, expected",
+        [
+            ("on", True),
+            ("off", False),
+        ],
+    )
+    def test_is_on(self, state, expected, empty_fan):
+        empty_fan._state = state
+        assert empty_fan.is_on == expected
+
+    def test_extra_state_attributes(self, mocked_coordinator):
+        model = "bean model"
+        device_id = "bean-123"
+        child_id = "bean-123-123"
+        test_fan = fan.DreoFanHA(
+            mocked_coordinator,
+            "test fan",
+            model=model,
+            device_id=device_id,
+            child_id=child_id,
+        )
+        assert test_fan.extra_state_attributes == {
+            "model": model,
+            "deviceId": device_id,
+            "Child ID": child_id,
+        }
+
+    def test_current_direction(self, empty_fan):
+        empty_fan._current_direction = "reverse"
+        assert empty_fan.current_direction == "reverse"
+
+    def test_oscillating(self, empty_fan):
+        assert not empty_fan.oscillating
+
+    @pytest.mark.parametrize(
+        "set_speed, expected",
+        [
+            # Speed not set
+            (None, 0),
+            # Speed is set but 000
+            ("fan-speed-6-000", 0),
+            # Speed is set to a value
+            ("fan-speed-6-016", 16),
+        ],
+    )
+    def test_percentage(self, set_speed, expected, speed_fan):
+        speed_fan._fan_speed = set_speed
+        assert speed_fan.percentage == expected
+
+    @pytest.mark.parametrize(
+        "preset, expected",
+        [
+            # Breeze
+            ("comfort-breeze", "breeze"),
+            ("not supported", None),
+        ],
+    )
+    def test_preset_mode(self, preset, expected, empty_fan):
+        empty_fan._preset_mode = preset
+        assert empty_fan.preset_mode == expected
+
+    def test_preset_modes(self, empty_fan):
+        preset_modes = ["comfort-breeze"]
+        empty_fan._preset_modes = preset_modes
+        assert empty_fan.preset_modes == preset_modes
+
+    def test_speed_count(self, speed_fan):
+        assert speed_fan.speed_count == 6
+
+    def test_supported_features(self, empty_fan):
+        features = [1, 2, 3]
+        empty_fan._supported_features = features
+        assert empty_fan.supported_features == features
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "percentage, preset_mode, expected_attrs",
+        [
+            (
+                12,
+                None,
+                {
+                    "_fan_speed": "fan-speed-6-016",
+                    "_preset_mode": None,
+                },
+            ),
+            (
+                17,
+                "comfort-breeze",
+                {
+                    "_fan_speed": "fan-speed-6-033",
+                    "_preset_mode": "breeze",
+                },
+            ),
+        ],
+    )
+    async def test_async_turn_on(
+        self, percentage, preset_mode, expected_attrs, speed_fan
+    ):
+        speed_fan._supported_features = process_functions_expected
+        await speed_fan.async_turn_on(percentage=percentage, preset_mode=preset_mode)
+        for key, val in expected_attrs.items():
+            assert getattr(speed_fan, key) == val
+
+    @pytest.mark.asyncio
+    async def test_async_turn_off(self, empty_fan):
+        # Added in 2024.8.0
+        with suppress(AttributeError):
+            empty_fan._supported_features |= fan.FanEntityFeature.TURN_OFF
+        await empty_fan.async_turn_off()
+        assert empty_fan._state == "off"

--- a/tests/dreo/test_fan.py
+++ b/tests/dreo/test_fan.py
@@ -1,225 +1,42 @@
-from contextlib import suppress
-
 import pytest
+from unittest.mock import patch
+#from homeassistant.helpers import Entity
 from homeassistant.components.fan import FanEntityFeature
 
 from custom_components.dreo import fan
 
-from .utils import create_devices_from_data
+PATCH_BASE_PATH = 'homeassistant.helpers.entity.Entity'
+PATCH_SEND_COMMAND = f'{PATCH_BASE_PATH}.schedule_update_ha_state'
 
-fan_zandra = create_devices_from_data("fan-ZandraFan.json")
+class Test_DreoFanHA:
 
+    def test_fan_simple(self, mocker):
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
 
-process_functions_expected = (
-    FanEntityFeature.PRESET_MODE
-    | FanEntityFeature.SET_SPEED
-    | FanEntityFeature.DIRECTION
-)
-# Added in 2024.8.0
-with suppress(AttributeError):
-    process_functions_expected |= FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
+            mocked_pydreo_fan = mocker.MagicMock()
+            mocked_pydreo_fan.is_on = True
+            mocked_pydreo_fan.fan_speed = 3
+            mocked_pydreo_fan.speed_range = (1, 5)
+            mocked_pydreo_fan.preset_modes = ['normal', 'natural', 'sleep', 'auto']
 
+            test_fan = fan.DreoFanHA(mocked_pydreo_fan)
+            assert test_fan.is_on is True
+            assert test_fan.percentage == 60
+            assert test_fan.speed_count == 5
 
-@pytest.fixture
-def empty_fan(mocked_coordinator):
-    yield fan.DreoFanHA(mocked_coordinator, "test fan")
+            test_fan.set_percentage(20)
+            assert mocked_pydreo_fan.fan_speed == 1
+            mock_send_command.assert_called_once()
+            mock_send_command.reset_mock()
 
+            test_fan.set_percentage(0)
+            assert mocked_pydreo_fan.is_on is False
+            # TODO: Possible bug; need to test at home.  Why does this not cause an update?
+            #mock_send_command.assert_called_once()
+            #mock_send_command.reset_mock()
 
-@pytest.fixture
-def speed_fan(mocked_coordinator):
-    test_fan = fan.DreoFanHA(mocked_coordinator, "test fan")
-    test_fan._supported_features = process_functions_expected
-    test_fan._fan_speeds = [
-        "fan-speed-6-016",
-        "fan-speed-6-033",
-        "fan-speed-6-050",
-        "fan-speed-6-066",
-        "fan-speed-6-083",
-        "fan-speed-6-100",
-    ]
-    yield test_fan
+            test_fan.set_preset_mode("normal")
+            assert mocked_pydreo_fan.preset_mode is "normal"
+            mock_send_command.assert_called_once()
+            mock_send_command.reset_mock()
 
-
-class Test_DreoTowerFan:
-
-    @pytest.mark.parametrize(
-        "functions, expected_attrs",
-        [
-            (
-                fan_zandra[0].functions,
-                {
-                    "_instance_attrs": {
-                        "fan-speed": "fan-speed",
-                        "fan-reverse": "fan-reverse",
-                        "power": "fan-power",
-                    },
-                    "_supported_features": process_functions_expected,
-                    "_preset_modes": {"comfort-breeze"},
-                    "_fan_speeds": [
-                        "fan-speed-6-016",
-                        "fan-speed-6-033",
-                        "fan-speed-6-050",
-                        "fan-speed-6-066",
-                        "fan-speed-6-083",
-                        "fan-speed-6-100",
-                    ],
-                },
-            )
-        ],
-    )
-    def test_process_functions(self, functions, expected_attrs, empty_fan):
-        empty_fan.process_functions(functions)
-        for key, val in expected_attrs.items():
-            assert getattr(empty_fan, key) == val
-
-    @pytest.mark.parametrize(
-        "states, expected_attrs, extra_attrs",
-        [
-            (
-                fan_zandra[0].states,
-                {
-                    "_preset_mode": "comfort-breeze",
-                    "_fan_speed": "fan-speed-6-050",
-                    "_current_direction": "reverse",
-                    "_state": "on",
-                    "_availability": True,
-                },
-                {
-                    "model": None,
-                    "deviceId": None,
-                    "Child ID": None,
-                    "wifi-ssid": "71e7209f-b932-44b9-ba2f-a8179f68c3ac",
-                    "wifi-mac-address": "e1119e0a-688d-45df-9882-a76549db9bc3",
-                    "ble-mac-address": "07346a23-350b-4606-8d86-67217ec7a688",
-                },
-            ),
-        ],
-    )
-    
-    def test_update_states(self, states, expected_attrs, extra_attrs, empty_fan):
-        empty_fan.states = states
-        empty_fan.coordinator.data[ENTITY_FAN][empty_fan._child_id] = empty_fan
-        empty_fan.update_states()
-        assert empty_fan.extra_state_attributes == extra_attrs
-        for key, val in expected_attrs.items():
-            assert getattr(empty_fan, key) == val
-
-    def test_name(self, empty_fan):
-        assert empty_fan.name == "test fan"
-
-    def test_unique_id(self, empty_fan):
-        empty_fan._child_id = "beans"
-        assert empty_fan.unique_id == "beans"
-
-    @pytest.mark.parametrize(
-        "state, expected",
-        [
-            ("on", True),
-            ("off", False),
-        ],
-    )
-    def test_is_on(self, state, expected, empty_fan):
-        empty_fan._state = state
-        assert empty_fan.is_on == expected
-
-    def test_extra_state_attributes(self, mocked_coordinator):
-        model = "bean model"
-        device_id = "bean-123"
-        child_id = "bean-123-123"
-        test_fan = fan.DreoFanHA(
-            mocked_coordinator,
-            "test fan",
-            model=model,
-            device_id=device_id,
-            child_id=child_id,
-        )
-        assert test_fan.extra_state_attributes == {
-            "model": model,
-            "deviceId": device_id,
-            "Child ID": child_id,
-        }
-
-    def test_current_direction(self, empty_fan):
-        empty_fan._current_direction = "reverse"
-        assert empty_fan.current_direction == "reverse"
-
-    def test_oscillating(self, empty_fan):
-        assert not empty_fan.oscillating
-
-    @pytest.mark.parametrize(
-        "set_speed, expected",
-        [
-            # Speed not set
-            (None, 0),
-            # Speed is set but 000
-            ("fan-speed-6-000", 0),
-            # Speed is set to a value
-            ("fan-speed-6-016", 16),
-        ],
-    )
-    def test_percentage(self, set_speed, expected, speed_fan):
-        speed_fan._fan_speed = set_speed
-        assert speed_fan.percentage == expected
-
-    @pytest.mark.parametrize(
-        "preset, expected",
-        [
-            # Breeze
-            ("comfort-breeze", "breeze"),
-            ("not supported", None),
-        ],
-    )
-    def test_preset_mode(self, preset, expected, empty_fan):
-        empty_fan._preset_mode = preset
-        assert empty_fan.preset_mode == expected
-
-    def test_preset_modes(self, empty_fan):
-        preset_modes = ["comfort-breeze"]
-        empty_fan._preset_modes = preset_modes
-        assert empty_fan.preset_modes == preset_modes
-
-    def test_speed_count(self, speed_fan):
-        assert speed_fan.speed_count == 6
-
-    def test_supported_features(self, empty_fan):
-        features = [1, 2, 3]
-        empty_fan._supported_features = features
-        assert empty_fan.supported_features == features
-
-    @pytest.mark.asyncio
-    @pytest.mark.parametrize(
-        "percentage, preset_mode, expected_attrs",
-        [
-            (
-                12,
-                None,
-                {
-                    "_fan_speed": "fan-speed-6-016",
-                    "_preset_mode": None,
-                },
-            ),
-            (
-                17,
-                "comfort-breeze",
-                {
-                    "_fan_speed": "fan-speed-6-033",
-                    "_preset_mode": "breeze",
-                },
-            ),
-        ],
-    )
-    async def test_async_turn_on(
-        self, percentage, preset_mode, expected_attrs, speed_fan
-    ):
-        speed_fan._supported_features = process_functions_expected
-        await speed_fan.async_turn_on(percentage=percentage, preset_mode=preset_mode)
-        for key, val in expected_attrs.items():
-            assert getattr(speed_fan, key) == val
-
-    @pytest.mark.asyncio
-    async def test_async_turn_off(self, empty_fan):
-        # Added in 2024.8.0
-        with suppress(AttributeError):
-            empty_fan._supported_features |= fan.FanEntityFeature.TURN_OFF
-        await empty_fan.async_turn_off()
-        assert empty_fan._state == "off"

--- a/tests/dreo/utils.py
+++ b/tests/dreo/utils.py
@@ -1,0 +1,48 @@
+import asyncio
+import json
+import os
+from typing import Any
+
+from hubspace_async import HubSpaceConnection, HubSpaceDevice, HubSpaceState
+
+from custom_components.hubspace import anonomyize_data
+
+current_path: str = os.path.dirname(os.path.realpath(__file__))
+
+
+def get_device_dump(file_name: str) -> Any:
+    """Get a device dump
+
+    :param file_name: Name of the file to load
+    """
+    with open(os.path.join(current_path, "device_dumps", file_name), "r") as fh:
+        return json.load(fh)
+
+
+def create_devices_from_data(file_name: str) -> list[HubSpaceDevice]:
+    """Generate devices from a data dump
+
+    :param file_name: Name of the file to load
+    """
+    devices = get_device_dump(file_name)
+    processed = []
+    for device in devices:
+        processed_states = []
+        for state in device["states"]:
+            processed_states.append(HubSpaceState(**state))
+        device["states"] = processed_states
+        if "children" not in device:
+            device["children"] = []
+        processed.append(HubSpaceDevice(**device))
+    return processed
+
+
+def convert_hs_raw(data):
+    """Used for converting old data-dumps to new data dumps"""
+    loop = asyncio.get_event_loop()
+    conn = HubSpaceConnection(None, None)
+    loop.run_until_complete(conn._process_api_results(data))
+    devs = loop.run_until_complete(anonomyize_data.generate_anon_data(conn))
+    with open("converted.json", "w") as fh:
+        json.dump(devs, fh, indent=4)
+    return devs

--- a/tests/dreo/utils.py
+++ b/tests/dreo/utils.py
@@ -1,11 +1,8 @@
-import asyncio
 import json
 import os
 from typing import Any
 
-from hubspace_async import HubSpaceConnection, HubSpaceDevice, HubSpaceState
-
-from custom_components.hubspace import anonomyize_data
+from custom_components.dreo.basedevice import DreoBaseDeviceHA
 
 current_path: str = os.path.dirname(os.path.realpath(__file__))
 
@@ -19,7 +16,7 @@ def get_device_dump(file_name: str) -> Any:
         return json.load(fh)
 
 
-def create_devices_from_data(file_name: str) -> list[HubSpaceDevice]:
+def create_devices_from_data(file_name: str) -> list[DreoBaseDeviceHA]:
     """Generate devices from a data dump
 
     :param file_name: Name of the file to load
@@ -28,21 +25,11 @@ def create_devices_from_data(file_name: str) -> list[HubSpaceDevice]:
     processed = []
     for device in devices:
         processed_states = []
-        for state in device["states"]:
-            processed_states.append(HubSpaceState(**state))
+#        for state in device["states"]:
+#            processed_states.append(HubSpaceState(**state))
         device["states"] = processed_states
         if "children" not in device:
             device["children"] = []
-        processed.append(HubSpaceDevice(**device))
+#        processed.append(HubSpaceDevice(**device))
     return processed
 
-
-def convert_hs_raw(data):
-    """Used for converting old data-dumps to new data dumps"""
-    loop = asyncio.get_event_loop()
-    conn = HubSpaceConnection(None, None)
-    loop.run_until_complete(conn._process_api_results(data))
-    devs = loop.run_until_complete(anonomyize_data.generate_anon_data(conn))
-    with open("converted.json", "w") as fh:
-        json.dump(devs, fh, indent=4)
-    return devs

--- a/tests/pydreo/README.md
+++ b/tests/pydreo/README.md
@@ -3,7 +3,6 @@
 *This aims to briefly describe how these unit-tests are setup. Note that this is my first attempt at Python UnitTesting, so there is likely a much better way to do some of this. If you have suggestions, let me know.*
 
 - All tests inherit off TestBase.py
-- Imports in each file are done twice, once for PyLint and once for actual test execution.
 - All API responses are in the **api_responses** folder.
     - Tests can specify a version of get_devices response for their specific scenarios. 
         - Recommendation would be to have seperate get_devices files for each device to test.

--- a/tests/pydreo/call_json.py
+++ b/tests/pydreo/call_json.py
@@ -2,10 +2,7 @@
 from typing import TYPE_CHECKING
 import json
 
-if TYPE_CHECKING:
-    from .defaults import Defaults
-else:
-    from defaults import Defaults
+from .defaults import Defaults
 
 # DEFAULT_BODY = Standard body for new device calls
 # DEFAULT_HEADER = standard header for most calls

--- a/tests/pydreo/defaults.py
+++ b/tests/pydreo/defaults.py
@@ -1,5 +1,4 @@
 """PyDreo Test Defaults"""
-from typing import TYPE_CHECKING
 from requests.structures import CaseInsensitiveDict
 
 from .imports import * # pylint: disable=W0401,W0614

--- a/tests/pydreo/defaults.py
+++ b/tests/pydreo/defaults.py
@@ -2,10 +2,7 @@
 from typing import TYPE_CHECKING
 from requests.structures import CaseInsensitiveDict
 
-if TYPE_CHECKING:
-    from .imports import * # pylint: disable=W0401,W0614
-else:
-    from imports import * # pylint: disable=W0401,W0614
+from .imports import * # pylint: disable=W0401,W0614
 
 class Defaults:
     """General defaults for API responses and requests.

--- a/tests/pydreo/imports.py
+++ b/tests/pydreo/imports.py
@@ -1,13 +1,4 @@
-#from custom_components.dreo.pydreo import PyDreo
 import sys
 import importlib.util
 from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from custom_components.dreo.pydreo import * # pylint: disable=W0401,W0614
-else:
-    spec = importlib.util.spec_from_file_location("pydreo", "custom_components/dreo/pydreo/__init__.py")
-    pydreo = importlib.util.module_from_spec(spec)
-    sys.modules["pydreo"] = pydreo
-    spec.loader.exec_module(pydreo)
-    from pydreo import * # pylint: disable=W0401,W0614
+from custom_components.dreo.pydreo import * # pylint: disable=W0401,W0614

--- a/tests/pydreo/test_all_devices.py
+++ b/tests/pydreo/test_all_devices.py
@@ -8,14 +8,9 @@ and methods needed to run the tests.
 import logging
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from  .imports import PyDreo
-    from . import call_json
-    from .testbase import TestBase
-else:
-    from imports import * # pylint: disable=W0401,W0614
-    import call_json
-    from testbase import TestBase
+from .imports import PyDreo
+from . import call_json
+from .testbase import TestBase
 
 
 logger = logging.getLogger(__name__)

--- a/tests/pydreo/test_helpers.py
+++ b/tests/pydreo/test_helpers.py
@@ -1,14 +1,9 @@
 """Test helpers for PyDreo."""
 from typing import TYPE_CHECKING
+from  .imports import PyDreo, Helpers
+from . import call_json
+from .testbase import TestBase
 
-if TYPE_CHECKING:
-    from  .imports import PyDreo, Helpers
-    from . import call_json
-    from .testbase import TestBase
-else:
-    from imports import * # pylint: disable=W0401,W0614
-    import call_json
-    from testbase import TestBase
 
 class TestHelpers:
     """Test Helpers class."""

--- a/tests/pydreo/test_pydreofan.py
+++ b/tests/pydreo/test_pydreofan.py
@@ -1,18 +1,11 @@
 """Tests for Dreo Fans"""
 # pylint: disable=used-before-assignment
 import logging
-from typing import TYPE_CHECKING
 from unittest.mock import patch
 import pytest
-
-if TYPE_CHECKING:
-    from  .imports import * # pylint: disable=W0401,W0614
-    from . import call_json
-    from .testbase import TestBase
-else:
-    from imports import * # pylint: disable=W0401,W0614
-    import call_json
-    from testbase import TestBase
+from  .imports import * # pylint: disable=W0401,W0614
+from . import call_json
+from .testbase import TestBase, PATCH_SEND_COMMAND
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -32,18 +25,18 @@ class TestPyDreoFan(TestBase):
         assert fan.speed_range == (1, 5)
         assert fan.preset_modes == ['normal', 'natural', 'sleep', 'auto']
 
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.is_on = True
             mock_send_command.assert_called_once_with(fan, {POWERON_KEY: True})
 
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.preset_mode = 'normal'
             mock_send_command.assert_called_once_with(fan, {WINDTYPE_KEY: 1})
 
         with pytest.raises(ValueError):
             fan.preset_mode = 'not_a_mode'
 
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.fan_speed = 3
             mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 3})
 
@@ -62,18 +55,18 @@ class TestPyDreoFan(TestBase):
         assert fan.speed_range == (1, 9)
         assert fan.preset_modes == ['normal', 'natural', 'sleep', 'auto', 'turbo', 'custom']
 
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.is_on = True
             mock_send_command.assert_called_once_with(fan, {POWERON_KEY: True})
 
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.preset_mode = 'normal'
             mock_send_command.assert_called_once_with(fan, {WIND_MODE_KEY: 1})
 
         with pytest.raises(ValueError):
             fan.preset_mode = 'not_a_mode'
 
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.fan_speed = 3
             mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 3})
 

--- a/tests/pydreo/test_pydreofan.py
+++ b/tests/pydreo/test_pydreofan.py
@@ -43,35 +43,6 @@ class TestPyDreoFan(TestBase):
         with pytest.raises(ValueError):
             fan.fan_speed = 10
 
-
-    def test_HTF005S(self):  # pylint: disable=invalid-name
-        """Load fan and test sending commands."""
-
-        self.get_devices_file_name = "get_devices_HTF005S.json"
-        self.manager.load_devices()
-        assert len(self.manager.fans) == 1
-        fan = self.manager.fans[0]
-        assert fan.speed_range == (1, 12)
-        assert fan.preset_modes == ['normal', 'natural', 'sleep', 'auto']
-
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
-            fan.is_on = True
-            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: True})
-
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
-            fan.preset_mode = 'normal'
-            mock_send_command.assert_called_once_with(fan, {WINDTYPE_KEY: 1})
-
-        with pytest.raises(ValueError):
-            fan.preset_mode = 'not_a_mode'
-
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
-            fan.fan_speed = 3
-            mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 3})
-
-        with pytest.raises(ValueError):
-            fan.fan_speed = 13
-
     def test_circulator_load_and_send_commands(self):
         """Load circulator fan and test sending commands."""
         self.get_devices_file_name = "get_devices_HAF004S.json"
@@ -103,7 +74,7 @@ class TestPyDreoFan(TestBase):
             fan.fan_speed = 10
 
 
-    def test_HCF005S(self):  # pylint: disable=invalid-name
+    def test_HCF001S(self):  # pylint: disable=invalid-name
         """Load fan and test sending commands."""
 
         self.get_devices_file_name = "get_devices_HCF001S.json"
@@ -113,18 +84,46 @@ class TestPyDreoFan(TestBase):
         assert fan.speed_range == (1, 12)
         assert fan.preset_modes == ['normal', 'natural', 'sleep', 'reverse']
 
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.is_on = True
             mock_send_command.assert_called_once_with(fan, {POWERON_KEY: True})
 
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.preset_mode = 'normal'
             mock_send_command.assert_called_once_with(fan, {MODE_KEY: 1})
 
         with pytest.raises(ValueError):
             fan.preset_mode = 'not_a_mode'
 
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.fan_speed = 3
+            mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 3})
+
+        with pytest.raises(ValueError):
+            fan.fan_speed = 13
+
+    def test_HTF005S(self):  # pylint: disable=invalid-name
+        """Load fan and test sending commands."""
+
+        self.get_devices_file_name = "get_devices_HTF005S.json"
+        self.manager.load_devices()
+        assert len(self.manager.fans) == 1
+        fan = self.manager.fans[0]
+        assert fan.speed_range == (1, 12)
+        assert fan.preset_modes == ['normal', 'natural', 'sleep', 'auto']
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.is_on = True
+            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: True})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = 'normal'
+            mock_send_command.assert_called_once_with(fan, {WINDTYPE_KEY: 1})
+
+        with pytest.raises(ValueError):
+            fan.preset_mode = 'not_a_mode'
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.fan_speed = 3
             mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 3})
 

--- a/tests/pydreo/test_pydreoheater.py
+++ b/tests/pydreo/test_pydreoheater.py
@@ -1,24 +1,16 @@
 """Tests for Dreo Fans"""
 # pylint: disable=used-before-assignment
 import logging
-from typing import TYPE_CHECKING
 from unittest.mock import patch, call
 import pytest
-
-if TYPE_CHECKING:
-    from  .imports import * # pylint: disable=W0401,W0614
-    from . import call_json
-    from .testbase import TestBase
-else:
-    from imports import * # pylint: disable=W0401,W0614
-    import call_json
-    from testbase import TestBase
+from  .imports import * # pylint: disable=W0401,W0614
+from . import call_json
+from .testbase import TestBase, PATCH_SEND_COMMAND
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 LOGIN_RESPONSE = call_json.LOGIN_RET_BODY
-
 
 class TestPyDreoHeater(TestBase):
     """Test PyDreoHeater class."""
@@ -33,11 +25,11 @@ class TestPyDreoHeater(TestBase):
         assert heater.heat_range == (1, 3)
         assert heater.preset_modes == ['H1', 'H2', 'H3']
 
-        with patch('pydreo.PyDreo.send_command') as mock_send_command:
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
             heater.poweron = True
             mock_send_command.assert_called_once_with(heater, {POWERON_KEY: True})
 
-        with (patch('pydreo.PyDreo.send_command') as mock_send_command):
+        with (patch(PATCH_SEND_COMMAND) as mock_send_command):
             heater.preset_mode = 'H1'
             mock_send_command.assert_has_calls([call(heater, {HTALEVEL_KEY: 1})], True)
 

--- a/tests/pydreo/testbase.py
+++ b/tests/pydreo/testbase.py
@@ -4,18 +4,15 @@ import logging
 from typing import Optional, TYPE_CHECKING
 from unittest.mock import patch
 import pytest
-
-if TYPE_CHECKING:
-    from  .imports import * # pylint: disable=W0401,W0614
-    from . import defaults
-    from . import call_json
-else:
-    from imports import * # pylint: disable=W0401,W0614
-    import defaults
-    import call_json
+from  .imports import * # pylint: disable=W0401,W0614
+from . import defaults
+from . import call_json
 
 logger = logging.getLogger(__name__)
 
+PATCH_BASE_PATH = 'custom_components.dreo.pydreo'
+PATCH_SEND_COMMAND = f'{PATCH_BASE_PATH}.PyDreo.send_command'
+PATCH_CALL_DREO_API = f'{PATCH_BASE_PATH}.PyDreo.call_dreo_api'
 
 Defaults = defaults.Defaults
 
@@ -50,7 +47,7 @@ class TestBase:
         Class instance with mocked call_api() function and Dreo object
         """
         self._get_devices_file_name = None
-        self.mock_api_call = patch('pydreo.PyDreo.call_dreo_api')
+        self.mock_api_call = patch(PATCH_CALL_DREO_API)
         self.caplog = caplog
         self.mock_api = self.mock_api_call.start()
         self.mock_api.side_effect = self.call_dreo_api


### PR DESCRIPTION
## Major Changes
* Added UTs at the HA layer.  Just one basic one, but they run.

This pull request includes several changes to improve code readability, enhance type safety, and add new test utilities for the Dreo fan platform. The most important changes include type annotations, updating log messages, and adding new pytest fixtures and test utilities.

### Code improvements and type safety:

* [`custom_components/dreo/fan.py`](diffhunk://#diff-f21b5375590d3b0f814a70234404b87cec157d77529559b46a636dbba06d0989L30-R33): Added type annotations and updated log messages in the `async_setup_entry` function.
* [`custom_components/dreo/number.py`](diffhunk://#diff-3ed9ab06600d90cec145cccb0311d5af7d5a2a5c2e5d13d63b53b3c171e80582L107-R118): Improved type safety by renaming variables and updating log messages in the `add_entries` function. [[1]](diffhunk://#diff-3ed9ab06600d90cec145cccb0311d5af7d5a2a5c2e5d13d63b53b3c171e80582L107-R118) [[2]](diffhunk://#diff-3ed9ab06600d90cec145cccb0311d5af7d5a2a5c2e5d13d63b53b3c171e80582L127-R129)

### Test enhancements:

* [`tests/dreo/conftest.py`](diffhunk://#diff-212be1e267506c5cf1f16844345abf9351ecc8254aaa35fdc7aad298024c16fbR1-R13): Added a new pytest fixture to set debug mode for capturing all log messages.
* [`tests/dreo/test_fan.py`](diffhunk://#diff-12261a71a9eac0ed0263d4242ab69f36caf7b52167497db1a5a3542481d427a8R1-R42): Added new test cases for the `DreoFanHA` class, including tests for fan speed, preset modes, and power states.
* [`tests/dreo/utils.py`](diffhunk://#diff-7d8a6430af23ebc80f55bdedead61a9788f81ead3064d1c337397bde269486b7R1-R35): Introduced utility functions for loading device dumps and creating devices from data.

### Configuration and dependency updates:

* [`pytest.ini`](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1L2-R2): Commented out the `pythonpath` configuration to avoid potential conflicts.
* [`requirements.test.txt`](diffhunk://#diff-ed8a96ce1b28bade8f588574ef61062e1b5626d8ac7e1465f854be2470cb7d31R4-L5): Added `pytest-mock` to the test dependencies.

### Miscellaneous:

* [`tests/dreo/__init__.py`](diffhunk://#diff-2a981c3f28607a1d8eb20aeccc50b1f3ee179b0384d2e043c74748b3ab66876aR1): Added an empty file to ensure pytest can find the tests directory.