### PR TITLE
Add Debug Test Mode functionality to Dreo integration

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -11,6 +11,29 @@ There are three buckets of tests, please feel free to add as appropriate.
 * [Dreo Integration Tests](tests/dreo/integrationtests/README.md) - That do talk to PyDreo
     * These integration tests ensure that the Dreo HA code gets what we expect from the device JSON files.
 
+# Debug Test Mode
+There is a special mode you can put the integration in that will allow you to pretend you have any device. Please note that enabling this will do the following:
+* Temporarily disconnect your integration from the Dreo servers.
+* All data will come from JSON files on disk.
+* Unit-tests will fail to prevent accidental merge.
+
+## Enabling
+In [custom_components/dreo/const.py](custom_components/dreo/const.py), uncomment the line:
+```
+# DEBUG_TEST_MODE = True
+```
+
+## Configuration
+In [custom_components/dreo/e2e_test_data](custom_components/dreo/e2e_test_data), you'll find 2 types of files containing content as they would be returned from the Dreo server.
+
+1. [custom_components/dreo/e2e_test_data/get_devices.json](get_devices.json) which contains a JSON blob containing a list of all devices. You can add/change anything in here, just make sure to update the device count at the top. For each device, you'll need a state file - see next point.
+1. Device state files, named as SERIALNUMBER.json. You'll need one of these for each device.
+
+Make sure you have Debug logging enabled as well so you can confirm your files are loading correctly.
+
+## Status Updates
+TODO
+
 ## Getting Network Traces from Dreo App
 As of a recent release, Dreo seems to have removed certificate pinning, at least for iOS. That makes all this a bunch easier.
 

--- a/contributing.md
+++ b/contributing.md
@@ -31,6 +31,8 @@ In [custom_components/dreo/e2e_test_data](custom_components/dreo/e2e_test_data),
 
 Make sure you have Debug logging enabled as well so you can confirm your files are loading correctly.
 
+Simply edit the necessary files, and copy them over to your HA server and you're good to go.
+
 ## Status Updates
 TODO
 

--- a/custom_components/dreo/const.py
+++ b/custom_components/dreo/const.py
@@ -8,3 +8,10 @@ PYDREO_MANAGER = "pydreo_manager"
 DREO_PLATFORMS = "platforms"
 
 CONF_AUTO_RECONNECT = "auto_reconnect"
+
+DEBUG_TEST_MODE : bool = False
+# Uncomment to enable test mode.
+# Tests will not pass if this is set to True to prevent accidental commits.
+# DEBUG_TEST_MODE = True
+DEBUG_TEST_MODE_DIRECTORY_NAME = "e2e_test_data"
+DEBUG_TEST_MODE_DEVICES_FILE_NAME = "get_devices.json"

--- a/custom_components/dreo/debug_test_mode.py
+++ b/custom_components/dreo/debug_test_mode.py
@@ -1,0 +1,85 @@
+"""Support for Dreo Debug Test Mode."""
+import json
+import logging
+
+from .const import (
+    LOGGER,
+    DEBUG_TEST_MODE_DIRECTORY_NAME,
+    DEBUG_TEST_MODE_DEVICES_FILE_NAME
+)
+
+_LOGGER = logging.getLogger(LOGGER)
+
+
+def get_debug_test_mode_payload(base_dir: str) -> dict:
+    """Get the debug test mode payload from the file."""
+
+    debug_test_mode_payload: dict = {}
+
+    _LOGGER.debug("DEBUG_TEST_MODE: get_debug_test_mode_payload called")
+    get_devices_payload = load_test_file(base_dir, DEBUG_TEST_MODE_DEVICES_FILE_NAME)
+    if get_devices_payload is None: 
+        _LOGGER.error("DEBUG_TEST_MODE: Failed to load devices payload from file.")
+        return None 
+    debug_test_mode_payload["get_devices"] = get_devices_payload
+    _LOGGER.debug("DEBUG_TEST_MODE: GetDevices Payload: %s", get_devices_payload)
+
+    # Iterate over all devices and verify uniqueness of serial number and device id
+    seen_serial_numbers = set()
+    seen_device_ids = set()
+
+    data = get_devices_payload.get("data", None)
+    if data is None:
+        _LOGGER.error("DEBUG_TEST_MODE: No data found in get_devices payload")
+        return None
+    
+    for device in data.get("list", []):
+        serial_number = device.get("sn")
+        device_id = device.get("deviceId")
+
+        if not serial_number:
+            _LOGGER.error("DEBUG_TEST_MODE: Device missing serial number")
+            continue
+
+        if not device_id:
+            _LOGGER.error("DEBUG_TEST_MODE: Device missing device id")
+            continue                
+
+        if serial_number in seen_serial_numbers:
+            _LOGGER.error("DEBUG_TEST_MODE: Duplicate serial number found: %s", serial_number)
+            continue
+
+        if device_id in seen_device_ids:
+            _LOGGER.error("DEBUG_TEST_MODE: Duplicate device id found: %s", device_id)
+            continue
+
+        seen_serial_numbers.add(serial_number)
+        seen_device_ids.add(device_id)
+
+        # Load a file specific to the serial number
+        device_state : dict = load_test_file(base_dir, serial_number + ".json")
+        if device_state is None:
+            _LOGGER.error("DEBUG_TEST_MODE: Failed to load device state for serial number %s", serial_number)
+            continue
+        _LOGGER.debug("Loaded data for serial number %s: %s", serial_number, device_state)
+        debug_test_mode_payload[serial_number] = device_state
+
+    return debug_test_mode_payload
+
+def load_test_file(base_dir, filename: str) -> dict:
+    """Load a JSON response from a file in the debug test mode directory."""
+    
+    returned_data: dict = None
+
+    _LOGGER.debug("DEBUG_TEST_MODE: Attempting to load response from file: %s", filename)
+    full_path = f"{base_dir}/{DEBUG_TEST_MODE_DIRECTORY_NAME}/{filename}"
+    try:
+        with open(full_path, 'r', encoding="utf-8") as file:
+            _LOGGER.debug("DEBUG_TEST_MODE: Successfully loaded file: %s", full_path)
+            returned_data = json.load(file)
+    except FileNotFoundError:
+        _LOGGER.error("DEBUG_TEST_MODE: File not found: %s", full_path)
+    except json.JSONDecodeError as e:
+        _LOGGER.error("DEBUG_TEST_MODE: Error decoding JSON for file %s: %s", full_path, e)
+
+    return returned_data

--- a/custom_components/dreo/e2e_test_data/HAC005S_1.json
+++ b/custom_components/dreo/e2e_test_data/HAC005S_1.json
@@ -1,0 +1,157 @@
+{
+    "code": 0,
+    "msg": "OK",
+    "data": {
+      "mixed": {
+        "wifi_rssi": {
+          "state": -79,
+          "timestamp": 1725555670
+        },
+        "poweron": {
+          "state": true,
+          "timestamp": 1725555670
+        },
+        "scheid": {
+          "state": 231789745,
+          "timestamp": 1725555670
+        },
+        "timeron": {
+          "state": {
+            "du": 0,
+            "ts": 1724691562
+          },
+          "timestamp": null
+        },
+        "coolcruvendts": {
+          "state": 0,
+          "timestamp": 1725555670
+        },
+        "scheon": {
+          "state": false,
+          "timestamp": 1725555670
+        },
+        "mcuon": {
+          "state": true,
+          "timestamp": 1725555670
+        },
+        "templevel": {
+          "state": 86,
+          "timestamp": 1725555670
+        },
+        "mode": {
+          "state": 3,
+          "timestamp": 1725570308
+        },
+        "network_latency": {
+          "state": 124,
+          "timestamp": 1725555670
+        },
+        "rhlevel": {
+          "state": 80,
+          "timestamp": 1725555670
+        },
+        "module_hardware_model": {
+          "state": "HeFi",
+          "timestamp": 1725555670
+        },
+        "mcu_firmware_version": {
+          "state": "1.0.72",
+          "timestamp": 1725555670
+        },
+        "oscmode": {
+          "state": 2,
+          "timestamp": 1725555670
+        },
+        "temperature": {
+          "state": 88,
+          "timestamp": 1725570351
+        },
+        "module_hardware_mac": {
+          "state": "001cc27c0c74",
+          "timestamp": 1725555670
+        },
+        "reachtarget": {
+          "state": 0,
+          "timestamp": 1725555670
+        },
+        "muteon": {
+          "state": true,
+          "timestamp": 1725555670
+        },
+        "lighton": {
+          "state": true,
+          "timestamp": 1725555670
+        },
+        "mcu_hardware_model": {
+          "state": "SC95F8613B/US",
+          "timestamp": 1725555670
+        },
+        "wifi_ssid": {
+          "state": "**REDACTED**",
+          "timestamp": 1724691562
+        },
+        "windlevel": {
+          "state": 4,
+          "timestamp": 1725565961
+        },
+        "tempunit": {
+          "state": 1,
+          "timestamp": 1725555670
+        },
+        "sleeptempoffset": {
+          "state": 0,
+          "timestamp": 1725555670
+        },
+        "module_firmware_version": {
+          "state": "3.2.16",
+          "timestamp": 1725555670
+        },
+        "wrong": {
+          "state": 0,
+          "timestamp": 1725555670
+        },
+        "connected": {
+          "state": true,
+          "timestamp": 1725555670
+        },
+        "timeroff": {
+          "state": {
+            "du": 0,
+            "ts": 1724691562
+          },
+          "timestamp": null
+        },
+        "_ota": {
+          "state": 2,
+          "timestamp": 1725555670
+        },
+        "filterthr": {
+          "state": 600,
+          "timestamp": 1725555670
+        },
+        "coolcurveconf": {
+          "state": "NULL",
+          "timestamp": 1725555670
+        },
+        "rh": {
+          "state": 69,
+          "timestamp": 1725570573
+        },
+        "ecopauserate": {
+          "state": 30,
+          "timestamp": 1725555670
+        },
+        "childlockon": {
+          "state": false,
+          "timestamp": 1725555670
+        },
+        "worktime": {
+          "state": 542,
+          "timestamp": 1725568078
+        }
+      },
+      "sn": "HAC005S_1",
+      "productId": "**REDACTED**",
+      "region": "us-east-2/emq"
+    }
+  }

--- a/custom_components/dreo/e2e_test_data/HTF008S_1.json
+++ b/custom_components/dreo/e2e_test_data/HTF008S_1.json
@@ -1,0 +1,101 @@
+{
+    "code": 0,
+    "msg": "OK",
+    "data": {
+        "mixed": {
+            "mcu_hardware_model": {
+                "state": "SC95F8613B",
+                "timestamp": 1686788164
+            },
+            "wifi_ssid": {
+                "state": "REDACTED",
+                "timestamp": 1686788164
+            },
+            "windlevel": {
+                "state": 2,
+                "timestamp": 1687064489
+            },
+            "wifi_rssi": {
+                "state": -37,
+                "timestamp": 1686788164
+            },
+            "poweron": {
+                "state": "true",
+                "timestamp": 1687057235
+            },
+            "windtype": {
+                "state": 1,
+                "timestamp": 1686789795
+            },
+            "timeron": {
+                "state": {
+                    "du": 0,
+                    "ts": 7
+                },
+                "timestamp": null
+            },
+            "voiceon": {
+                "state": false,
+                "timestamp": 1686788993
+            },
+            "wrong": {
+                "state": 0,
+                "timestamp": 1686788164
+            },
+            "module_firmware_version": {
+                "state": "2.3.15",
+                "timestamp": 1686788164
+            },
+            "connected": {
+                "state": true,
+                "timestamp": 1686788164
+            },
+            "mcuon": {
+                "state": true,
+                "timestamp": 1686788164
+            },
+            "timeroff": {
+                "state": {
+                    "du": 0,
+                    "ts": 7
+                },
+                "timestamp": null
+            },
+            "shakehorizon": {
+                "state": false,
+                "timestamp": 1686811203
+            },
+            "network_latency": {
+                "state": 102,
+                "timestamp": 1686788164
+            },
+            "_ota": {
+                "state": 0,
+                "timestamp": 1686788164
+            },
+            "module_hardware_model": {
+                "state": "HeFi",
+                "timestamp": 1686788164
+            },
+            "mcu_firmware_version": {
+                "state": "1.0.17",
+                "timestamp": 1686788164
+            },
+            "temperature": {
+                "state": 71,
+                "timestamp": 1687062055
+            },
+            "module_hardware_mac": {
+                "state": "**REDACTED**",
+                "timestamp": 1686788164
+            },
+            "ledalwayson": {
+                "state": false,
+                "timestamp": 1686788164
+            }
+        },
+        "sn": "HTF008S_1",
+        "productId": "**REDACTED**",
+        "region": "us-east-2"
+    }
+}

--- a/custom_components/dreo/e2e_test_data/get_devices.json
+++ b/custom_components/dreo/e2e_test_data/get_devices.json
@@ -1,0 +1,716 @@
+{
+    "code": 0,
+    "msg": "OK",
+    "data": {
+      "currentPage": 1,
+      "pageSize": 10,
+      "totalNum": 1,
+      "totalPage": 1,
+      "list": [
+        {
+          "deviceId": "1234",
+          "sn": "HTF008S_1",
+          "brand": "Dreo",
+          "model": "DR-HTF008S",
+          "productId": "**REDACTED**",
+          "productName": "Tower Fan",
+          "deviceName": "DEVTEST - Main Bedroom Fan",
+          "shared": false,
+          "series": null,
+          "seriesName": "Cruiser Pro T3 S",
+          "controlsConf": {
+            "template": "DR-HTF008S",
+            "lottie": {
+              "key": "poweron",
+              "frames": [
+                {
+                  "value": 0,
+                  "frame": [
+                    0
+                  ]
+                },
+                {
+                  "value": 1,
+                  "frame": [
+                    2
+                  ]
+                }
+              ]
+            },
+            "cards": [
+              {
+                "type": 2,
+                "title": "device_control_temp",
+                "icon": "",
+                "image": "",
+                "url": "",
+                "show": true
+              },
+              {
+                "type": 6,
+                "title": "device_settings_title",
+                "icon": "ic_setting",
+                "image": "",
+                "url": "dreo://nav/device/setting?deviceSn=${sn}",
+                "show": true,
+                "key": "setting"
+              }
+            ],
+            "preference": [
+              {
+                "id": "200",
+                "type": "Panel Sound",
+                "title": "device_control_panelsound",
+                "image": "ic_mute",
+                "reverse": false,
+                "cmd": "voiceon"
+              },
+              {
+                "id": "210",
+                "type": "Display Auto Off",
+                "title": "device_fans_mode_auto_display",
+                "image": "ic_display",
+                "reverse": true,
+                "cmd": "ledalwayson"
+              },
+              {
+                "id": "230",
+                "type": "Temperature Unit",
+                "title": "device_control_temp_unit",
+                "image": "ic_temp_unit"
+              }
+            ],
+            "control": [
+              {
+                "id": "100",
+                "type": "Mode",
+                "title": "device_mode",
+                "items": [
+                  {
+                    "text": "device_fans_mode_straight",
+                    "textColors": [
+                      "#D5D6D7",
+                      "#D5D6D7"
+                    ],
+                    "image": "ic_normal_wind",
+                    "imageColors": [
+                      "#D5D6D7",
+                      "#25D7E4"
+                    ],
+                    "cmd": "windtype",
+                    "value": 1
+                  },
+                  {
+                    "text": "device_fans_mode_natural",
+                    "textColors": [
+                      "#D5D6D7",
+                      "#D5D6D7"
+                    ],
+                    "image": "ic_natural_wind",
+                    "imageColors": [
+                      "#D5D6D7",
+                      "#2CDD96"
+                    ],
+                    "cmd": "windtype",
+                    "value": 2
+                  },
+                  {
+                    "text": "device_control_mode_sleep",
+                    "textColors": [
+                      "#D5D6D7",
+                      "#D5D6D7"
+                    ],
+                    "image": "ic_sleep_wind",
+                    "imageColors": [
+                      "#D5D6D7",
+                      "#6249DF"
+                    ],
+                    "cmd": "windtype",
+                    "value": 3
+                  },
+                  {
+                    "text": "device_control_mode_auto",
+                    "textColors": [
+                      "#D5D6D7",
+                      "#D5D6D7"
+                    ],
+                    "image": "ic_auto_wind",
+                    "imageColors": [
+                      "#D5D6D7",
+                      "#0A80F5"
+                    ],
+                    "cmd": "windtype",
+                    "value": 4
+                  }
+                ]
+              },
+              {
+                "id": "110",
+                "type": "Speed",
+                "title": "device_control_speed",
+                "items": [
+                  {
+                    "text": "1",
+                    "cmd": "windlevel",
+                    "value": 1
+                  },
+                  {
+                    "text": "5",
+                    "cmd": "windlevel",
+                    "value": 5
+                  }
+                ]
+              },
+              {
+                "id": "120",
+                "type": "Oscillation",
+                "title": "device_control_oscillation",
+                "items": [],
+                "cmd": "shakehorizon"
+              }
+            ],
+            "category": "Tower Fan",
+            "setting": [
+              {
+                "text": "Firmware Version",
+                "image": "image.png",
+                "value": "1.0.0",
+                "url": "dreo://control"
+              }
+            ]
+          },
+          "mainConf": {
+            "isSmart": true,
+            "isWifi": true,
+            "isBluetooth": true,
+            "isVoiceControl": true
+          },
+          "resourcesConf": {
+            "imageSmallSrc": "https://resources.dreo-cloud.com/app/202302/154b19731975c74404ba60cc6a4af66c08.png",
+            "imageFullSrc": "https://resources.dreo-cloud.com/app/202302/16acefeb4c1aaa47c189c693cdf0beb612.zip"
+          },
+          "servicesConf": [
+            {
+              "key": "user_manual",
+              "value": "https://resources.dreo-cloud.com/app/202302/15e71c34e2b2e24aa79e9b2b4a5733f852.pdf"
+            }
+          ]
+        },
+        {
+            "deviceId": "**REDACTED**",
+            "sn": "HAC005S_1",
+            "brand": "Dreo",
+            "model": "DR-HAC005S",
+            "productId": "REDACTED",
+            "productName": "Air Conditioner",
+            "deviceName": "DEVTEST - Electric AC",
+            "shared": false,
+            "series": null,
+            "seriesName": "AC515S",
+            "type": 0,
+            "owner": true,
+            "familyId": null,
+            "familyName": null,
+            "roomId": null,
+            "roomName": null,
+            "roomNameI18Key": "",
+            "color": "w",
+            "controlsConf": {
+                "template": "DR-HAC005S",
+                "lottie": {
+                    "key": "mode",
+                    "frames": [
+                        {
+                            "value": 0,
+                            "frame": [
+                                0
+                            ]
+                        },
+                        {
+                            "value": 1,
+                            "frame": [
+                                3
+                            ]
+                        },
+                        {
+                            "value": 2,
+                            "frame": [
+                                4
+                            ]
+                        },
+                        {
+                            "value": 3,
+                            "frame": [
+                                2
+                            ]
+                        },
+                        {
+                            "value": 4,
+                            "frame": [
+                                3
+                            ]
+                        },
+                        {
+                            "value": 5,
+                            "frame": [
+                                3
+                            ]
+                        }
+                    ]
+                },
+                "schedule": {
+                    "modes": [
+                        {
+                            "controls": [
+                                {
+                                    "groupId": 0,
+                                    "type": 3,
+                                    "identity": "mode",
+                                    "items": [
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": true,
+                                            "cmd": [
+                                                "mode"
+                                            ],
+                                            "title": "schedule_ac_cool",
+                                            "value": 1,
+                                            "subItems": [
+                                                {
+                                                    "endValue": 86,
+                                                    "endColor": "#0051CF",
+                                                    "valueType": 1,
+                                                    "groupId": 0,
+                                                    "isSelected": false,
+                                                    "cmd": [
+                                                        "templevel"
+                                                    ],
+                                                    "startValue": 65,
+                                                    "type": 4,
+                                                    "title": "base_temp",
+                                                    "value": 76,
+                                                    "startColor": "#0051CF",
+                                                    "identity": "cooltemp"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": false,
+                                            "cmd": [
+                                                "mode"
+                                            ],
+                                            "title": "schedule_ac_sleep",
+                                            "value": 4,
+                                            "identity": "sleep"
+                                        },
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": false,
+                                            "cmd": [
+                                                "mode"
+                                            ],
+                                            "title": "schedule_ac_eco",
+                                            "value": 5,
+                                            "subItems": [
+                                                {
+                                                    "endValue": 86,
+                                                    "endColor": "#0051CF",
+                                                    "valueType": 1,
+                                                    "groupId": 0,
+                                                    "isSelected": false,
+                                                    "cmd": [
+                                                        "templevel"
+                                                    ],
+                                                    "startValue": 76,
+                                                    "type": 4,
+                                                    "title": "base_temp",
+                                                    "value": 76,
+                                                    "startColor": "#0051CF",
+                                                    "identity": "ecotemp"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "groupId": 0,
+                                    "type": 3,
+                                    "title": "device_control_speed",
+                                    "identity": "speed",
+                                    "value": 4,
+                                    "items": [
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": false,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_1",
+                                            "value": 1
+                                        },
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": false,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_2",
+                                            "value": 2
+                                        },
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": false,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_3",
+                                            "value": 3
+                                        },
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": true,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_auto",
+                                            "value": 4
+                                        }
+                                    ]
+                                }
+                            ],
+                            "valueType": 1,
+                            "icon": "ic_cool_mode_hac",
+                            "isSelected": true,
+                            "attention": [
+                                "mode",
+                                "windlevel",
+                                "poweron",
+                                "templevel",
+                                "oscmode"
+                            ],
+                            "cmd": "mode",
+                            "title": "base_cool",
+                            "value": 1
+                        },
+                        {
+                            "controls": [
+                                {
+                                    "endValue": 80,
+                                    "endColor": "#0051CF",
+                                    "valueType": 1,
+                                    "groupId": 0,
+                                    "isSelected": false,
+                                    "cmd": [
+                                        "rhlevel"
+                                    ],
+                                    "startValue": 30,
+                                    "type": 0,
+                                    "title": "home_humidity",
+                                    "value": 60,
+                                    "startColor": "#0051CF",
+                                    "unit": "%",
+                                    "identity": "temperature"
+                                },
+                                {
+                                    "groupId": 0,
+                                    "type": 3,
+                                    "title": "device_control_speed",
+                                    "identity": "speed",
+                                    "items": [
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": false,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_1",
+                                            "value": 1
+                                        },
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": false,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_2",
+                                            "value": 2
+                                        },
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": false,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_3",
+                                            "value": 3
+                                        },
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": true,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_auto",
+                                            "value": 4
+                                        }
+                                    ]
+                                }
+                            ],
+                            "valueType": 1,
+                            "icon": "ic_dry_mode",
+                            "isSelected": false,
+                            "attention": [
+                                "mode",
+                                "windlevel",
+                                "poweron",
+                                "rhlevel",
+                                "oscmode"
+                            ],
+                            "cmd": "mode",
+                            "title": "base_dry",
+                            "value": 2
+                        },
+                        {
+                            "controls": [
+                                {
+                                    "groupId": 0,
+                                    "type": 3,
+                                    "title": "device_control_speed",
+                                    "identity": "speed",
+                                    "items": [
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": false,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_1",
+                                            "value": 1
+                                        },
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": false,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_2",
+                                            "value": 2
+                                        },
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": false,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_3",
+                                            "value": 3
+                                        },
+                                        {
+                                            "valueType": 1,
+                                            "isSelected": true,
+                                            "cmd": [
+                                                "windlevel"
+                                            ],
+                                            "title": "base_auto",
+                                            "value": 4
+                                        }
+                                    ]
+                                }
+                            ],
+                            "valueType": 1,
+                            "icon": "ic_cool_mode",
+                            "isSelected": false,
+                            "attention": [
+                                "mode",
+                                "windlevel",
+                                "poweron",
+                                "oscmode"
+                            ],
+                            "cmd": "mode",
+                            "title": "base_fan",
+                            "value": 3
+                        }
+                    ]
+                },
+                "timer": {
+                    "minHour": 0,
+                    "maxHour": 23
+                },
+                "cards": [
+                    {
+                        "type": 2,
+                        "title": "device_control_temp",
+                        "icon": "",
+                        "image": "",
+                        "url": "dreo://nav/device/report?deviceSn=${sn}&type=temp",
+                        "show": true,
+                        "minVersion": "2.3.1"
+                    },
+                    {
+                        "type": 8,
+                        "title": "",
+                        "icon": "",
+                        "image": "",
+                        "url": "dreo://nav/device/schedule?deviceSn={sn}",
+                        "show": true,
+                        "key": ""
+                    },
+                    {
+                        "type": 3,
+                        "title": "home_humidifier_cleaning",
+                        "icon": "ic_hum_cleanning",
+                        "image": "",
+                        "url": "dreo://nav/device/cleanreminder?deviceSn=${sn}&start=50&end=300&step=10",
+                        "show": true,
+                        "key": "worktime"
+                    },
+                    {
+                        "type": 6,
+                        "title": "device_chart_usage",
+                        "icon": "ic_usage",
+                        "image": "",
+                        "url": "dreo://nav/device/hacstatistics?deviceSn=${sn}",
+                        "show": true,
+                        "key": "usage"
+                    },
+                    {
+                        "type": 6,
+                        "title": "base_maintenance",
+                        "icon": "https://resources.dreo-cloud.com/app/202312/4/c06d58240e114f019c92abf5d3bd6f8c.png",
+                        "image": "",
+                        "url": "https://fe.dreo.com/article/dreo-air-conditioner-installation-maintenance",
+                        "show": true
+                    },
+                    {
+                        "type": 6,
+                        "title": "device_settings_title",
+                        "icon": "ic_setting",
+                        "image": "",
+                        "url": "dreo://nav/device/setting?deviceSn=${sn}",
+                        "show": true,
+                        "key": "setting"
+                    }
+                ],
+                "urlConfig": [
+                    {
+                        "key": "clean",
+                        "url": "https://fe.dreo.com/en/guides/videos/v?source=https://resources.dreo-cloud.com/app/202404/9/1094c8bcd7fc4811bd5d944b6a70f658.mp4&coverImage=https://resources.dreo-cloud.com/app/202404/10/47672f46958c4605ba621683d5db57fb.png"
+                    }
+                ],
+                "feature": {
+                    "schedule": {
+                        "enable": true,
+                        "localSupport": true,
+                        "module": [
+                            {
+                                "type": "HeFi",
+                                "version": "0.0.4"
+                            }
+                        ]
+                    }
+                },
+                "preference": [
+                    {
+                        "image": "ic_display",
+                        "id": "240",
+                        "cmd": "lighton",
+                        "type": "Display",
+                        "title": "dev_ctrl_heater_display",
+                        "reverse": false
+                    },
+                    {
+                        "id": "210",
+                        "type": "Panel Sound",
+                        "title": "device_control_panelsound",
+                        "image": "ic_mute",
+                        "cmd": "muteon",
+                        "reverse": true
+                    },
+                    {
+                        "id": "220",
+                        "type": "Child Lock",
+                        "title": "device_control_childlock",
+                        "image": "ic_child_lock",
+                        "reverse": false,
+                        "cmd": "childlockon"
+                    },
+                    {
+                        "id": "230",
+                        "type": "Temperature Unit",
+                        "title": "device_control_temp_unit",
+                        "image": "ic_temp_unit"
+                    }
+                ],
+                "control": [
+                    {
+                        "id": "130",
+                        "type": "Speed",
+                        "title": "device_control_speed",
+                        "items": [
+                            {
+                                "text": "base_1",
+                                "cmd": "windlevel",
+                                "value": 1
+                            },
+                            {
+                                "text": "base_2",
+                                "cmd": "windlevel",
+                                "value": 2
+                            },
+                            {
+                                "text": "base_3",
+                                "cmd": "windlevel",
+                                "value": 3
+                            },
+                            {
+                                "text": "device_control_mode_auto",
+                                "cmd": "windlevel",
+                                "value": 4
+                            }
+                        ]
+                    },
+                    {
+                        "id": "120",
+                        "type": "Oscillation",
+                        "title": "base_swing",
+                        "items": [],
+                        "cmd": "oscmode"
+                    }
+                ],
+                "category": "Air Conditioner",
+                "version": {
+                    "minControlVer": "2.6.0",
+                    "minPairingVer": "2.6.0"
+                }
+            },
+            "mainConf": {
+                "isSmart": true,
+                "isWifi": true,
+                "isBluetooth": true,
+                "isVoiceControl": true
+            },
+            "resourcesConf": {
+                "imageSmallSrc": "https://resources.dreo-cloud.com/app/preSigned202407/556eb3b7aab924e838315b41aba7536fb.png",
+                "imageFullSrc": "https://resources.dreo-cloud.com/app/202402/20/a82251e0d1ab44d89b356a5dcea07f1a.zip",
+                "imageSmallDarkSrc": "",
+                "imageFullDarkSrc": ""
+            },
+            "servicesConf": [
+                {
+                    "key": "user_manual",
+                    "value": "https://resources.dreo-cloud.com/app/202403/16/b59dd99941cb4ca89390622f4e894428.pdf"
+                }
+            ],
+            "userManuals": [
+                {
+                    "url": "https://resources.dreo-cloud.com/app/202403/16/b59dd99941cb4ca89390622f4e894428.pdf",
+                    "icon": null,
+                    "desc": "User Manual",
+                    "lang": "en"
+                }
+            ]
+        }        
+      ]
+    }
+  }

--- a/tests/dreo/integrationtests/test_debug_test_mode.py
+++ b/tests/dreo/integrationtests/test_debug_test_mode.py
@@ -1,0 +1,36 @@
+"""Tests for Dreo Fans"""
+# pylint: disable=used-before-assignment
+import logging
+import pytest
+from custom_components.dreo.debug_test_mode import get_debug_test_mode_payload
+from custom_components.dreo.pydreo import PyDreo
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+class TestDebugTestMode:
+    """Test Debug Test Mode."""
+
+    def test_load(self):
+        """Test that the Debug Test Mode loads correctly."""
+        payload: dict = get_debug_test_mode_payload("custom_components/dreo")
+        assert payload is not None, "Payload should not be None"
+
+    def test_pydreo(self):  # pylint: disable=invalid-name
+        """Load fan and test sending commands."""
+        pydreo_manager = PyDreo('EMAIL', 
+                                'PASSWORD', 
+                                redact=True, 
+                                debug_test_mode=True, 
+                                debug_test_mode_payload=get_debug_test_mode_payload("custom_components/dreo")) # pylint: disable=E0601
+
+        pydreo_manager.login()
+        pydreo_manager.load_devices()
+        assert len(pydreo_manager.devices) == 2
+        fan = pydreo_manager.devices[0]
+        assert fan.speed_range == (1, 5)
+        assert fan.preset_modes == ['normal', 'natural', 'sleep', 'auto']
+        assert fan.oscillating is False
+
+        ac = pydreo_manager.devices[1]
+        assert ac.temperature == 88

--- a/tests/dreo/test_init.py
+++ b/tests/dreo/test_init.py
@@ -1,0 +1,9 @@
+"""Init tests for the Dreo integration."""
+
+from custom_components.dreo.const import DEBUG_TEST_MODE
+
+class TestInit:
+    
+    def test_debug_test_mode(self):
+        """Test that DEBUG_TEST_MODE is set to False."""
+        assert DEBUG_TEST_MODE is False, "DEBUG_TEST_MODE should be False to merge changes."

--- a/tests/pydreo/api_responses/get_devices_HAC006S.json
+++ b/tests/pydreo/api_responses/get_devices_HAC006S.json
@@ -10,7 +10,7 @@
       "list": [
         {
           "deviceId": "1834678463454253057",
-          "sn": "**REDACTED**",
+          "sn": "HAC006S_1",
           "brand": "Dreo",
           "model": "DR-HAC006S",
           "productId": "**REDACTED**",

--- a/tests/pydreo/call_json.py
+++ b/tests/pydreo/call_json.py
@@ -45,11 +45,13 @@ LOGIN_RET_BODY = (
     200,
 )
 
-def get_response_from_file(filename: str) -> json:
-    with open("tests/pydreo/api_responses/" + filename, 'r') as file:
+def get_response_from_file(filename: str) -> dict:
+    """Load a JSON response from a file."""
+    with open("tests/pydreo/api_responses/" + filename, 'r', encoding="utf-8") as file:
         return json.load(file)
 
 def login_call_body(email, password):
+    """Create the body for the login call."""
     json_object = {
         'acceptLanguage': 'en',
         'devToken': '',


### PR DESCRIPTION
This PR adds a new Debug Test Mode to the integration so that it can be tested end-to-end in HomeAssistant.
See https://github.com/JeffSteinbok/hass-dreo/blob/main/contributing.md for information on how to use.