### PR TITLE
Support Device Deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,21 @@ This plugin supports configuration from the HomeAssistant UX. The following opti
 
 Note that at present you need to restart HA when you change an option for it to take effect.
 
+## Device Management
+
+### Removing Devices
+
+You can remove individual Dreo devices from Home Assistant through the UI:
+
+1. Navigate to **Settings** → **Devices & Services**
+2. Click on the **Dreo** integration
+3. Click on the device you want to remove
+4. Click the three-dot menu (⋮) in the top right
+5. Select **Delete**
+6. Confirm the deletion
+
+The device will be removed from Home Assistant but will remain in your Dreo account. If you reload the integration or restart Home Assistant, the device will be re-discovered and added back automatically.
+
 ## Debugging
 
 Use the **Diagnostics** feature in HomeAssistant to get diagnostics from the integration. Sensitive info should be redacted automatically.

--- a/custom_components/dreo/__init__.py
+++ b/custom_components/dreo/__init__.py
@@ -142,3 +142,24 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 
     pydreo_manager.stop_transport()
     return unload_ok
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Remove a config entry from a device.
+    
+    This allows users to delete Dreo devices from the UI.
+    Since Dreo devices are cloud-based and managed by the Dreo service,
+    we can safely remove them from Home Assistant's device registry.
+    """
+    _LOGGER.debug(
+        "Removing device %s (identifiers: %s) from config entry %s",
+        device_entry.name,
+        device_entry.identifiers,
+        config_entry.entry_id,
+    )
+    
+    # For cloud-based devices, we don't need to do any cleanup on the device itself.
+    # The device will still exist in the Dreo cloud and can be re-added by reloading
+    # the integration or if the device is discovered again.
+    return True

--- a/custom_components/dreo/haimports.py
+++ b/custom_components/dreo/haimports.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.typing import StateType
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
+from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,


### PR DESCRIPTION
This pull request adds support for removing individual Dreo devices from Home Assistant through the UI, clarifies the device removal process in the documentation, and introduces the necessary backend logic to handle device removal. The changes ensure that users can delete devices from Home Assistant without affecting their Dreo cloud account, and the devices will be re-discovered if the integration is reloaded.

**Device Removal Feature**

* Added a new section to `README.md` explaining how users can remove Dreo devices from Home Assistant via the UI, and clarified that devices remain in the Dreo cloud and are re-discovered if the integration is reloaded.

**Backend Support for Device Removal**

* Implemented the `async_remove_config_entry_device` function in `custom_components/dreo/__init__.py` to handle device removal requests from the UI, ensuring safe removal from Home Assistant's device registry without affecting the cloud device.
* Imported `DeviceEntry` in `custom_components/dreo/haimports.py` to support the new device removal logic.