### PR TITLE
Fix null ref if no preset modes

### DIFF
--- a/custom_components/dreo/pydreo/pydreofanbase.py
+++ b/custom_components/dreo/pydreo/pydreofanbase.py
@@ -109,6 +109,8 @@ class PyDreoFanBase(PyDreoBaseDevice):
     @property
     def preset_modes(self) -> list[str]:
         """Get the list of preset modes"""
+        if self._preset_modes is None:
+            return None
         return Helpers.get_name_list(self._preset_modes)
     
     @property


### PR DESCRIPTION
This pull request includes a small change to the `speed_range` method in the `pydreofanbase.py` file. The change ensures that if `_preset_modes` is `None`, the method will return `None` instead of attempting further processing.