### PR TITLE
Fix displaying temperature in Celsius

### DIFF
--- a/custom_components/dreo/dreoheater.py
+++ b/custom_components/dreo/dreoheater.py
@@ -49,7 +49,7 @@ class DreoHeaterHA(DreoBaseDeviceHA, ClimateEntity):
     """Representation of a Dreo heater as a climate entity."""
 
     _attr_precision = PRECISION_WHOLE
-    _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT  # TODO
+    _attr_temperature_unit = UnitOfTemperature.FAHRENHEIT
     _attr_target_temperature = None
     _attr_current_temperature = None
     _attr_fan_mode = None
@@ -153,7 +153,6 @@ class DreoHeaterHA(DreoBaseDeviceHA, ClimateEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the heater."""
         return {
-            "current_temperature": self.device.temperature,
             "model": self.device.model,
             "htalevel": self.device.htalevel,
         }

--- a/custom_components/dreo/number.py
+++ b/custom_components/dreo/number.py
@@ -53,9 +53,11 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         key="Target Temperature",
         translation_key="target_temp",
         attr_name="ecolevel",
-        icon="mdi:temperature",
+        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
+        icon="mdi:thermometer",
         min_value=0,
-        max_value=100
+        max_value=100,
+        device_class=NumberDeviceClass.TEMPERATURE,
     ),
     DreoNumberEntityDescription(
         key="Horizontal Oscillation Angle Left",
@@ -122,12 +124,16 @@ def get_entries(pydreo_devices : list[PyDreoBaseDevice]) -> list[DreoNumberHA]:
 
                 device_range = get_device_range(pydreo_device, number_definition)
                 if device_range is not None and isinstance(device_range, tuple):
-                    dned = DreoNumberEntityDescription(key=number_definition.key,
-                                                       translation_key=number_definition.translation_key,
-                                                       attr_name=number_definition.attr_name,
-                                                       icon=number_definition.icon,
-                                                       min_value=device_range[0],
-                                                       max_value=device_range[1])
+                    dned = DreoNumberEntityDescription(
+                        key=number_definition.key,
+                        translation_key=number_definition.translation_key,
+                        attr_name=number_definition.attr_name,
+                        icon=number_definition.icon,
+                        min_value=device_range[0],
+                        max_value=device_range[1],
+                        device_class=number_definition.device_class,
+                        native_unit_of_measurement=number_definition.native_unit_of_measurement,
+                    )
                     number_ha_collection.append(DreoNumberHA(pydreo_device, dned))
                 else:
                     number_ha_collection.append(DreoNumberHA(pydreo_device,number_definition))
@@ -182,6 +188,8 @@ class DreoNumberHA(DreoBaseDeviceHA, NumberEntity): # pylint: disable=abstract-m
         self._attr_native_min_value = description.min_value
         self._attr_native_max_value = description.max_value
         self._attr_native_step = description.step
+        self._attr_native_unit_of_measurement = description.native_unit_of_measurement
+        self._device_class_name = description.device_class
 
     @property
     def native_value(self) -> float:

--- a/custom_components/dreo/sensor.py
+++ b/custom_components/dreo/sensor.py
@@ -59,9 +59,7 @@ SENSORS: tuple[DreoSensorEntityDescription, ...] = (
         translation_key="temperature",
         device_class=SensorDeviceClass.TEMPERATURE,
         state_class=SensorStateClass.MEASUREMENT,
-        native_unit_of_measurement_fn=lambda device: UnitOfTemperature.CELSIUS
-        if (device.temperature_units == TemperatureUnit.CELCIUS)
-        else UnitOfTemperature.FAHRENHEIT,
+        native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
         value_fn=lambda device: device.temperature,
         exists_fn=lambda device: device.is_feature_supported("temperature"),
     ),


### PR DESCRIPTION
I noticed that when your Home Assistant temperature unit was set to Celsius the values were not displaying correctly.

It looks as if the Dreo API always returns the temperature reading in Fahrenheit, so I've updated that in a couple of places. Home Assistant then handles storing/displaying the value in Celsius if required.

Before - note the current temperature is 53C which is 127.4F 😅:
![Screenshot 2025-01-03 100627](https://github.com/user-attachments/assets/43aacc93-3700-43c9-bda1-4888a0a04b43)

After:
![Screenshot 2025-01-03 095326](https://github.com/user-attachments/assets/1334b150-961d-4075-bb43-519e509f208f)

--- 
Before:
![Screenshot 2025-01-03 100828](https://github.com/user-attachments/assets/3ff095e9-3486-46a4-ab29-5933c7cc7d72)

After:
![image](https://github.com/user-attachments/assets/aff05696-001f-4bed-860d-e36eba48ce90)
I've also set the device class to temperature here and updated the icon as mdi:temperature resulted in a blank icon.

