### PR TITLE
Add platforms for Humidifer to HA

### DIFF
--- a/custom_components/dreo/__init__.py
+++ b/custom_components/dreo/__init__.py
@@ -69,6 +69,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         platforms.add(Platform.SWITCH)
         platforms.add(Platform.NUMBER)
 
+    if (DreoDeviceType.HUMIDIFIER in device_types):
+        platforms.add(Platform.HUMIDIFIER)
+        platforms.add(Platform.SENSOR)
+        platforms.add(Platform.SWITCH)
+        platforms.add(Platform.NUMBER)
+
     if (DreoDeviceType.CHEF_MAKER in device_types):
         platforms.add(Platform.SENSOR)
         platforms.add(Platform.SWITCH)

--- a/custom_components/dreo/pydreo/constant.py
+++ b/custom_components/dreo/pydreo/constant.py
@@ -261,3 +261,4 @@ class DreoDeviceType(StrEnum):
     HEATER = "Heater"
     AIR_CONDITIONER = "Air Conditioner"
     CHEF_MAKER = "Chef Maker"
+    HUMIDIFIER = "Humidifier"


### PR DESCRIPTION
This pull request includes a small change to the `custom_components/dreo/__init__.py` file. The change adds support for `HUMIDIFIER` devices by including the necessary platforms.

* [`custom_components/dreo/__init__.py`](diffhunk://#diff-0ae7123b22240ee3372d4a3446b65e5039bb6590dcefd68669d2827dd1630f35R74-R79): Added support for `HUMIDIFIER` devices by including `Platform.HUMIDIFIER`, `Platform.SENSOR`, `Platform.SWITCH`, and `Platform.NUMBER` in the `async_setup_entry` function.