### PR TITLE
Feature/fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The following fans types are supported. Not all variants have been tested.
 | Air Circulators | DR-HAF, DR-HPF | |
 | Ceiling Fans | DR-HCF | |
 | Air Purifiers | DR-HAP | |
+| Air Conditioners | DR-HAC | |
 
 Models that have been specifically tested can be found below.
 

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -124,7 +124,7 @@ SUPPORTED_DEVICES = {
     "DR-HCF": DreoDeviceDetails(device_type=DreoDeviceType.CEILING_FAN),
 
     # Air Purifiers
-    "DR-HAP003S": DreoDeviceDetails(device_type=DreoDeviceType.AIR_PURIFIER),
+    "DR-HAP": DreoDeviceDetails(device_type=DreoDeviceType.AIR_PURIFIER),
 
     # Heaters
     "DR-HSH017BS": DreoDeviceDetails(

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -245,7 +245,8 @@ SUPPORTED_DEVICES = {
     ),
 
     # Air Conditioners
-    "DR-HAC005S": DreoDeviceDetails(
+    # Note we had HAC-005S and HAC-006S in the list but they are identical.
+    "DR-HAC": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CONDITIONER,
         device_ranges={
             TEMP_RANGE: (60, 95),
@@ -260,23 +261,6 @@ SUPPORTED_DEVICES = {
         # TODO Add fan modes, windlevel: 1,2,3,4 (Auto)
         fan_modes=[FAN_LOW, FAN_MEDIUM, FAN_HIGH, FAN_AUTO],
     ),
-
-    # Air Conditioners
-    "DR-HAC006S": DreoDeviceDetails(
-        device_type=DreoDeviceType.AIR_CONDITIONER,
-        device_ranges={
-            TEMP_RANGE: (60, 95),
-            TARGET_TEMP_RANGE: (64, 86),
-            TARGET_TEMP_RANGE_ECO: (75, 86),
-            HUMIDITY_RANGE: (30, 80),
-        },
-        # TODO Eco is a Present, not HVAC mode (HVACMode.AUTO)
-        hvac_modes=[HVACMode.COOL, HVACMode.FAN_ONLY, HVACMode.DRY],
-        swing_modes=[SWING_OFF, SWING_ON],
-        preset_modes=[PRESET_NONE, PRESET_ECO],
-        # TODO Add fan modes, windlevel: 1,2,3,4 (Auto)
-        fan_modes=[FAN_LOW, FAN_MEDIUM, FAN_HIGH, FAN_AUTO],
-    ),    
 
     "DR-KCM001S": DreoDeviceDetails(
         device_type=DreoDeviceType.CHEF_MAKER,


### PR DESCRIPTION
This pull request introduces updates to support and streamline the handling of Dreo device models, including changes to the documentation and device model definitions. The most significant updates include adding Air Conditioners to the supported device types in the `README.md`, consolidating model definitions for Air Purifiers and Air Conditioners, and simplifying the associated code.

### Documentation Updates:
* Added "Air Conditioners" (`DR-HAC`) to the list of supported device types in the `README.md`.

### Code Simplification:
* Consolidated the Air Purifier model definitions by replacing `DR-HAP003S` with the more generic `DR-HAP` in `custom_components/dreo/pydreo/models.py`.
* Simplified Air Conditioner model definitions by merging `DR-HAC005S` and `DR-HAC006S` into a single generic model `DR-HAC`, as both were determined to be identical. Removed redundant attributes and comments in `custom_components/dreo/pydreo/models.py`.