### PR TITLE
Draft version of HSH034S support and angle ranges for 007S

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 
 from .constant import (
+    HORIZONTAL_ANGLE_RANGE,
     SPEED_RANGE,
     HEATER_MODE_COOLAIR,
     HEATER_MODE_HOTAIR,
@@ -131,7 +132,11 @@ SUPPORTED_DEVICES = {
 
     "DR-HPF007S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,
-        device_ranges={SPEED_RANGE: (1, 10)}),        
+        device_ranges={
+            SPEED_RANGE: (1, 10),
+            HORIZONTAL_ANGLE_RANGE: (-75,75),
+            VERTICAL_ANGLE_RANGE: (-30,90)
+        }),
 
     # Ceiling Fans
     "DR-HCF": DreoDeviceDetails(device_type=DreoDeviceType.CEILING_FAN),
@@ -226,7 +231,20 @@ SUPPORTED_DEVICES = {
             HEATER_MODE_OFF,
         ],
         swing_modes=[SWING_OFF, SWING_ON],
-    ),    
+    ),
+    "DR-HSH034S": DreoDeviceDetails(
+        device_type=DreoDeviceType.HEATER,
+        device_ranges={
+            HEAT_RANGE: (1, 5), 
+            ECOLEVEL_RANGE: (41, 95)},
+        hvac_modes=[
+            HEATER_MODE_COOLAIR,
+            HEATER_MODE_HOTAIR,
+            HEATER_MODE_ECO,
+            HEATER_MODE_OFF,
+        ],
+        swing_modes=[SWING_OFF, SWING_ON]
+    ),
     # Are these even used?  They don't show up as model numbers.  Should they be a DR prefix?
     "WH719S": DreoDeviceDetails(
         device_type=DreoDeviceType.HEATER,

--- a/custom_components/dreo/switch.py
+++ b/custom_components/dreo/switch.py
@@ -181,6 +181,10 @@ class DreoSwitchHA(DreoBaseDeviceHA, SwitchEntity):
             self._attr_name,
             self._attr_unique_id)
 
+    def __repr__(self):
+        # Representation string of object.
+        return f"<{self.__class__.__name__}:{self.entity_description}"
+    
     @property
     def is_on(self) -> bool:
         """Return True if device is on."""

--- a/tests/dreo/integrationtests/api_responses/get_device_state_HSH034S_1.json
+++ b/tests/dreo/integrationtests/api_responses/get_device_state_HSH034S_1.json
@@ -1,0 +1,140 @@
+{
+    "code": 0,
+    "msg": "OK",
+    "data": {
+    "mixed": {
+        "coollevel": {
+        "state": 3,
+        "timestamp": 1759047085
+        },
+        "wifi_rssi": {
+        "state": -31,
+        "timestamp": 1759047085
+        },
+        "poweron": {
+        "state": false,
+        "timestamp": 1759047085
+        },
+        "scheid": {
+        "state": 0,
+        "timestamp": 1759047085
+        },
+        "cruiseconf": {
+        "state": "45,45,-15,-45",
+        "timestamp": 1759047085
+        },
+        "timeron": {
+        "state": {
+            "du": 0,
+            "ts": 1759047083
+        },
+        "timestamp": null
+        },
+        "scheon": {
+        "state": false,
+        "timestamp": 1759047085
+        },
+        "mode": {
+        "state": "hotair",
+        "timestamp": 1759047085
+        },
+        "mcuon": {
+        "state": true,
+        "timestamp": 1759047085
+        },
+        "network_latency": {
+        "state": 6,
+        "timestamp": 1759047085
+        },
+        "module_hardware_model": {
+        "state": "HeFi",
+        "timestamp": 1759047085
+        },
+        "mcu_firmware_version": {
+        "state": "0.3.0",
+        "timestamp": 1759047085
+        },
+        "oscmode": {
+        "state": 0,
+        "timestamp": 1759047085
+        },
+        "temperature": {
+        "state": 67,
+        "timestamp": 1759047089
+        },
+        "cooldown": {
+        "state": 0,
+        "timestamp": 1759047085
+        },
+        "winopenon": {
+        "state": false,
+        "timestamp": 1759047085
+        },
+        "winopened": {
+        "state": 0,
+        "timestamp": 1759047085
+        },
+        "module_hardware_mac": "**REDACTED**",
+        "ptcon": {
+        "state": false,
+        "timestamp": 1759047085
+        },
+        "muteon": {
+        "state": true,
+        "timestamp": 1759047085
+        },
+        "lighton": {
+        "state": false,
+        "timestamp": 1759047085
+        },
+        "wifi_ssid": "**REDACTED**",
+        "mcu_hardware_model": {
+        "state": "SC95F8613B/EU",
+        "timestamp": 1759047085
+        },
+        "wrong": {
+        "state": 0,
+        "timestamp": 1759047085
+        },
+        "module_firmware_version": {
+        "state": "3.7.6",
+        "timestamp": 1759047085
+        },
+        "connected": {
+        "state": true,
+        "timestamp": 1759047085
+        },
+        "timeroff": {
+        "state": {
+            "du": 0,
+            "ts": 1759047083
+        },
+        "timestamp": null
+        },
+        "_ota": {
+        "state": 0,
+        "timestamp": 1759047085
+        },
+        "ecolevel": {
+        "state": 85,
+        "timestamp": 1759047085
+        },
+        "childlockon": {
+        "state": false,
+        "timestamp": 1759047085
+        },
+        "htalevel": {
+        "state": 3,
+        "timestamp": 1759047085
+        },
+        "tempoffset": {
+        "state": 0,
+        "timestamp": 1759047085
+        }
+    },
+    "sn": "**REDACTED**",
+    "productId": "**REDACTED**",
+    "region": "eu-central-1/emq",
+    "deviceInfo": null
+    }
+}

--- a/tests/dreo/integrationtests/api_responses/get_devices_HSH034S.json
+++ b/tests/dreo/integrationtests/api_responses/get_devices_HSH034S.json
@@ -1,0 +1,58 @@
+{
+    "code": 0,
+    "msg": "OK",
+    "data": {
+        "currentPage": 1,
+        "pageSize": 100,
+        "totalNum": 1,
+        "totalPage": 1,
+        "familyRooms": null,
+        "list": [
+        {
+            "deviceId": "1972212506796044290",
+            "sn": "HSH034S_1",
+            "brand": "Dreo",
+            "model": "DR-HSH034S",
+            "productId": "**REDACTED**",
+            "productName": "Heater",
+            "deviceName": "Heater",
+            "shared": false,
+            "series": null,
+            "seriesName": "WH714S",
+            "type": 0,
+            "owner": true,
+            "familyId": null,
+            "familyName": null,
+            "roomId": null,
+            "roomName": null,
+            "roomNameI18Key": "",
+            "color": "w",
+            "widgetOnImage": "https://resources.dreo-tech.com/app/preSigned202506/20318301b260764a74aad8eb1445f4c58b.png",
+            "widgetOffImage": "https://resources.dreo-tech.com/app/preSigned202506/2044b51ce232cd44e39831738d6053b092.png",
+            "widgetAbnormalImage": null,
+            "variantIconMd5": null,
+            "controlsConf": {},
+            "mainConf": {
+            "isSmart": true,
+            "isWifi": true,
+            "isBluetooth": true,
+            "isVoiceControl": true
+            },
+            "resourcesConf": {
+            "imageSmallSrc": "https://resources.dreo-tech.com/app/preSigned202506/206863035815c54e87b4a53f5260f27515.png",
+            "imageFullSrc": "https://resources.dreo-tech.com/app/preSigned202506/20e37c1d43a1b1409681b8e1ba77236597.zip",
+            "imageSmallDarkSrc": null,
+            "imageFullDarkSrc": null
+            },
+            "servicesConf": [],
+            "userManuals": [
+            {
+                "url": "https://resources.dreo-tech.com/app/preSigned202506/175b03bb00e1d14561beb4facbe7c2d8ef.pdf",
+                "icon": null,
+                "desc": "DR-HSH034S User Manual V1",
+                "lang": "en"
+            }
+            ]
+        }]
+    }
+}

--- a/tests/dreo/integrationtests/test_dreoheater.py
+++ b/tests/dreo/integrationtests/test_dreoheater.py
@@ -51,4 +51,34 @@ class TestDreoHeater(IntegrationTestBase):
             assert heater_ha.hvac_mode == HVACMode.AUTO
 
 
+    def test_HSH034S(self):  # pylint: disable=invalid-name
+        """Load heater and test sending commands."""
+        with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):
+
+            self.get_devices_file_name = "get_devices_HSH034S.json"
+            self.pydreo_manager.load_devices()
+            assert len(self.pydreo_manager.devices) == 1
+
+            pydreo_heater : PyDreoHeater = self.pydreo_manager.devices[0]
+            assert pydreo_heater.type == 'Heater'
+
+            heater_ha = dreoheater.DreoHeaterHA(pydreo_heater)
+            assert heater_ha.hvac_mode is HVACMode.OFF
+
+            numbers = number.get_entries([pydreo_heater])
+            self.verify_expected_entities(numbers, ["Heat Level"])
+
+            sensors = sensor.get_entries([pydreo_heater])
+            self.verify_expected_entities(sensors, [])
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:  
+                heater_ha.set_hvac_mode(HVACMode.AUTO)
+                mock_send_command.assert_any_call(pydreo_heater, {POWERON_KEY: True})
+                mock_send_command.assert_any_call(pydreo_heater, {MODE_KEY: "eco"})
+
+            pydreo_heater.handle_server_update({ REPORTED_KEY: {POWERON_KEY: True} })
+            pydreo_heater.handle_server_update({ REPORTED_KEY: {MODE_KEY: "eco"} })
+            assert heater_ha.hvac_mode == HVACMode.AUTO            
+
+
 


### PR DESCRIPTION
This pull request adds support for the new Dreo heater model `DR-HSH034S` and improves debugging for switch entities. The main changes include updating the device model definitions, adding integration test data and cases for the new heater, and enhancing the object representation for switches.

### Device model updates
* Added the new heater model `DR-HSH034S` to the `DreoDeviceDetails` mapping in `models.py`, including its supported ranges and modes.
* Added angle range definitions for the air circulator model `DR-HPF007S`. [[1]](diffhunk://#diff-cdadd0568e4a8350663bd47160470780391d85a446d82f6a2b9eb7254435c4f6L134-R139) [[2]](diffhunk://#diff-cdadd0568e4a8350663bd47160470780391d85a446d82f6a2b9eb7254435c4f6R6)

### Integration test additions
* Added test data files for device listing and state for the new heater model: `get_devices_HSH034S.json` and `get_device_state_HSH034S_1.json`. [[1]](diffhunk://#diff-8c09c17e0bf43235ae68276473e1cd60b2d3b822d5b66226c668b37ac12f1458R1-R58) [[2]](diffhunk://#diff-6d5f9c0e7b92145ecda7d75cf2f1bbde433a1d9c5d640848a09668710a790fb4R1-R140)
* Added a new test case for `DR-HSH034S` in `test_dreoheater.py` to verify device loading, entity creation, and command handling.

### Debugging and developer experience
* Implemented a `__repr__` method for switch entities to improve object introspection and debugging.