### PR TITLE
Add support for DR-HDH001S dehumidifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
-Unofficial HomeAssistant integration for Dreo brand smart devices. Currently supports most models of Fans, Air Conditioners, Humidifiers and Space Heaters as well as ChefMaker. I do not work for Dreo; just something I'm doing for fun.
+Unofficial HomeAssistant integration for Dreo brand smart devices. Currently supports most models of Fans, Air Conditioners, Humidifiers, Dehumidifiers and Space Heaters as well as ChefMaker. I do not work for Dreo; just something I'm doing for fun.
 
 You can purchase these devices from Amazon: [Dreo Fans on Amazon](https://www.amazon.com/gp/search?ie=UTF8&tag=jeffsteinbok-20&linkCode=ur2&linkId=264bf9285db76a172f81bad93760d162&camp=1789&creative=9325&index=hpc&keywords=Dreo%20Smart%20Fan)
 
@@ -75,6 +75,11 @@ Models that have been specifically tested can be found below.
 
 - DR-HHM*
 - DR-HHM004S
+
+### Dehumidifiers
+*Initial beta-level support*
+
+- DR-HDH001S
 
 ### Space Heaters
 

--- a/custom_components/dreo/__init__.py
+++ b/custom_components/dreo/__init__.py
@@ -96,6 +96,13 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         platforms.add(Platform.SWITCH)
         platforms.add(Platform.NUMBER)
 
+    if (DreoDeviceType.DEHUMIDIFIER in device_types):
+        platforms.add(Platform.HUMIDIFIER)
+        platforms.add(Platform.FAN)
+        platforms.add(Platform.SENSOR)
+        platforms.add(Platform.SWITCH)
+        platforms.add(Platform.NUMBER)
+
     if (DreoDeviceType.CHEF_MAKER in device_types):
         platforms.add(Platform.SENSOR)
         platforms.add(Platform.SWITCH)

--- a/custom_components/dreo/dreofan.py
+++ b/custom_components/dreo/dreofan.py
@@ -27,10 +27,20 @@ class DreoFanHA(DreoBaseDeviceHA, FanEntity):
         self.device = pyDreoFan
         if self.device.type is DreoDeviceType.CEILING_FAN:
             self._attr_icon = "mdi:ceiling-fan"
+        elif self.device.type is DreoDeviceType.DEHUMIDIFIER:
+            self._attr_name = f"{super().name} Fan Speed"
 
     @property
     def percentage(self) -> int | None:
         """Return the current speed."""
+        if self.device.type is DreoDeviceType.DEHUMIDIFIER:
+            if self.device.preset_mode == "Low":
+                return 33
+            elif self.device.preset_mode == "Medium": 
+                return 67
+            elif self.device.preset_mode == "High":
+                return 100
+            return None
         return ranged_value_to_percentage(
             self.device.speed_range, self.device.fan_speed
         )
@@ -43,6 +53,8 @@ class DreoFanHA(DreoBaseDeviceHA, FanEntity):
     @property
     def oscillating(self) -> bool:
         """This represents horizontal oscillation only"""
+        if self.device.type is DreoDeviceType.DEHUMIDIFIER:
+            return False
         return self.device.oscillating
 
     @property
@@ -74,7 +86,7 @@ class DreoFanHA(DreoBaseDeviceHA, FanEntity):
         supported_features = FanEntityFeature.SET_SPEED | FanEntityFeature.TURN_ON | FanEntityFeature.TURN_OFF
         if (self.device.preset_modes is not None):
             supported_features = supported_features | FanEntityFeature.PRESET_MODE
-        if (self.device.oscillating is not None):
+        if (self.device.oscillating is not None and self.device.type is not DreoDeviceType.DEHUMIDIFIER):
             supported_features = supported_features | FanEntityFeature.OSCILLATE
 
         return supported_features
@@ -103,7 +115,15 @@ class DreoFanHA(DreoBaseDeviceHA, FanEntity):
         if not self.device.is_on:
             self.device.is_on = True
 
-        self.device.fan_speed = math.ceil(percentage_to_ranged_value(self.device.speed_range, percentage))
+        if self.device.type is DreoDeviceType.DEHUMIDIFIER:
+            if percentage <= 33:
+                self.device.set_preset_mode("Low")
+            elif percentage <= 67:
+                self.device.set_preset_mode("Medium")
+            else:
+                self.device.set_preset_mode("High")
+        else:
+            self.device.fan_speed = math.ceil(percentage_to_ranged_value(self.device.speed_range, percentage))
         
         self.schedule_update_ha_state()
 
@@ -118,7 +138,10 @@ class DreoFanHA(DreoBaseDeviceHA, FanEntity):
         if not self.device.is_on:
             self.device.is_on = True
 
-        self.device.preset_mode = preset_mode
+        if self.device.type is DreoDeviceType.DEHUMIDIFIER:
+            self.device.set_preset_mode(preset_mode)
+        else:
+            self.device.preset_mode = preset_mode
 
         self.schedule_update_ha_state()
 

--- a/custom_components/dreo/fan.py
+++ b/custom_components/dreo/fan.py
@@ -25,6 +25,7 @@ def get_entries(pydreo_devices : list[PyDreoBaseDevice]) -> list[DreoFanHA]:
             pydreo_device.type == DreoDeviceType.AIR_PURIFIER or
             pydreo_device.type == DreoDeviceType.CEILING_FAN or
             pydreo_device.type == DreoDeviceType.HUMIDIFIER or
+            pydreo_device.type == DreoDeviceType.DEHUMIDIFIER or
             pydreo_device.type == DreoDeviceType.EVAPORATIVE_COOLER):
             _LOGGER.debug("Fan:get_entries: Found a %s - %s", pydreo_device.type, pydreo_device.name)
             fan_entities_ha.append(DreoFanHA(pydreo_device))

--- a/custom_components/dreo/humidifier.py
+++ b/custom_components/dreo/humidifier.py
@@ -4,11 +4,12 @@ import logging
 
 from homeassistant.components.humidifier import (
     HumidifierEntity,
-    HumidifierEntityFeature
+    HumidifierEntityFeature,
+    HumidifierDeviceClass
 )
 
 from .haimports import * # pylint: disable=W0401,W0614
-from .pydreo import PyDreo, PyDreoBaseDevice, PyDreoHumidifier
+from .pydreo import PyDreo, PyDreoBaseDevice, PyDreoHumidifier, PyDreoDehumidifier
 from .pydreo.constant import DreoDeviceType
 from .dreobasedevice import DreoBaseDeviceHA
 
@@ -20,14 +21,17 @@ from .const import (
 
 _LOGGER = logging.getLogger(LOGGER)
 
-def get_entries(pydreo_devices : list[PyDreoBaseDevice]) -> list[DreoHumidifierHA]:
+def get_entries(pydreo_devices : list[PyDreoBaseDevice]) -> list:
     """Get the Dreo Humidifier entities for the devices."""
-    humidifier_entities_ha : DreoHumidifierHA = []
+    humidifier_entities_ha = []
 
     for pydreo_device in pydreo_devices:
         if (pydreo_device.type == DreoDeviceType.HUMIDIFIER):
             _LOGGER.debug("Humidifier:get_entries: Found a %s - %s", pydreo_device.type, pydreo_device.name)
             humidifier_entities_ha.append(DreoHumidifierHA(pydreo_device))
+        elif (pydreo_device.type == DreoDeviceType.DEHUMIDIFIER):
+            _LOGGER.debug("Humidifier:get_entries: Found a %s - %s", pydreo_device.type, pydreo_device.name)
+            humidifier_entities_ha.append(DreoDehumidifierHA(pydreo_device))
 
     return humidifier_entities_ha
 
@@ -143,3 +147,144 @@ class DreoHumidifierHA(DreoBaseDeviceHA, HumidifierEntity):
             "DreoHumidiferHA:set_humidity(%s) --> %s", self.device.name, humidity
         )
         self.device.target_humidity = humidity
+
+
+# Implementation of the Dehumidifier
+class DreoDehumidifierHA(DreoBaseDeviceHA, HumidifierEntity):
+    """Representation of a Dreo Dehumidifier entity."""
+
+    def __init__(self, pyDreoDevice: PyDreoDehumidifier) -> None:
+        super().__init__(pyDreoDevice)
+        self.device = pyDreoDevice
+        _LOGGER.info(
+            "DreoDehumidifierHA:__init__(%s)",
+            pyDreoDevice.name
+        )
+
+        _LOGGER.info(
+            "new DreoDehumidifierHA instance(%s), mode %s, available_modes [%s]",
+            self.name,
+            self.mode,
+            self.available_modes,
+        )
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for this dehumidifier."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.device.serial_number)},
+            manufacturer=self.device.brand,
+            model=f"{self.device.series_name} ({self.device.model}) {self.device.product_name}",
+            name=self.device.device_name,
+        )
+
+    @property
+    def device_class(self) -> HumidifierDeviceClass:
+        """Return the device class for this dehumidifier."""
+        return HumidifierDeviceClass.DEHUMIDIFIER
+
+    @property
+    def supported_features(self) -> int:
+        """Return the list of supported features."""
+        supported_features = 0
+        if self.device.modes is not None:
+            supported_features |= HumidifierEntityFeature.MODES
+        
+        if self.device.mode == "Auto":
+            try:
+                supported_features |= HumidifierEntityFeature.TARGET_HUMIDITY
+            except AttributeError:
+                pass
+
+        return supported_features
+    
+    @property
+    def is_on(self) -> bool:
+        """Return True if device is on."""
+        return self.device.is_on
+
+    @property
+    def mode(self) -> str | None:
+        """Get the current mode."""
+        return self.device.mode
+
+    @property
+    def available_modes(self) -> list[str]:
+        """Return the list of supported modes."""
+        return self.device.modes
+
+    @property
+    def current_humidity(self) -> float:
+        """Return the current humidity."""
+        return self.device.humidity
+    
+    @property
+    def target_humidity(self) -> float:
+        """Return the humidity level we try to reach."""
+        return self.device.target_humidity
+
+    @property
+    def min_humidity(self) -> int:
+        """Return the minimum humidity."""
+        return 30
+
+    @property
+    def max_humidity(self) -> int:
+        """Return the maximum humidity."""
+        return 85
+    
+    def turn_on(self, **kwargs: any) -> None:
+        """Turn the device on."""
+        _LOGGER.debug("DreoDehumidifierHA:turn_on(%s)", self.device.name)
+        self.device.is_on = True
+
+    def turn_off(self, **kwargs: any) -> None:
+        """Turn the device off."""
+        _LOGGER.debug("DreoDehumidifierHA:turn_off(%s)", self.device.name)
+        self.device.is_on = False
+
+    def set_mode(self, mode: str) -> None:
+        """Set the mode of the device."""
+        _LOGGER.debug(
+            "DreoDehumidifierHA:set_mode(%s) --> %s", self.device.name, mode
+        )
+        
+        if not self.device.is_on:
+            self.device.is_on = True
+
+        if mode not in self.available_modes:
+            raise ValueError(
+                f"{mode} is not one of the valid preset modes: {self.available_modes}"
+            )
+
+        self.device.mode = mode
+
+    def set_humidity(self, humidity: float) -> None:
+        """Set the target humidity level."""
+        _LOGGER.debug(
+            "DreoDehumidifierHA:set_humidity(%s) --> %s", self.device.name, humidity
+        )
+        self.device.target_humidity = int(humidity)
+
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return additional state attributes."""
+        attributes = {}
+        
+        if hasattr(self.device, 'display_light'):
+            attributes["display_light"] = self.device.display_light
+        
+        if hasattr(self.device, 'childlockon'):
+            attributes["childlockon"] = self.device.childlockon
+            
+        if hasattr(self.device, 'auto_mode'):
+            attributes["auto_mode"] = self.device.auto_mode
+            
+        if hasattr(self.device, 'panel_sound'):
+            attributes["panel_sound"] = self.device.panel_sound
+            
+        if hasattr(self.device, 'temperature'):
+            attributes["temperature"] = f"{getattr(self.device, 'temperature', 'N/A')}°F"
+            
+        return attributes

--- a/custom_components/dreo/pydreo/__init__.py
+++ b/custom_components/dreo/pydreo/__init__.py
@@ -25,6 +25,7 @@ from .pydreoheater import PyDreoHeater
 from .pydreoairconditioner import PyDreoAC
 from .pydreochefmaker import PyDreoChefMaker
 from .pydreohumidifier import PyDreoHumidifier
+from .pydreodehumidifier import PyDreoDehumidifier
 from .pydreoevaporativecooler import PyDreoEvaporativeCooler
 
 _LOGGER = logging.getLogger(LOGGER_NAME)
@@ -38,6 +39,7 @@ _DREO_DEVICE_TYPE_TO_CLASS = {
     DreoDeviceType.AIR_CONDITIONER: PyDreoAC,
     DreoDeviceType.CHEF_MAKER: PyDreoChefMaker,
     DreoDeviceType.HUMIDIFIER: PyDreoHumidifier,
+    DreoDeviceType.DEHUMIDIFIER: PyDreoDehumidifier,
     DreoDeviceType.EVAPORATIVE_COOLER: PyDreoEvaporativeCooler
 }
 

--- a/custom_components/dreo/pydreo/constant.py
+++ b/custom_components/dreo/pydreo/constant.py
@@ -273,5 +273,6 @@ class DreoDeviceType(StrEnum):
     AIR_CONDITIONER = "Air Conditioner"
     CHEF_MAKER = "Chef Maker"
     HUMIDIFIER = "Humidifier"
+    DEHUMIDIFIER = "Dehumidifier"
     EVAPORATIVE_COOLER = "Evaporative Cooler"
     UNKNOWN = "Unknown"

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -112,6 +112,7 @@ SUPPORTED_MODEL_PREFIXES = {
     "WH",
     "DR-HAC",
     "DR-HHM",
+    "DR-HDH",
     "DR-HEC"
 }
 
@@ -280,6 +281,15 @@ SUPPORTED_DEVICES = {
     ),
 
     "DR-HHM": DreoDeviceDetails(device_type=DreoDeviceType.HUMIDIFIER),
+
+    # Dehumidifiers
+    "DR-HDH001S": DreoDeviceDetails(
+        device_type=DreoDeviceType.DEHUMIDIFIER,
+        device_ranges={
+            HUMIDITY_RANGE: (30, 85),
+            SPEED_RANGE: (1, 3)
+        }
+    ),
 
     # Evaporative Coolers
     "DR-HEC": DreoDeviceDetails(

--- a/custom_components/dreo/pydreo/pydreodehumidifier.py
+++ b/custom_components/dreo/pydreo/pydreodehumidifier.py
@@ -1,0 +1,281 @@
+"""Dreo API for controlling Dehumidifiers."""
+
+import logging
+from typing import TYPE_CHECKING, Dict
+
+from .constant import (
+    LOGGER_NAME,
+    MODE_KEY,
+    MUTEON_KEY,
+    POWERON_KEY,
+    HUMIDITY_KEY,
+    WINDLEVEL_KEY,
+    CHILDLOCKON_KEY,
+    LIGHTON_KEY,
+    SPEED_RANGE,
+    TEMPERATURE_KEY
+)
+
+from .pydreobasedevice import PyDreoBaseDevice
+from .models import DreoDeviceDetails
+
+_LOGGER = logging.getLogger(LOGGER_NAME)
+
+if TYPE_CHECKING:
+    from pydreo import PyDreo
+
+# Dehumidifier-specific constants
+RHAUTOLEVEL_KEY = "rhautolevel"
+AUTOON_KEY = "autoon"
+
+class PyDreoDehumidifier(PyDreoBaseDevice):
+    """Base class for Dreo Dehumidifiers"""
+
+    def __init__(self, device_definition: DreoDeviceDetails, details: Dict[str, list], dreo: "PyDreo"):
+        """Initialize dehumidifier devices."""
+        super().__init__(device_definition, details, dreo)
+
+        self._modes = [("Auto", 1), ("Continuous", 2)]
+        
+        self._mode = None
+        self._mute_on = None
+        self._humidity = None
+        self._target_humidity = None
+        self._wind_level = None
+        self._child_lock_on = None
+        self._light_on = None
+        self._auto_on = None
+        self._temperature = None
+        
+        self._speed_range = device_definition.device_ranges.get(SPEED_RANGE, (1, 3)) if device_definition.device_ranges else (1, 3)
+        
+    @property
+    def is_on(self):
+        """Returns `True` if the device is on, `False` otherwise."""
+        return self._is_on
+
+    @is_on.setter
+    def is_on(self, value: bool):
+        """Set if the dehumidifier is on or off"""
+        _LOGGER.debug("PyDreoDehumidifier:is_on.setter - %s", value)
+        self._send_command(POWERON_KEY, value)
+
+    @property
+    def modes(self) -> list[str]:
+        """Get the list of operating modes"""
+        return [mode[0] for mode in self._modes]
+
+    @property
+    def humidity(self):
+        """Get the current humidity"""
+        return self._humidity
+
+    @property
+    def target_humidity(self):
+        """Get the target humidity"""
+        return self._target_humidity
+
+    @target_humidity.setter
+    def target_humidity(self, value: int) -> None:
+        """Set the target humidity"""
+        _LOGGER.debug("PyDreoDehumidifier:target_humidity.setter(%s) %s --> %s", self, self._target_humidity, value)
+        if value < 30 or value > 85:
+            raise ValueError(f"Target humidity {value} is out of range (30-85)")
+        self._target_humidity = value
+        self._send_command(RHAUTOLEVEL_KEY, value)
+
+    @property
+    def wind_level(self):
+        """Get the fan speed level"""
+        return self._wind_level
+
+    @wind_level.setter 
+    def wind_level(self, value: int) -> None:
+        """Set the fan speed level (1-3)"""
+        _LOGGER.debug("PyDreoDehumidifier:wind_level.setter(%s) %s --> %s", self, self._wind_level, value)
+        if value < 1 or value > 3:
+            raise ValueError(f"Wind level {value} is out of range (1-3)")
+        self._wind_level = value
+        self._send_command(WINDLEVEL_KEY, value)
+
+    @property
+    def panel_sound(self) -> bool:
+        """Is the panel sound on"""
+        if self._mute_on is not None:
+            return not self._mute_on
+        return None
+
+    @panel_sound.setter
+    def panel_sound(self, value: bool) -> None:
+        """Set if the panel sound is on"""
+        _LOGGER.debug("PyDreoDehumidifier:panel_sound.setter(%s) --> %s", self.name, value)
+        self._send_command(MUTEON_KEY, not value)
+
+    @property
+    def display_light(self) -> bool:
+        """Is the display light on"""
+        return self._light_on
+
+    @display_light.setter
+    def display_light(self, value: bool) -> None:
+        """Set if the display light is on"""
+        _LOGGER.debug("PyDreoDehumidifier:display_light.setter(%s) --> %s", self.name, value)
+        self._send_command(LIGHTON_KEY, value)
+
+    @property
+    def childlockon(self) -> bool:
+        """Is the child lock on"""
+        return self._child_lock_on
+
+    @childlockon.setter
+    def childlockon(self, value: bool) -> None:
+        """Set if the child lock is on"""
+        _LOGGER.debug("PyDreoDehumidifier:childlockon.setter(%s) --> %s", self.name, value)
+        self._send_command(CHILDLOCKON_KEY, value)
+
+    @property
+    def auto_mode(self) -> bool:
+        """Is auto mode on"""
+        return self._auto_on
+
+    @auto_mode.setter
+    def auto_mode(self, value: bool) -> None:
+        """Set if auto mode is on"""
+        _LOGGER.debug("PyDreoDehumidifier:auto_mode.setter(%s) --> %s", self.name, value)
+        self._send_command(AUTOON_KEY, value)
+
+    @property
+    def speed_range(self):
+        """Get the fan speed range"""
+        return self._speed_range
+
+    @property
+    def fan_speed(self):
+        """Get the current fan speed (alias for wind_level)"""
+        return self._wind_level
+
+    @fan_speed.setter
+    def fan_speed(self, value: int) -> None:
+        """Set the fan speed (alias for wind_level)"""
+        self.wind_level = value
+
+    @property
+    def preset_modes(self):
+        """Get the list of fan speed preset modes"""
+        return ["Low", "Medium", "High"]
+
+    @property
+    def preset_mode(self):
+        """Get the current fan speed preset mode"""
+        if self._wind_level == 1:
+            return "Low"
+        elif self._wind_level == 2:
+            return "Medium"
+        elif self._wind_level == 3:
+            return "High"
+        return None
+
+    def set_preset_mode(self, preset_mode: str) -> None:
+        """Set the fan speed preset mode"""
+        _LOGGER.debug("PyDreoDehumidifier:set_preset_mode(%s) --> %s", self.name, preset_mode)
+        if preset_mode == "Low":
+            self.wind_level = 1
+        elif preset_mode == "Medium":
+            self.wind_level = 2
+        elif preset_mode == "High":
+            self.wind_level = 3
+        else:
+            raise ValueError(f"Invalid fan preset mode: {preset_mode}")
+
+    @property
+    def oscillating(self):
+        """Get oscillating state (dehumidifier doesn't oscillate)"""
+        return False
+
+    @property 
+    def temperature(self):
+        """Get the current temperature"""
+        return self._temperature
+        
+    @property
+    def mode(self):
+        """Return the current operating mode."""
+        for mode_name, mode_value in self._modes:
+            if self._mode == mode_value:
+                return mode_name
+        return None
+
+    @mode.setter
+    def mode(self, value: str) -> None:
+        """Set the operating mode"""
+        mode_value = None
+        for mode_name, mode_val in self._modes:
+            if mode_name == value:
+                mode_value = mode_val
+                break
+                
+        if mode_value is not None:
+            _LOGGER.debug("PyDreoDehumidifier:mode.setter(%s) %s --> %s", self, self._mode, mode_value)
+            self._send_command(MODE_KEY, mode_value)
+        else:
+            raise ValueError(f"Operating mode {value} is not in the acceptable list: {self.modes}")
+
+    def update_state(self, state: dict):
+        """Process the state dictionary from the REST API."""
+        super().update_state(state)
+
+        _LOGGER.debug("PyDreoDehumidifier(%s):update_state: %s", self.name, state)
+        self._mode = self.get_state_update_value(state, MODE_KEY)
+        self._mute_on = self.get_state_update_value(state, MUTEON_KEY)
+        self._humidity = self.get_state_update_value(state, HUMIDITY_KEY)
+        self._target_humidity = self.get_state_update_value(state, RHAUTOLEVEL_KEY)
+        self._wind_level = self.get_state_update_value(state, WINDLEVEL_KEY)
+        self._child_lock_on = self.get_state_update_value(state, CHILDLOCKON_KEY)
+        self._light_on = self.get_state_update_value(state, LIGHTON_KEY)
+        self._auto_on = self.get_state_update_value(state, AUTOON_KEY)
+        self._temperature = self.get_state_update_value(state, TEMPERATURE_KEY)
+        
+    def handle_server_update(self, message):
+        """Process a websocket update"""
+        _LOGGER.debug("PyDreoDehumidifier:handle_server_update(%s): %s", self.name, message)
+
+        val_poweron = self.get_server_update_key_value(message, POWERON_KEY)
+        if isinstance(val_poweron, bool):
+            self._is_on = val_poweron
+            _LOGGER.debug("PyDreoDehumidifier:handle_server_update - poweron is %s", self._is_on)
+
+        val_mode = self.get_server_update_key_value(message, MODE_KEY)
+        if isinstance(val_mode, int):
+            self._mode = val_mode
+
+        val_humidity = self.get_server_update_key_value(message, HUMIDITY_KEY)
+        if isinstance(val_humidity, int):
+            self._humidity = val_humidity
+
+        val_target_humidity = self.get_server_update_key_value(message, RHAUTOLEVEL_KEY)
+        if isinstance(val_target_humidity, int):
+            self._target_humidity = val_target_humidity
+
+        val_wind_level = self.get_server_update_key_value(message, WINDLEVEL_KEY)
+        if isinstance(val_wind_level, int):
+            self._wind_level = val_wind_level
+
+        val_mute = self.get_server_update_key_value(message, MUTEON_KEY)
+        if isinstance(val_mute, bool):
+            self._mute_on = val_mute
+
+        val_light = self.get_server_update_key_value(message, LIGHTON_KEY)
+        if isinstance(val_light, bool):
+            self._light_on = val_light
+
+        val_child_lock = self.get_server_update_key_value(message, CHILDLOCKON_KEY)
+        if isinstance(val_child_lock, bool):
+            self._child_lock_on = val_child_lock
+
+        val_auto = self.get_server_update_key_value(message, AUTOON_KEY)
+        if isinstance(val_auto, bool):
+            self._auto_on = val_auto
+
+        val_temperature = self.get_server_update_key_value(message, TEMPERATURE_KEY)
+        if isinstance(val_temperature, (int, float)):
+            self._temperature = val_temperature

--- a/custom_components/dreo/switch.py
+++ b/custom_components/dreo/switch.py
@@ -92,6 +92,18 @@ SWITCHES: tuple[DreoSwitchEntityDescription, ...] = (
         translation_key="humidify",
         attr_name="humidify",
         icon="mdi:air-humidifier",
+    ),
+    DreoSwitchEntityDescription(    
+        key="Display Light",
+        translation_key="display_light",
+        attr_name="display_light",
+        icon="mdi:led-on",
+    ),
+    DreoSwitchEntityDescription(    
+        key="Auto Turn On",
+        translation_key="auto_mode",
+        attr_name="auto_mode",
+        icon="mdi:autorenew",
     )
 )
 

--- a/tests/dreo/test_fan.py
+++ b/tests/dreo/test_fan.py
@@ -29,7 +29,7 @@ class TestDreoFanHA(TestDeviceBase):
                                                             self.create_mock_device( name="Test Air Conditioner", type="Air Conditioner")]
 
             entity_list = fan.get_entries(mocked_pydreo_fans)
-            assert len(entity_list) == 5
+            assert len(entity_list) == 6
 
     def test_fan_simple(self):
         """Test the creation of the fan entity."""

--- a/tests/dreo/test_humidifer.py
+++ b/tests/dreo/test_humidifer.py
@@ -27,7 +27,7 @@ class TestDreoHumidifier(TestDeviceBase):
             self.create_mock_device( name="Test Air Conditioner", type="Air Conditioner")]
 
         entity_list = humidifier.get_entries(mocked_pydreo_devices)
-        assert len(entity_list) == 1
+        assert len(entity_list) == 2
 
     def test_humidifier_simple(self): 
         """Test the creation of the humidifier entity."""


### PR DESCRIPTION
## Summary

  This PR adds comprehensive support for the DR-HDH001S dehumidifier, implementing full device control through Home Assistant.

## Features Added

  - Device Support: DR-HDH001S dehumidifier recognition and setup
  - Operating Modes: Auto (humidity-based control) and Continuous operation
  - Humidity Control: Target humidity setting (30-85% range, Auto mode only)
  - Fan Speed Control: Low/Medium/High speeds via separate fan entity
  - Temperature Monitoring: Current temperature display
  - Switch Controls: Display light, child lock, panel sound, auto turn on toggles

## Technical Implementation

  - Created PyDreoDehumidifier class with complete API integration
  - Added DreoDehumidifierHA entity to humidifier platform
  - Extended fan platform for dehumidifier speed control (discrete modes, no oscillation)
  - Added multiple switch entities for device-specific toggles
  - Implemented proper Home Assistant entity features and device classes

## Testing

  - Tested with physical DR-HDH001S device
  - Network traffic analysis confirmed correct API commands
  - All controls verified working: power, modes, humidity, fan speed, toggles

## Files Modified

  - constant.py - Added DEHUMIDIFIER device type
  - models.py - Added DR-HDH001S device definition
  - __init__.py files - Added dehumidifier integration setup
  - humidifier.py - Added dehumidifier entity class
  - fan.py & dreofan.py - Extended for dehumidifier fan control
  - switch.py - Added dehumidifier-specific switches
  - New: pydreodehumidifier.py - Complete dehumidifier API class

## Breaking Changes

  None - this is purely additive functionality.