### PR TITLE
Feat/add sleep preset clean

### DIFF
--- a/custom_components/dreo/dreoairconditioner.py
+++ b/custom_components/dreo/dreoairconditioner.py
@@ -19,6 +19,7 @@ from .pydreo import (
     TARGET_TEMP_RANGE,
     TARGET_TEMP_RANGE_ECO,
     HUMIDITY_RANGE,
+    PRESET_SLEEP,
 )
 
 from .pydreo.pydreoairconditioner import (
@@ -176,6 +177,9 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
         """Set the preset mode of the device."""
         _LOGGER.debug("DreoAirConditionerHA:set_preset_mode(%s) --> %s", self.device.name, preset_mode)
         if preset_mode == PRESET_ECO:
+            self.device.mode = DREO_AC_MODE_COOL
+            self.device.preset_mode = preset_mode
+        elif preset_mode == PRESET_SLEEP:
             self.device.mode = DREO_AC_MODE_COOL
             self.device.preset_mode = preset_mode
         else:

--- a/custom_components/dreo/pydreo/constant.py
+++ b/custom_components/dreo/pydreo/constant.py
@@ -24,6 +24,7 @@ OSCANGLE_KEY = "oscangle"
 CRUISECONF_KEY = "cruiseconf"
 TEMPERATURE_KEY = "temperature"
 TARGET_TEMPERATURE_KEY = "templevel"
+SLEEPTEMPOFFSET_KEY = "sleeptempoffset"
 VOICEON_KEY = "voiceon"
 LEDALWAYSON_KEY = "ledalwayson"
 LIGHTSENSORON_KEY = "lightsensoron"
@@ -217,6 +218,9 @@ PRESET_NONE = "none"
 
 # Device is running an energy-saving mode
 PRESET_ECO = "eco"
+
+# Device is running in sleep mode
+PRESET_SLEEP = "sleep"
 
 class HVACMode(StrEnum):
     """HVAC mode for climate devices."""

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -24,6 +24,7 @@ from .constant import (
     FAN_HIGH,
     PRESET_NONE,
     PRESET_ECO,
+    PRESET_SLEEP,
     HVACMode,
     DreoDeviceType
 )
@@ -268,7 +269,7 @@ SUPPORTED_DEVICES = {
             HVACMode.DRY
         ],
         swing_modes=[SWING_OFF, SWING_ON],
-        preset_modes=[PRESET_NONE, PRESET_ECO],
+        preset_modes=[PRESET_NONE, PRESET_ECO, PRESET_SLEEP],
         # TODO Add fan modes, windlevel: 1,2,3,4 (Auto)
         fan_modes=[FAN_LOW, FAN_MEDIUM, FAN_HIGH, FAN_AUTO],
     ),

--- a/custom_components/dreo/pydreo/pydreoairconditioner.py
+++ b/custom_components/dreo/pydreo/pydreoairconditioner.py
@@ -7,6 +7,7 @@ from .constant import (
     LOGGER_NAME,
     TEMPERATURE_KEY,
     TARGET_TEMPERATURE_KEY,
+    SLEEPTEMPOFFSET_KEY,
     MODE_KEY,
     OSCMODE_KEY,
     MUTEON_KEY,
@@ -30,7 +31,8 @@ from .constant import (
     FAN_MEDIUM,
     FAN_HIGH,
     PRESET_NONE,
-    PRESET_ECO
+    PRESET_ECO,
+    PRESET_SLEEP
 )
 from .pydreobasedevice import PyDreoBaseDevice
 from .models import DreoDeviceDetails
@@ -38,12 +40,14 @@ from .models import DreoDeviceDetails
 DREO_AC_MODE_COOL = 1
 DREO_AC_MODE_DRY = 2
 DREO_AC_MODE_FAN = 3
+DREO_AC_MODE_SLEEP = 4
 DREO_AC_MODE_ECO = 5
 
 DREO_AC_MODES = [
     DREO_AC_MODE_COOL,
     DREO_AC_MODE_FAN,
     DREO_AC_MODE_DRY,
+    DREO_AC_MODE_SLEEP,
     DREO_AC_MODE_ECO,
 ]
 
@@ -119,6 +123,7 @@ class PyDreoAC(PyDreoBaseDevice):
         self._fan_mode = None
         self.work_time = None
         self.temp_target_reached = None
+        self._sleep_preset_initialization_temp = None
         
     @property
     def poweron(self):
@@ -204,19 +209,10 @@ class PyDreoAC(PyDreoBaseDevice):
 
     @target_temperature.setter
     def target_temperature(self, value: int) -> None:
-        """Set the target temperature with empirical mapping for Celsius conversions."""
-        if self.temperature_units == TemperatureUnit.CELSIUS:
-            celsius_equivalent = round((value - 32) * 5/9)
-            mapped_fahrenheit = CELSIUS_TO_FAHRENHEIT_MAP.get(celsius_equivalent, value)
-            _LOGGER.debug("PyDreoAC:target_temperature.setter(%s) Celsius mode: %s°F (%s°C) --> %s°F", 
-                          self, value, celsius_equivalent, mapped_fahrenheit)
-            self._target_temperature = mapped_fahrenheit
-            self._send_command(TARGET_TEMPERATURE_KEY, mapped_fahrenheit)
-        else:
-            # HA uses Fahrenheit - pass through directly
-            _LOGGER.debug("PyDreoAC:target_temperature.setter(%s) Fahrenheit mode: %s°F", self, value)
-            self._target_temperature = value
-            self._send_command(TARGET_TEMPERATURE_KEY, value)
+        """Set the target temperature"""
+        _LOGGER.debug("PyDreoAC:target_temperature.setter(%s) %s --> %s", self, self._target_temperature, value)
+        self._target_temperature = value
+        self._send_command(TARGET_TEMPERATURE_KEY, value)
 
     @property
     def humidity(self):
@@ -317,6 +313,12 @@ class PyDreoAC(PyDreoBaseDevice):
         
         if mode == PRESET_ECO:
             self._send_command(MODE_KEY, DREO_AC_MODE_ECO)
+        elif mode == PRESET_SLEEP:
+            # Store the current target temperature as the sleep initialization temperature
+            self._sleep_preset_initialization_temp = self._target_temperature
+            _LOGGER.debug("PyDreoAC:preset_mode.setter(%s) Sleep mode - storing init temp: %s", 
+                          self.name, self._sleep_preset_initialization_temp)
+            self._send_command(MODE_KEY, DREO_AC_MODE_SLEEP)
         else:
             self._send_command(MODE_KEY, DREO_AC_MODE_COOL)
         
@@ -334,6 +336,9 @@ class PyDreoAC(PyDreoBaseDevice):
         if mode == DREO_AC_MODE_ECO:
             mode = DREO_AC_MODE_COOL
             self._preset_mode = PRESET_ECO
+        elif mode == DREO_AC_MODE_SLEEP:
+            mode = DREO_AC_MODE_COOL
+            self._preset_mode = PRESET_SLEEP
         else:
             self._preset_mode = PRESET_NONE
         self._mode = mode
@@ -388,6 +393,9 @@ class PyDreoAC(PyDreoBaseDevice):
             if target_mode == 5:
                 target_mode = DREO_AC_MODE_COOL
                 self._preset_mode = PRESET_ECO
+            elif target_mode == 4:
+                target_mode = DREO_AC_MODE_COOL
+                self._preset_mode = PRESET_SLEEP
             else:
                 self._preset_mode = PRESET_NONE
             _LOGGER.debug("PyDreoAC(%s):handle_server_update - mode: %s --> %s", 

--- a/tests/pydreo/api_responses/get_device_state_HAC006S_1.json
+++ b/tests/pydreo/api_responses/get_device_state_HAC006S_1.json
@@ -1,0 +1,58 @@
+{
+    "code": 0,
+    "msg": "OK",
+    "data": {
+        "mixed": {
+            "wifi_rssi": {"state": -45, "timestamp": 1745612915},
+            "poweron": {"state": false, "timestamp": 1745612915},
+            "mode": {"state": 1, "timestamp": 1745612915},
+            "windlevel": {"state": 4, "timestamp": 1745612915},
+            "temperature": {"state": 74, "timestamp": 1745612915},
+            "templevel": {"state": 76, "timestamp": 1745612915},
+            "muteon": {"state": true, "timestamp": 1745612915},
+            "mcuon": {"state": true, "timestamp": 1745612915},
+            "network_latency": {"state": 62, "timestamp": 1745612915},
+            "module_hardware_model": {"state": "HeFi", "timestamp": 1745612915},
+            "mcu_firmware_version": {"state": "1.0.0", "timestamp": 1745612915},
+            "module_hardware_mac": {"state": "REDACTED", "timestamp": 1745612915},
+            "wifi_ssid": {"state": "REDACTED", "timestamp": 1745612915},
+            "module_firmware_version": {"state": "3.6.3", "timestamp": 1745612915},
+            "connected": {"state": true, "timestamp": 1745612915},
+            "wrong": {"state": 0, "timestamp": 1745612915},
+            "childlockon": {"state": false, "timestamp": 1745612915},
+            "tempoffset": {"state": 0, "timestamp": 1745612915},
+            "scheid": {"state": 0, "timestamp": 1745612915},
+            "timeron": {
+                "state": {
+                    "du": 0,
+                    "ts": 0
+                },
+                "timestamp": null
+            },
+            "timeroff": {
+                "state": {
+                    "du": 0,
+                    "ts": 0
+                },
+                "timestamp": null
+            },
+            "tempunit": {"state": 2, "timestamp": 1745612915},
+            "sleeptempoffset": {"state": 0, "timestamp": 1745612915},
+            "oscmode": {"state": 0, "timestamp": 1745612915},
+            "devon": {"state": true, "timestamp": 1745612915},
+            "cooldown": {"state": 0, "timestamp": 1745612915},
+            "ptcon": {"state": false, "timestamp": 1745612915},
+            "lighton": {"state": true, "timestamp": 1745612915},
+            "ctlstatus": {"state": "normal", "timestamp": 1745612915},
+            "fixedconf": {"state": "0,0", "timestamp": 1745612915},
+            "rh": {"state": 45, "timestamp": 1745612915},
+            "rhlevel": {"state": 50, "timestamp": 1745612915},
+            "worktime": {"state": 3600, "timestamp": 1745612915},
+            "reachtarget": {"state": 0, "timestamp": 1745612915}
+        },
+        "sn": "HAC006S_1",
+        "productId": "**REDACTED**",
+        "region": "us-east-2",
+        "deviceInfo": null
+    }
+} 

--- a/tests/pydreo/test_pydreoairconditioner.py
+++ b/tests/pydreo/test_pydreoairconditioner.py
@@ -23,7 +23,7 @@ class TestPyDreoAirConditioner(TestBase):
 
         ac : PyDreoAC = self.pydreo_manager.devices[0]
 
-        assert ac.preset_modes == ['none', 'eco']
+        assert ac.preset_modes == ['none', 'eco', 'sleep']
 
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             ac.poweron = True
@@ -36,6 +36,12 @@ class TestPyDreoAirConditioner(TestBase):
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             ac.preset_mode = 'eco'
             mock_send_command.assert_called_once_with(ac, {WIND_MODE_KEY: 5})
+
+        # Test sleep preset mode
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            ac.preset_mode = 'sleep'
+            mock_send_command.assert_called_once_with(ac, {WIND_MODE_KEY: 4})
+            assert ac.preset_mode == 'sleep'  # Verify mode was set
 
         # TODO: Fix this in the AC class
         # with pytest.raises(ValueError):


### PR DESCRIPTION
Apologies about duplicate PR - this PR adds the same features as #306, but has proper tests for Sleep preset. 

Sleep preset in Dreo air conditioners, tested on DR-HAC005S

**Feature:**
- Support for Sleep preset.

**Changes:**
- Implements Sleep preset
- Adds support for ```sleeptempoffset``` that is used to change target temperature when device is set to sleep mode (instead of the usual ```templevel```)
- Added tests for Sleep preset
- Added API Responses for HAC006S for use in tests. 
- <del>Prequisite: #305 with support for Celcius to Fahrenheit Map used by Dreo.

**Limitations:**
- Sleep profile cannot be customized in Home assistant. 
- When a custom profile is selected / set in Dreo app, toggling Sleep preset in Home assistant toggles this custom preset. 

Observations regarding ```sleeptempoffset```
- When device is set to Sleep preset, Dreo App sends ```sleeptempoffset``` instead of ```templevel```:
```json
// PRESET_SLEEP: 
// 26*C to 25*C
{
	"desired": {
		"sleeptempoffset": -2
	},
	"devicesn": "REDACTED"
}
```
- Seems to be a "offset" value that is calculated using a simple calculation: ```sleeptempoffset = new desired temperature - target temperature that was set when sleep preset was enabled```
- This is again handled in Fahrenheit, which is sent using integers according to the Map documented in #305
- This results in uneven/non-linear relationship between different temperatures:
```
Initial temp: 19°C             Initial temp: 20°C
Temp   Offset                    Temp         Offset    
16:        -6                    16:          -7
17:        -4                    17:          -5
18:        -2                    18:          -3
19:         0                    19:          -1
20:         1                    20:           0
21:         3                    21:           2
22:         5                    22:           4
23:         7                    23:           6
24:         9                    24:           8
25:        10                    25:           9
26:        12                    26:          11
27:        14                    27:          13
28:        16                    28:          15
29:        18                    29:          17
30:        19                    30:          18
```
