### PR TITLE
Fix issue with updating airconditioner target temperature (#300) with fix for incorrect temperature being set when using celcius in HA.

### DIFF
--- a/custom_components/dreo/dreoairconditioner.py
+++ b/custom_components/dreo/dreoairconditioner.py
@@ -116,6 +116,14 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
             self._attr_fan_mode,
         )
 
+    async def async_added_to_hass(self) -> None:
+        """Configure temperature mapping after entity is added to HA."""
+        await super().async_added_to_hass()
+        
+        # Configure temperature mapping based on HA's unit configuration
+        ha_uses_celsius = self.hass.config.units.temperature_unit == UnitOfTemperature.CELSIUS
+        self.device.set_ha_temperature_unit_is_celsius(ha_uses_celsius)
+
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information for this air conditioner."""

--- a/custom_components/dreo/dreoairconditioner.py
+++ b/custom_components/dreo/dreoairconditioner.py
@@ -244,7 +244,7 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
 
     ### Implementation of climate methods
     @property
-    def current_temperature(self) -> float:
+    def current_temperature(self) -> int:
         return self.device.temperature
     
     @property
@@ -252,12 +252,12 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
         return self.device.device_definition.device_ranges[TEMP_RANGE][0]
 
     @property
-    def max_temp(self) -> float | None:
+    def max_temp(self) -> int | None:
         return self.device.device_definition.device_ranges[TEMP_RANGE][1]
     
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        self.device.target_temperature = kwargs.get(ATTR_TEMPERATURE)
+        self.device.target_temperature = int(kwargs.get(ATTR_TEMPERATURE))
         _LOGGER.debug("DreoAirConditionerHA::set_temperature(%s) %s --> %s", 
                       self.device.name, 
                       self._attr_target_temperature, 
@@ -266,11 +266,11 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
         self.schedule_update_ha_state()
 
     @property
-    def target_temperature(self) -> float | None:
+    def target_temperature(self) -> int | None:
         return self.device.target_temperature
     
     @property
-    def target_temperature_low(self) -> float | None:
+    def target_temperature_low(self) -> int | None:
         if self.device.preset_mode == PRESET_ECO:
             range_key = TARGET_TEMP_RANGE_ECO
         else:
@@ -278,7 +278,7 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
         return self.device.device_definition.device_ranges[range_key][0]
 
     @property
-    def target_temperature_high(self) -> float | None:
+    def target_temperature_high(self) -> int | None:
         if self.device.preset_mode == PRESET_ECO:
             range_key = TARGET_TEMP_RANGE_ECO
         else:
@@ -286,7 +286,7 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
         return self.device.device_definition.device_ranges[range_key][1]
 
     @property
-    def target_temperature_step(self) -> float | None:
+    def target_temperature_step(self) -> int | None:
         return 1
 
     @property

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -255,7 +255,7 @@ SUPPORTED_DEVICES = {
     "DR-HAC": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CONDITIONER,
         device_ranges={
-            TEMP_RANGE: (60, 95),
+            TEMP_RANGE: (60, 86),
             TARGET_TEMP_RANGE: (64, 86),
             TARGET_TEMP_RANGE_ECO: (75, 86),
             HUMIDITY_RANGE: (30, 80),


### PR DESCRIPTION
Due to heatwaves in UK I recently bit the bullet and got a Dreo DR-HAC005S, but noticed that I could not change the target temperature in Home assistant. 

This PR will fix the issue with setting target temperature in airconditioners, tested on Dreo DR-HAC005S.

**Issue:**
- Target temperature set in Home assistant is not updated in Dreo App or in Air conditioner device.
- Temperature range specified in ```models.py``` for ```DR-HAC005S``` is not accurate. 
- When temperature unit is set to Celcius in Home assistant, temperature is not correctly updated in Dreo App or device. 

**Changes:**
- ce4ce87 changes the target_temperature data type to INT, which fixes the issue with setting target temp in the API. (credit PR #269 by @andy-cooper)
- 6b8cbb3 Adjusts the target temperature range to what is actually supported on Dreo DR-HAC005S (60 - 86F or 16 - 30°C)
- 7d2c5a2 fixes inaccurate temperature being set when home assistant is using Celcius as temperature unit.
     - This checks ```UnitOfTemperature``` from Home assistant, and uses the ```CELSIUS_TO_FAHRENHEIT_MAP``` if Home assistant is set to uses Celcius. (explained below)

### Why the ```CELSIUS_TO_FAHRENHEIT_MAP``` is needed
After fixing the issue setting the target temperature, I noticed that the temperature set in home assistant is not properly in the AC/App. When I dialed it all the way down, temperature was not updated at all. When I set the dial to 17°C, the AC and APP reported it was set to 16°C. Device reported 18°C when dial set to 19°C, is unable to set device to 19°C,  device set to 20°C when plugin set to 20°C or 21°C and so on. 

Looking at the logs, it seemed that issue lies in the fact that API is using Fahrenheit even though the device and App is set to celcius. I confirmed this using Charles and checking what was sent to the API when I set a temperature:
```json
// PRESET_NONE: 25°C to 26°C
{
	"desired": {
		"templevel": 79
	},
	"devicesn": "REDACTED"
}
```
 Its not converting from Celcius to Fahrenheit, but using a 1:1 mapping of temparatures to stick with integers. Behaviour seems to be:
```
16°C (60.8)     (App sends 61)    Using HA, device is set to: None
17°C (62.6)     (App sends 63)    Using HA, device is set to: 16°C 
18°C (64.4F)    (App sends 65)   Using HA, device is set to:  17°C 
19°C (66.2)     (App sends 67)    Using HA, device is set to: 18°C 
20°C (68.0F)    (App sends 68)    Using HA, device is set to: 20°C 
21°C (69.8F)    (App sends 70)    Using HA, device is set to: 20°C 
22°C (71.6F)    (App sends 72)    Using HA, device is set to: 21°C 
23°C (73.4F)    (App sends 74)    Using HA, device is set to: 22°C 
24°C (75.2F)    (App sends 76)    Using HA, device is set to: 23°C 
25°C (77.0F)    (App sends 77)    Using HA, device is set to: 25°C 
26°C (78.8F)    (App sends 79)   Using HA, device is set to: 25°C 
27°C (80.6F)    (App sends 81)   Using HA, device is set to: 26°C 
28°C (82.4F)    (App sends 83)   Using HA, device is set to: 27°C 
29°C (84.2F)    (App sends 85)   Using HA, device is set to: 28°C 
30°C (86.0F)    (App sends 86)   Using HA, device is set to: 30°C 
```
Using this data, I added the Celcius to Fahrenheit map that is being used by DREO, which successfully sets the right temperature in the AC when Home assistant is set to Celcius.
```python
CELSIUS_TO_FAHRENHEIT_MAP = {
    16: 61,   # Set 16°C → Send 61°F
    17: 63,   # Set 17°C → Send 63°F  
    18: 65,   # Set 18°C → Send 65°F
    19: 67,   # Set 19°C → Send 67°F
    20: 68,   # Set 20°C → Send 68°F
    21: 70,   # Set 21°C → Send 70°F
    22: 72,   # Set 22°C → Send 72°F
    23: 74,   # Set 23°C → Send 74°F
    24: 76,   # Set 24°C → Send 76°F
    25: 77,   # Set 25°C → Send 77°F
    26: 79,   # Set 26°C → Send 79°F
    27: 81,   # Set 27°C → Send 81°F
    28: 83,   # Set 28°C → Send 83°F
    29: 85,   # Set 29°C → Send 85°F
    30: 86,   # Set 30°C → Send 86°F
}
```
This map was handy later in calculating the ```sleeptempoffset``` that is used instead of ```templevel``` when the device is set to SLEEP preset which uses the same map with a simple subtraction to calculate the offset. 
