### PR TITLE
Read swing angle ranges from device

### DIFF
--- a/custom_components/dreo/pydreo/constant.py
+++ b/custom_components/dreo/pydreo/constant.py
@@ -163,6 +163,8 @@ OSCILLATION_ANGLE_KEY = "oscangle"
 
 WIND_MODE_KEY = "mode"
 
+HORIZONTAL_ANGLE_RANGE = "horizontal_angle_range"
+VERTICAL_ANGLE_RANGE = "vertical_angle_range"
 SPEED_RANGE = "speed_range"
 HEAT_RANGE = "heat_range"
 ECOLEVEL_RANGE = "ecolevel_range"

--- a/custom_components/dreo/pydreo/pydreoaircirculator.py
+++ b/custom_components/dreo/pydreo/pydreoaircirculator.py
@@ -181,6 +181,14 @@ class PyDreoAirCirculator(PyDreoFanBase):
             raise NotImplementedError("Horizontal oscillation is not supported.")
 
     @property
+    def horizontal_osc_angle_left_range(self):
+        return self.horizontal_angle_range
+
+    @property
+    def horizontal_osc_angle_right_range(self):
+        return self.horizontal_angle_range
+
+    @property
     def vertically_oscillating(self):
         """Returns `True` if vertical oscillation is on."""
         if self._vertically_oscillating is not None:
@@ -204,6 +212,14 @@ class PyDreoAirCirculator(PyDreoFanBase):
             self._send_command(OSCMODE_KEY, osc_computed)
         else:
             raise NotImplementedError("Vertical oscillation is not supported.")
+
+    @property
+    def vertical_osc_angle_top_range(self):
+        return self.vertical_angle_range
+
+    @property
+    def vertical_osc_angle_bottom_range(self):
+        return self.vertical_angle_range
 
     def set_horizontal_oscillation_angle(self, angle: int) -> None:
         """Set the horizontal oscillation angle."""

--- a/custom_components/dreo/pydreo/pydreoaircirculator.py
+++ b/custom_components/dreo/pydreo/pydreoaircirculator.py
@@ -14,6 +14,8 @@ from .constant import (
     OSCMODE_KEY,
     FIXEDCONF_KEY,
     OscillationMode,
+    HORIZONTAL_ANGLE_RANGE,
+    VERTICAL_ANGLE_RANGE,
     SPEED_RANGE
 )
 
@@ -32,7 +34,19 @@ class PyDreoAirCirculator(PyDreoFanBase):
     def __init__(self, device_definition: DreoDeviceDetails, details: Dict[str, list], dreo: "PyDreo"):
         """Initialize air devices."""
         super().__init__(device_definition, details, dreo)
-        
+
+        self._horizontal_angle_range = None
+        if device_definition.device_ranges is not None:
+            self._horizontal_angle_range = device_definition.device_ranges[HORIZONTAL_ANGLE_RANGE]
+        if self._horizontal_angle_range is None:
+            self._horizontal_angle_range = self.parse_swing_angle_range(details, "hor")
+
+        self._vertical_angle_range = None
+        if device_definition.device_ranges is not None:
+            self._vertical_angle_range = device_definition.device_ranges[VERTICAL_ANGLE_RANGE]
+        if self._vertical_angle_range is None:
+            self._vertical_angle_range = self.parse_swing_angle_range(details, "ver")
+
         self._speed_range = None
         if (device_definition.device_ranges is not None):
             self._speed_range = device_definition.device_ranges[SPEED_RANGE]
@@ -48,7 +62,31 @@ class PyDreoAirCirculator(PyDreoFanBase):
 
         self._horizontally_oscillating = None
         self._vertically_oscillating = None
-    
+
+    @staticmethod
+    def parse_swing_angle_range(details: Dict[str, list], direction: str) -> tuple[int, int] | None:
+        """Parse the swing angle range from the details."""
+        controls_conf = details.get("controlsConf", None)
+        if controls_conf is None:
+            return None
+
+        swing_angle = controls_conf.get("swingAngle", None)
+        if swing_angle is None:
+            _LOGGER.debug("PyDreoAirCirculator:no swing angle detected")
+            return None
+
+        fixed_angle = swing_angle.get("fixedAngle", None)
+        if fixed_angle is None:
+            _LOGGER.debug("PyDreoAirCirculator:no fixed angle detected")
+            return None
+
+        angle = fixed_angle.get(direction + "Angle", None)
+        zero_angle = fixed_angle.get(direction + "ZeroAngle", None)
+        if angle is None or zero_angle is None:
+            return None
+
+        return -zero_angle, angle - zero_angle
+
     def parse_preset_modes(self, details: Dict[str, list]) -> tuple[str, int]:
         """Parse the preset modes from the details."""
         preset_modes = []
@@ -78,6 +116,16 @@ class PyDreoAirCirculator(PyDreoFanBase):
             preset_modes = None
         _LOGGER.debug("PyDreoAirCirculator:Detected preset modes - %s", preset_modes)
         return preset_modes
+
+    @property
+    def horizontal_angle_range(self):
+        """Get the horizontal swing angle range"""
+        return self._horizontal_angle_range
+
+    @property
+    def vertical_angle_range(self):
+        """Get the vertical swing angle range"""
+        return self._vertical_angle_range
 
     @property
     def oscillating(self) -> bool:

--- a/tests/pydreo/test_pydreoaircirculator.py
+++ b/tests/pydreo/test_pydreoaircirculator.py
@@ -21,6 +21,8 @@ class TestPyDreoAirCirculator(TestBase):
 
         fan : PyDreoAirCirculator = self.pydreo_manager.devices[0]
 
+        assert fan.horizontal_angle_range == (-60, 60)
+        assert fan.vertical_angle_range == (-30, 90)
         assert fan.speed_range == (1, 9)
         assert fan.preset_modes == ['normal', 'natural', 'sleep', 'auto', 'turbo', 'custom']
         assert fan.oscillating is True

--- a/tests/pydreo/test_pydreoaircirculator.py
+++ b/tests/pydreo/test_pydreoaircirculator.py
@@ -27,7 +27,11 @@ class TestPyDreoAirCirculator(TestBase):
         assert fan.preset_modes == ['normal', 'natural', 'sleep', 'auto', 'turbo', 'custom']
         assert fan.oscillating is True
         assert fan.vertically_oscillating is True
+        assert fan.vertical_osc_angle_top_range == (-30, 90)
+        assert fan.vertical_osc_angle_bottom_range == (-30, 90)
         assert fan.horizontally_oscillating is False
+        assert fan.horizontal_osc_angle_left_range == (-60, 60)
+        assert fan.horizontal_osc_angle_right_range == (-60, 60)
 
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.is_on = True


### PR DESCRIPTION
This reads the proper horizontal and vertical swing angle ranges from the API's device details, rather than relying on the hard-coded per-model (prefix) information; though the latter is still used as a fallback for devices that do not report this (you never know, I suppose).

fixes https://github.com/JeffSteinbok/hass-dreo/issues/106
fixes https://github.com/JeffSteinbok/hass-dreo/issues/150
fixes https://github.com/JeffSteinbok/hass-dreo/issues/173
relates https://github.com/JeffSteinbok/hass-dreo/issues/157

In a second commit I am also overwriting the ranges for oscillation, as they should be the same ones.

relates https://github.com/JeffSteinbok/hass-dreo/issues/106
relates https://github.com/JeffSteinbok/hass-dreo/pull/115