### PR TITLE
Fix swing mode assignment and update test cases for target humidity a…

### DIFF
--- a/custom_components/dreo/dreoairconditioner.py
+++ b/custom_components/dreo/dreoairconditioner.py
@@ -95,7 +95,7 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
         self._attr_unique_id = f"{super().unique_id}-{self.device.device_id}"
         self._attr_target_temperature = self.device.target_temperature
         self._attr_current_temperature = self.device.temperature
-        self._attr_swing_mode = self.device.device_definition.swing_modes[0]
+        self._attr_swing_mode = self.device.device_definition.swing_modes[0] if self.device.device_definition.swing_modes else None
         self._attr_swing_modes = self.device.device_definition.swing_modes
         self._attr_hvac_mode = AC_MODE_MAP[self.device.mode] if self.device.poweron else HVACMode.OFF
         self._attr_hvac_modes = self.device.device_definition.hvac_modes

--- a/custom_components/dreo/dreoheater.py
+++ b/custom_components/dreo/dreoheater.py
@@ -71,7 +71,7 @@ class DreoHeaterHA(DreoBaseDeviceHA, ClimateEntity):
         self._attr_unique_id = f"{super().unique_id}-{self.device.device_id}"
         self._attr_target_temperature = self.device.ecolevel
         self._attr_current_temperature = self.device.temperature
-        self._attr_swing_mode = self.device.device_definition.swing_modes[0]
+        self._attr_swing_mode = self.device.device_definition.swing_modes[0] if self.device.device_definition.swing_modes else None
         self._attr_swing_modes = self.device.device_definition.swing_modes
         self._attr_hvac_mode = (
             HEATER_MODE_MAP[self.device.hvac_mode] if self.device.poweron else HVACMode.OFF

--- a/custom_components/dreo/e2e_test_data/get_device_state_HAC001S_1.json
+++ b/custom_components/dreo/e2e_test_data/get_device_state_HAC001S_1.json
@@ -150,7 +150,7 @@
           "timestamp": 1725568078
         }
       },
-      "sn": "HAC005S_1",
+      "sn": "HAC001S_1",
       "productId": "**REDACTED**",
       "region": "us-east-2/emq"
     }

--- a/custom_components/dreo/e2e_test_data/get_devices.json
+++ b/custom_components/dreo/e2e_test_data/get_devices.json
@@ -10,12 +10,12 @@
     "list": [
       {
         "deviceId": "**REDACTED**",
-        "sn": "HAC005S_1",
+        "sn": "HAC001S_1",
         "brand": "Dreo",
         "model": "DR-HAC005S",
         "productId": "REDACTED",
         "productName": "Air Conditioner",
-        "deviceName": "DEBUGTEST - Air Conditioner - DR-HAC005S",
+        "deviceName": "DEBUGTEST - Air Conditioner - DR-HAC001S",
         "shared": false,
         "series": null,
         "seriesName": "AC515S",
@@ -5322,7 +5322,7 @@
         ]
       },
       {
-        "deviceId": "1828558438380138498",
+        "deviceId": "1828558436380138499",
         "sn": "HTF010S_1",
         "brand": "Dreo",
         "model": "DR-HTF010S",

--- a/tests/dreo/integrationtests/test_debug_test_mode.py
+++ b/tests/dreo/integrationtests/test_debug_test_mode.py
@@ -26,7 +26,7 @@ class TestDebugTestMode:
 
         pydreo_manager.login()
         pydreo_manager.load_devices()
-        assert len(pydreo_manager.devices) == 18
+        assert len(pydreo_manager.devices) == 22
         
         # Find tower fan by serial number
         tower_fan = next((d for d in pydreo_manager.devices if d.serial_number == "HTF005S_1"), None)

--- a/tests/dreo/integrationtests/test_dreoairconditioner.py
+++ b/tests/dreo/integrationtests/test_dreoairconditioner.py
@@ -27,10 +27,10 @@ class TestDreoAirConditioner(IntegrationTestBase):
             assert pydreo_ac.type == 'Air Conditioner'
 
             numbers = number.get_entries([pydreo_ac])
-            self.verify_expected_entities(numbers, [])
+            self.verify_expected_entities(numbers, ["Target Humidity"])
 
             sensors = sensor.get_entries([pydreo_ac])
-            self.verify_expected_entities(sensors, [])
+            self.verify_expected_entities(sensors, ['Humidity', 'Target temp reached', 'Use since cleaning'])
 
     def test_HAC006S(self):  # pylint: disable=invalid-name
         """Load air conditioner and test sending commands."""
@@ -44,7 +44,7 @@ class TestDreoAirConditioner(IntegrationTestBase):
             assert pydreo_ac.type == 'Air Conditioner'
 
             numbers = number.get_entries([pydreo_ac])
-            self.verify_expected_entities(numbers, [])
+            self.verify_expected_entities(numbers, ["Target Humidity"])
 
             sensors = sensor.get_entries([pydreo_ac])
             self.verify_expected_entities(sensors, ["Humidity", "Use since cleaning", "Target temp reached"])

--- a/tests/dreo/integrationtests/test_dreodehumidifier.py
+++ b/tests/dreo/integrationtests/test_dreodehumidifier.py
@@ -48,20 +48,20 @@ class TestDreoDeHumidifier(IntegrationTestBase):
 
             # Check to see what numbers are added to chef makers
             numbers = number.get_entries([pydreo_dehumidifier])
-            self.verify_expected_entities(numbers, [])
+            self.verify_expected_entities(numbers, ["Target Humidity"])
 
             # Check to see what sensors are added - should include Target Humidity
-            sensors = sensor.get_entries([pydreo_dehumidifier])
+            numbers = number.get_entries([pydreo_dehumidifier])
             
-            # Find the Target Humidity sensor
-            target_humidity_sensor = None
-            for s in sensors:
-                if s.entity_description.key == "Target Humidity":
-                    target_humidity_sensor = s
+            # Find the Target Humidity number
+            target_humidity_number = None
+            for n in numbers:
+                if n.entity_description.key == "Target Humidity":
+                    target_humidity_number = n
                     break
             
-            assert target_humidity_sensor is not None, "Target Humidity sensor should exist"
-            assert target_humidity_sensor.native_value == 50, "Target Humidity sensor value should be 50"
+            assert target_humidity_number is not None, "Target Humidity number should exist"
+            assert target_humidity_number.native_value == 50, "Target Humidity number value should be 50"
 
 
         

--- a/tests/dreo/integrationtests/test_dreoevaporativecooler.py
+++ b/tests/dreo/integrationtests/test_dreoevaporativecooler.py
@@ -48,7 +48,7 @@ class TestDreoEvaporativeCoolers(IntegrationTestBase):
                 assert len(pydreo_ec.preset_modes) > 0
 
             numbers = number.get_entries([pydreo_ec])
-            self.verify_expected_entities(numbers, [])
+            self.verify_expected_entities(numbers, ["Target Humidity"])
 
             sensors = sensor.get_entries([pydreo_ec])
             self.verify_expected_entities(sensors, ["Temperature", "Humidity","Use since cleaning"])

--- a/tests/dreo/integrationtests/test_dreohumidifier.py
+++ b/tests/dreo/integrationtests/test_dreohumidifier.py
@@ -46,22 +46,11 @@ class TestDreoHumidifier(IntegrationTestBase):
 
             # Check to see what numbers are added to humidifiers
             numbers = number.get_entries([pydreo_humidifier])
-            self.verify_expected_entities(numbers, [])
+            self.verify_expected_entities(numbers, ["Target Humidity"])
 
-            # Check to see what sensors are added - should include Target Humidity
+            # Check to see what sensors are added
             sensors = sensor.get_entries([pydreo_humidifier])
-            
-            # Find the Target Humidity sensor
-            target_humidity_sensor = None
-            for s in sensors:
-                if s.entity_description.key == "Target Humidity":
-                    target_humidity_sensor = s
-                    break
-            
-            assert target_humidity_sensor is not None, "Target Humidity sensor should exist"
-            assert target_humidity_sensor.native_value == 60, "Target Humidity sensor value should be 60"
-            
-            self.verify_expected_entities(sensors, ["Humidity", "Target Humidity", "Status", "Water Level", "Ambient Light Humidifier", "Use since cleaning"])
+            self.verify_expected_entities(sensors, ["Humidity", "Status", "Water Level", "Ambient Light Humidifier", "Use since cleaning"])
 
 
     def test_HHM014S(self):  # pylint: disable=invalid-name
@@ -93,21 +82,11 @@ class TestDreoHumidifier(IntegrationTestBase):
 
             # Check to see what numbers are added to humidifiers
             numbers = number.get_entries([pydreo_humidifier])
-            self.verify_expected_entities(numbers, [])
+            self.verify_expected_entities(numbers, ["Target Humidity"])
 
-            # Check to see what sensors are added - should include Target Humidity
+            # Check to see what sensors are added
             sensors = sensor.get_entries([pydreo_humidifier])
-            
-            # Find the Target Humidity sensor
-            target_humidity_sensor = None
-            for s in sensors:
-                if s.entity_description.key == "Target Humidity":
-                    target_humidity_sensor = s
-                    break
-            
-            assert target_humidity_sensor is not None, "Target Humidity sensor should exist for HHM014S"
-            assert target_humidity_sensor.native_value == 55, "Target Humidity sensor value should be 55 for HHM014S"
-            self.verify_expected_entities(sensors, ["Humidity", "Status", "Water Level", "Ambient Light Humidifier", "Use since cleaning", "Target Humidity"])
+            self.verify_expected_entities(sensors, ["Humidity", "Status", "Water Level", "Ambient Light Humidifier", "Use since cleaning"])
 
     def test_HHM003S(self):  # pylint: disable=invalid-name
         """Load HHM003S (HM713S/813S) humidifier and test all features including humidity sensors."""
@@ -138,9 +117,9 @@ class TestDreoHumidifier(IntegrationTestBase):
 
             # Check to see what numbers are added to humidifiers
             numbers = number.get_entries([pydreo_humidifier])
-            self.verify_expected_entities(numbers, [])
+            self.verify_expected_entities(numbers, ["Target Humidity"])
 
-            # Check to see what sensors are added - should include Humidity, Target Humidity, and worktime
+            # Check to see what sensors are added - should include Humidity, and worktime
             sensors = sensor.get_entries([pydreo_humidifier])
             
             # Find the Humidity sensor
@@ -153,16 +132,6 @@ class TestDreoHumidifier(IntegrationTestBase):
             assert humidity_sensor is not None, "Humidity sensor should exist for HHM003S"
             assert humidity_sensor.native_value == 40, "Humidity sensor value should be 40 for HHM003S"
             
-            # Find the Target Humidity sensor
-            target_humidity_sensor = None
-            for s in sensors:
-                if s.entity_description.key == "Target Humidity":
-                    target_humidity_sensor = s
-                    break
-            
-            assert target_humidity_sensor is not None, "Target Humidity sensor should exist for HHM003S"
-            assert target_humidity_sensor.native_value == 50, "Target Humidity sensor value should be 50 for HHM003S"
-            
             # Find the Use since cleaning sensor
             worktime_sensor = None
             for s in sensors:
@@ -173,6 +142,6 @@ class TestDreoHumidifier(IntegrationTestBase):
             assert worktime_sensor is not None, "Use since cleaning sensor should exist for HHM003S"
             assert worktime_sensor.native_value == 10, "Use since cleaning sensor value should be 10 for HHM003S"
             
-            self.verify_expected_entities(sensors, ["Humidity", "Status", "Water Level", "Ambient Light Humidifier", "Use since cleaning", "Target Humidity"])
+            self.verify_expected_entities(sensors, ["Humidity", "Status", "Water Level", "Ambient Light Humidifier", "Use since cleaning"])
 
         

--- a/tests/dreo/test_humidifer.py
+++ b/tests/dreo/test_humidifer.py
@@ -75,7 +75,7 @@ class TestDreoHumidifier(TestDeviceBase):
             self.verify_expected_entities(switch.get_entries([mocked_pydreo_humidifier]), [])
 
             # Check to see what numbers are added to ceiling Humidifiers
-            self.verify_expected_entities(number.get_entries([mocked_pydreo_humidifier]), [])
+            self.verify_expected_entities(number.get_entries([mocked_pydreo_humidifier]), ["Target Humidity"])
 
     def test_dehumidifier_simple(self):
         """Test the creation of the dehumidifier entity."""

--- a/tests/pydreo/api_responses/get_device_state_HAC001S_1.json
+++ b/tests/pydreo/api_responses/get_device_state_HAC001S_1.json
@@ -150,7 +150,7 @@
           "timestamp": 1725568078
         }
       },
-      "sn": "HAC005S_1",
+      "sn": "HAC001S_1",
       "productId": "**REDACTED**",
       "region": "us-east-2/emq"
     }

--- a/tests/pydreo/api_responses/get_devices_HAC001S.json
+++ b/tests/pydreo/api_responses/get_devices_HAC001S.json
@@ -10,12 +10,12 @@
     "list": [
       {
         "deviceId": "**REDACTED**",
-        "sn": "HAC005S_1",
+        "sn": "HAC001S_1",
         "brand": "Dreo",
         "model": "DR-HAC005S",
         "productId": "REDACTED",
         "productName": "Air Conditioner",
-        "deviceName": "DEBUGTEST - Air Conditioner - DR-HAC005S",
+        "deviceName": "DEBUGTEST - Air Conditioner - DR-HAC001S",
         "shared": false,
         "series": null,
         "seriesName": "AC515S",

--- a/tests/pydreo/api_responses/get_devices_HTF010S.json
+++ b/tests/pydreo/api_responses/get_devices_HTF010S.json
@@ -9,7 +9,7 @@
     "familyRooms": null,
     "list": [
       {
-        "deviceId": "1828558438380138498",
+        "deviceId": "1828558436380138499",
         "sn": "HTF010S_1",
         "brand": "Dreo",
         "model": "DR-HTF010S",


### PR DESCRIPTION
This pull request primarily improves device initialization robustness and updates test data and expectations to reflect changes in supported features and device identifiers. The most important changes include handling missing swing modes gracefully, updating test assertions for newly supported entities (especially "Target Humidity"), and correcting device serial numbers and IDs in test fixtures.

### Device Initialization Robustness

* Updated initialization in `dreoairconditioner.py` and `dreoheater.py` to set `swing_mode` to `None` if no swing modes are available, preventing potential errors when devices lack this feature. [[1]](diffhunk://#diff-605c3e0decab2998a9a3fb3838b8487ca11c4753903af91b9d1fd751b5fbfc4eL98-R98) [[2]](diffhunk://#diff-cacda032c7987dd0f8acd8f76ff8afc95501efdcb56ba825efb839353569297cL74-R74)

### Test Logic and Expectations

* Modified integration and unit tests to expect "Target Humidity" as a supported number entity for air conditioners, dehumidifiers, evaporative coolers, and humidifiers, reflecting expanded feature support. [[1]](diffhunk://#diff-aeaf4dde557baf262f857d6df08d7a7cc55853aea1906feb61737ba44459f7deL30-R33) [[2]](diffhunk://#diff-aeaf4dde557baf262f857d6df08d7a7cc55853aea1906feb61737ba44459f7deL47-R47) [[3]](diffhunk://#diff-4823118e76c1bde29e49d30fcdc0c7f90ba1bee6091a8b9d44ef10a6b869af40L51-R64) [[4]](diffhunk://#diff-095250be8c92fa38b8253aafb791b605a331bbfc2c69a5bfcf8ba8db3ac7f8b4L51-R51) [[5]](diffhunk://#diff-d377f2d0b130e176619ae279ec2aea0e5921f42117dc1e3dfa441f361564b33eL49-R53) [[6]](diffhunk://#diff-d377f2d0b130e176619ae279ec2aea0e5921f42117dc1e3dfa441f361564b33eL96-R89) [[7]](diffhunk://#diff-d377f2d0b130e176619ae279ec2aea0e5921f42117dc1e3dfa441f361564b33eL141-R122) [[8]](diffhunk://#diff-d377f2d0b130e176619ae279ec2aea0e5921f42117dc1e3dfa441f361564b33eL156-L165) [[9]](diffhunk://#diff-d377f2d0b130e176619ae279ec2aea0e5921f42117dc1e3dfa441f361564b33eL176-R145) [[10]](diffhunk://#diff-82275dbbb182f692746b56eef67799d390d602d1ba90a7ddeac2425b6af7d4ebL78-R78)

### Test Data and Device Identifiers

* Updated device serial numbers and device IDs in test data files (`get_devices.json`, `get_device_state_HAC001S_1.json`, and related API response files) to ensure consistency with the expected test environment and device definitions. [[1]](diffhunk://#diff-e765d9d88361af533fdc515991d3be586b433f49bfc338f126a48d5af8432092L153-R153) [[2]](diffhunk://#diff-71408f9466b4919417b2bd2ba7711fcfb190ea5bef9ce8e65e824f8af3854c1bL13-R18) [[3]](diffhunk://#diff-71408f9466b4919417b2bd2ba7711fcfb190ea5bef9ce8e65e824f8af3854c1bL5325-R5325) [[4]](diffhunk://#diff-e765d9d88361af533fdc515991d3be586b433f49bfc338f126a48d5af8432092L153-R153) [[5]](diffhunk://#diff-24927e65d2550e432daaaf31f758aeb4ab752f15fa6a20fe9d3902b7fb387df1L13-R18) [[6]](diffhunk://#diff-aed1d02254fa53d3c3adfeffec5b720573f0556b21873ca9a453d4cd408c3de6L12-R12)

### Test Coverage

* Increased the asserted number of devices in integration tests to reflect the addition of new devices in the test environment.