### PR TITLE
Fix for missing fan_2in1_breeze mode in FAN_MODE_STRINGS

### DIFF
--- a/custom_components/dreo/pydreo/constant.py
+++ b/custom_components/dreo/pydreo/constant.py
@@ -223,4 +223,5 @@ FAN_MODE_STRINGS = {
     "device_control_mode_turbo": "turbo",
     "base_reverse": "reverse",
     "device_control_custom": "custom"
+    "fan_2in1_breeze": "2-in-1 Breeze Mode"  # Added this line
 }


### PR DESCRIPTION
This pull request fixes the KeyError caused by the missing `fan_2in1_breeze` mode in the `FAN_MODE_STRINGS` dictionary in `constant.py`.