### PR TITLE
Revert "fix heater becoming unresponsive after turning off (#222)"

### DIFF
--- a/custom_components/dreo/pydreo/pydreoheater.py
+++ b/custom_components/dreo/pydreo/pydreoheater.py
@@ -170,10 +170,7 @@ class PyDreoHeater(PyDreoBaseDevice):
     @mode.setter
     def mode(self, mode: str) -> None:
         _LOGGER.debug("PyDreoHeater:mode(%s) --> %s", self.name, mode)
-        # setting heater mode to OFF is redundand because 'poweron' will be set
-        # and can prevent it from properly turning back on (tested on DR-HSH004S)
-        if not mode == HEATER_MODE_OFF:
-            self._send_command(MODE_KEY, mode)
+        self._send_command(MODE_KEY, mode)
 
     @property
     def fan_mode(self) -> str:


### PR DESCRIPTION
Reverts JeffSteinbok/hass-dreo#226

This commit breaks all my heaters. With this if you power off the heater with HA and then power it on by pressing button on heater or using dreo app, it will not show as being on in HA. You have to reload the integration or restart HA.

Models affected
DR-HSH009S

However it does seem to fix model DR-HSH017S
