### PR TITLE
Update number.py and models.py

### DIFF
--- a/custom_components/dreo/number.py
+++ b/custom_components/dreo/number.py
@@ -38,15 +38,15 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         translation_key="horizontal_angle",
         attr_name="horizontal_angle",
         icon="mdi:angle-acute",
-        min_value=-60,
-        max_value=60,
+        min_value=-75,
+        max_value=75,
     ),
     DreoNumberEntityDescription(
         key="Vertical Angle",
         translation_key="vertical_angle",
         attr_name="vertical_angle",
         icon="mdi:angle-acute",
-        min_value=0,
+        min_value=-30,
         max_value=90
     ),
     DreoNumberEntityDescription(
@@ -64,23 +64,23 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         translation_key="horizontal_osc_angle_left",
         attr_name="horizontal_osc_angle_left",
         icon="mdi:vector-radius",
-        min_value=-60,
-        max_value=60,
+        min_value=-75,
+        max_value=75,
     ),
     DreoNumberEntityDescription(
         key="Horizontal Oscillation Angle Right",
         translation_key="horizontal_osc_angle_right",
         attr_name="horizontal_osc_angle_right",
         icon="mdi:vector-radius",
-        min_value=-60,
-        max_value=60,
+        min_value=-75,
+        max_value=75,
     ),
     DreoNumberEntityDescription(
         key="Vertical Oscillation Angle Top",
         translation_key="vertical_osc_angle_top",
         attr_name="vertical_osc_angle_top",
         icon="mdi:vector-radius",
-        min_value=0,
+        min_value=-30,
         max_value=90
     ),
     DreoNumberEntityDescription(
@@ -88,7 +88,7 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         translation_key="vertical_osc_angle_bottom",
         attr_name="vertical_osc_angle_bottom",
         icon="mdi:vector-radius",
-        min_value=0,
+        min_value=-30,
         max_value=90
     ),
     DreoNumberEntityDescription(

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -126,6 +126,9 @@ SUPPORTED_DEVICES = {
     "DR-HPF008S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,
         device_ranges={SPEED_RANGE: (1, 9)}),
+    "DR-HPF007S": DreoDeviceDetails(
+        device_type=DreoDeviceType.AIR_CIRCULATOR,
+        device_ranges={SPEED_RANGE: (1, 9)}),
 
     # Ceiling Fans
     "DR-HCF": DreoDeviceDetails(device_type=DreoDeviceType.CEILING_FAN),

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 
 from .constant import (
     SPEED_RANGE,
+    HORIZONTAL_ANGLE_RANGE,
+    VERTICAL_ANGLE_RANGE,
     HEATER_MODE_COOLAIR,
     HEATER_MODE_HOTAIR,
     HEATER_MODE_ECO,
@@ -128,7 +130,11 @@ SUPPORTED_DEVICES = {
         device_ranges={SPEED_RANGE: (1, 9)}),
     "DR-HPF007S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,
-        device_ranges={SPEED_RANGE: (1, 9)}),
+        device_ranges={
+            SPEED_RANGE: (1, 12),
+            HORIZONTAL_ANGLE_RANGE: (-75,75),
+            VERTICAL_ANGLE_RANGE: (-30,90),
+        }),
 
     # Ceiling Fans
     "DR-HCF": DreoDeviceDetails(device_type=DreoDeviceType.CEILING_FAN),
@@ -217,7 +223,7 @@ SUPPORTED_DEVICES = {
             HEATER_MODE_OFF,
         ],
         swing_modes=[SWING_OFF, SWING_ON],
-    ),    
+    ),
     # Are these even used?  They don't show up as model numbers.  Should they be a DR prefix?
     "WH719S": DreoDeviceDetails(
         device_type=DreoDeviceType.HEATER,
@@ -267,8 +273,8 @@ SUPPORTED_DEVICES = {
         # TODO Eco is a Present, not HVAC mode (HVACMode.AUTO)
         hvac_modes=[
             HVACMode.OFF,
-            HVACMode.COOL, 
-            HVACMode.FAN_ONLY, 
+            HVACMode.COOL,
+            HVACMode.FAN_ONLY,
             HVACMode.DRY
         ],
         swing_modes=[SWING_OFF, SWING_ON],


### PR DESCRIPTION
### **707s supports -75 horizontal and -30 vertical which is lower than the current limits.**

### **Added DR-HPF007S to gain ability to power on / off**

----------

Fix: Adjust Dreo fan Horizontal Angle min_value=-75 , max_value=75

Fix: Adjust Dreo fan Vertical Angle -- min_value=-30

Fix: Adjust Dreo fan Horizontal Oscillation Angle Left -- min_value=-75 , max_value=75

Fix: Adjust Dreo fan Horizontal Oscillation Angle Right -- min_value=-75 , max_value=75

Fix: Adjust Dreo fan Vertical Oscillation Angle Top -- min_value=-30

Fix: Adjust Dreo fanVertical Oscillation Angle Bottom -- min_value=-30