### PR TITLE
Fix ceiling fan entity synchronization issues (#351)

### DIFF
--- a/custom_components/dreo/pydreo/pydreoceilingfan.py
+++ b/custom_components/dreo/pydreo/pydreoceilingfan.py
@@ -10,7 +10,8 @@ from .constant import (
     WINDLEVEL_KEY,
     SPEED_RANGE,
     BRIGHTNESS_KEY,
-    COLORTEMP_KEY
+    COLORTEMP_KEY,
+    POWERON_KEY
 )
 
 from .pydreofanbase import PyDreoFanBase
@@ -159,3 +160,18 @@ class PyDreoCeilingFan(PyDreoFanBase):
         val_color_temp = self.get_server_update_key_value(message, COLORTEMP_KEY)
         if isinstance(val_color_temp, int):
             self._color_temp = val_color_temp    
+
+    def _handle_power_state_update(self, message):
+        """Override power state handling for ceiling fans"""
+        # Handle poweron: False = turn off entire device (both fan and light)
+        val_poweron = self.get_server_update_key_value(message, POWERON_KEY)
+        if val_poweron is False:
+            self._is_on = False
+            self._light_on = False
+            _LOGGER.debug("PyDreoCeilingFan: Device powered off - fan and light off")
+            
+        # Handle fanon: True/False = specific fan motor control
+        val_fan_on = self.get_server_update_key_value(message, FANON_KEY)
+        if isinstance(val_fan_on, bool):
+            self._is_on = val_fan_on
+            _LOGGER.debug("PyDreoCeilingFan: Fan state updated from fanon: %s", val_fan_on)

--- a/custom_components/dreo/pydreo/pydreofanbase.py
+++ b/custom_components/dreo/pydreo/pydreofanbase.py
@@ -343,12 +343,22 @@ class PyDreoFanBase(PyDreoBaseDevice):
         """Process a websocket update"""
         _LOGGER.debug("PyDreoFanBase:handle_server_update")
         super().handle_server_update(message)
+        
+        # Handle power state
+        self._handle_power_state_update(message)
+        
+        # Handle common fan properties
+        self._handle_fan_properties_update(message)
 
+    def _handle_power_state_update(self, message):
+        """Handle power state updates"""
         val_poweron = self.get_server_update_key_value(message, self._power_on_key)
         if isinstance(val_poweron, bool):
-            self._is_on = val_poweron  # Ensure poweron state is updated
-            _LOGGER.debug("PyDreoFanBase:handle_server_update - %s is %s", self._power_on_key, self._is_on)
+            self._is_on = val_poweron
+            _LOGGER.debug("PyDreoFanBase:_handle_power_state_update - %s is %s", self._power_on_key, self._is_on)
 
+    def _handle_fan_properties_update(self, message):
+        """Handle common fan properties"""
         val_wind_level = self.get_server_update_key_value(message, WINDLEVEL_KEY)
         if isinstance(val_wind_level, int):
             self._fan_speed = val_wind_level


### PR DESCRIPTION
_Hey @JeffSteinbok, awesome project and thank you so much for this!_ 🚀 

This PR fixes the ceiling fan entity synchronization issues I discussed in #351 (and probably #322 as well).

## Problem

The [DR-HCF002S](https://www.amazon.com/Dreo-Ceiling-Dimmable-Lighting-Installation/dp/B0D65VQMZR?th=1) ceiling fan entities would incorrectly toggle when controlling the opposite entity — every time I'd turn the _light_ on/off, the _fan_ entity would incorrectly toggle too; and vice versa when controlling the _fan_, the _light_ entity would incorrectly also change state. Turns out the issue was that both fan and light operations send `poweron` messages — I think it's a signal that tells the overall device is on (effectively either the light or fan, or both, are on) but doesn't specify which. This was confusing the fan and light entity logic.

## What I Fixed

**The Issue**: Base fan class was treating all `poweron` messages the same way, so when you control the light or fan, it sends `poweron: true` and HA (or rather this integration) interpreted it as both the light _and_ fan are on — which is incorrect. The base `poweron` logic inherited from `pydreofanbase.py` wasn't correct for ceiling fans (or at least the model I have) — I'm guessing regular fans probably just have one entity and `poweron` directly corresponds to that entity's state. But ceiling fans have multiple entities (fan + light) that share the same device, so `poweron` messages are ambiguous.

**The Solution**: 
- Refactored `PyDreoFanBase` to split _poweron handling_ from the other _common fan properties_ using Template Method pattern
- Added `_handle_power_state_update()` method, soceiling fans can override and define their own poweron logic
- Made `PyDreoCeilingFan` smarter about how to handle these poweron messages:

Power Message Logic. Here's how the different poweron, lighton, and fanon messages are now interpreted for ceiling fans:

| Message | `true` | `false` |
|---------|--------|---------|
| `poweron` | **Ignore** (prevents the false toggles) | Turn off **both** fan and light entities |
| `fanon` | Turn fan entity ON | Turn fan entity OFF |
| `lighton` | Turn light entity ON | Turn light entity OFF |

## Testing

Tested with my DR-HCF002S — the only device I got:
- ✅ Light control no longer affects fan entity
- ✅ Fan control no longer affects light entity  
- ✅ Turning off device via Dreo app properly updates both entities
- ✅ Everything works as expected now

## Files Changed
- `pydreofanbase.py` - Added template method pattern
- `pydreoceilingfan.py` - Overrode poweron handling for ceiling fans _only_

I only have access to the HCF002S, so I could only test it with that. My guess, and my assumption while working on this, is that only ceiling fans have this nuanced poweron issue, while the other non-ceiling fans do not - they just treat poweron as you already had it coded. Consequently I wrote this patch in such a way to continue the previous behavior for all non-ceiling fans, and only override this behavior for ceiling fans.

**Fixes #351**  
**Probably also closes #322**