### PR TITLE
fix: fahrenheit values incorrectly displayed as celcius in airconditioner card. 

### DIFF
--- a/custom_components/dreo/dreoairconditioner.py
+++ b/custom_components/dreo/dreoairconditioner.py
@@ -179,8 +179,6 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the state attributes of the air conditioner."""
         return {
-            "current_temperature": self.device.temperature,
-            "target_temperature": self.device.target_temperature,
             "model": self.device.model,
         }
 


### PR DESCRIPTION
This will fix temperature display in Climate/airconditioner card.

Issue:
- Raw, unconverted fahrenheit value is displayed as °C in Home assistant Air conditioner card. In Sensors section, this value is displayed correctly. 
![image](https://github.com/user-attachments/assets/3f74fb72-88c1-4685-a89b-d71a5bd5dc97)
![image](https://github.com/user-attachments/assets/082150eb-61da-4804-9983-690c49245c4f)

Changes: 
- Removed temperature values from ```extra_state_attributes``` - this seems to be interfering with Home assistants ability to detect the raw values as temperature values in fahrenheit.
![image](https://github.com/user-attachments/assets/b7a4ea7c-03b3-4f2e-b117-4339c6937646)
