### PR TITLE
feat: add support for DR-HHM014S humidifier

### DIFF
--- a/custom_components/dreo/number.py
+++ b/custom_components/dreo/number.py
@@ -95,7 +95,23 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         translation_key="htalevel",
         attr_name="htalevel",
         icon="mdi:heat-wave"
-    )    
+    ),
+    DreoNumberEntityDescription(
+        key="Fan Speed",
+        translation_key="fan_speed",
+        attr_name="mist_level",
+        icon="mdi:fan",
+        min_value=1,
+        max_value=6,
+    ),
+    DreoNumberEntityDescription(
+        key="LED Brightness",
+        translation_key="led_brightness",
+        attr_name="led_level",
+        icon="mdi:brightness-6",
+        min_value=0,
+        max_value=2,
+    )
 )
 
 

--- a/custom_components/dreo/pydreo/constant.py
+++ b/custom_components/dreo/pydreo/constant.py
@@ -52,6 +52,15 @@ TARGET_HUMIDITY_KEY = "rhlevel"
 RGB_LEVEL = 'rgblevel'
 SCHEDULE_ENABLE = 'scheon'
 
+# Humidifier-specific keys
+FOGLEVEL_KEY = "foglevel"
+WATERLEVEL_KEY = "waterlevel"
+FILTERTIME_KEY = "filtertime"
+WORKTIME_KEY = "worktime"
+LEDLEVEL_KEY = "ledlevel"
+AUTODRYON_KEY = "autodryon"
+WRONG_KEY = "wrong"
+
 # Preferences Names
 # It's possible we should switch to IDs instead of names
 PREFERENCE_TYPE_TEMPERATURE_CALIBRATION = "Temperature Calibration"  # ID: 250

--- a/custom_components/dreo/sensor.py
+++ b/custom_components/dreo/sensor.py
@@ -19,7 +19,10 @@ from .pydreo.constant import (
     MODE_KEY,
     PM25_KEY,
     DreoDeviceType,
-    RGB_LEVEL
+    RGB_LEVEL,
+    WATERLEVEL_KEY,
+    FILTERTIME_KEY,
+    WORKTIME_KEY
 )
 
 from .pydreo.pydreoevaporativecooler import (
@@ -140,6 +143,35 @@ SENSORS: tuple[DreoSensorEntityDescription, ...] = (
         options=[LIGHT_ON, LIGHT_OFF],
         value_fn=lambda device: device.rgblevel,
         exists_fn=lambda device: (device.type in { DreoDeviceType.HUMIDIFIER }) and device.is_feature_supported(RGB_LEVEL),
+    ),
+    # Humidifier-specific sensors
+    DreoSensorEntityDescription(
+        key="Water Tank Level",
+        translation_key="water_tank_level",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement_fn=lambda device: "%",
+        icon="mdi:water-percent",
+        value_fn=lambda device: device.water_level,
+        exists_fn=lambda device: device.type == DreoDeviceType.HUMIDIFIER and device.is_feature_supported("water_level"),
+    ),
+    DreoSensorEntityDescription(
+        key="Filter Life",
+        translation_key="filter_life",
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement_fn=lambda device: "%",
+        icon="mdi:air-filter",
+        value_fn=lambda device: device.filter_time,
+        exists_fn=lambda device: device.is_feature_supported("filter_time"),
+    ),
+    DreoSensorEntityDescription(
+        key="Runtime",
+        translation_key="runtime",
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        native_unit_of_measurement_fn=lambda device: "h",
+        icon="mdi:clock-outline",
+        value_fn=lambda device: device.work_time,
+        exists_fn=lambda device: device.type == DreoDeviceType.HUMIDIFIER and device.is_feature_supported("work_time"),
     )
 )
 

--- a/custom_components/dreo/switch.py
+++ b/custom_components/dreo/switch.py
@@ -102,7 +102,7 @@ SWITCHES: tuple[DreoSwitchEntityDescription, ...] = (
         attr_name="display_light",
         icon="mdi:led-on",
     ),
-    DreoSwitchEntityDescription(    
+    DreoSwitchEntityDescription(
         key="Auto Turn On",
         translation_key="auto_mode",
         attr_name="auto_mode",
@@ -113,6 +113,12 @@ SWITCHES: tuple[DreoSwitchEntityDescription, ...] = (
         translation_key="scheon",
         attr_name="scheon",
         icon="mdi:calendar",
+    ),
+    DreoSwitchEntityDescription(
+        key="Auto Dry",
+        translation_key="auto_dry_on",
+        attr_name="auto_dry_on",
+        icon="mdi:hair-dryer",
     )  
 )
 


### PR DESCRIPTION
I only have access to a DR-HHM014S humidifier so I couldn't test if these changes have any impact on other models but hardcoding the available modes resolved the `'NoneType' object is not iterable` error seen in issues #417 and #418.

**Notable additions:**

- 2 new controls (fan speed, LED brightness)
- 3 new sensors (water level, filter life, runtime)
- 1 new switch/toggle (auto dry)

**Important notes:**
- enum int values for the 3 modes (manual, auto, sleep) were pulled from downloaded diagnostics
- mist levels / fan speeds show as 1-6 instead of the official app's scale of 1-/1/2-/2/3-/3
---

Here's a screenshot of how my device looks in HA now:

<img width="1249" height="1021" alt="image" src="https://github.com/user-attachments/assets/c59c9ad8-0c32-4ce5-9948-b2608f586c0a" />
