### PR TITLE
Fix inverted range validation for heater htalevel and ecolevel

### DIFF
--- a/custom_components/dreo/pydreo/pydreoheater.py
+++ b/custom_components/dreo/pydreo/pydreoheater.py
@@ -129,7 +129,7 @@ class PyDreoHeater(PyDreoBaseDevice):
         """Set the heat level."""
         htalevel = int(htalevel) # ensure it's an int
         _LOGGER.debug("htalevel: htalevel.setter(%s, %s)", self.name, htalevel)
-        if (self._device_definition.device_ranges[HEAT_RANGE][0] > htalevel > self._device_definition.device_ranges[HEAT_RANGE][1]):
+        if not (self._device_definition.device_ranges[HEAT_RANGE][0] <= htalevel <= self._device_definition.device_ranges[HEAT_RANGE][1]):
             _LOGGER.error("htalevel: Heat level %s is not in the acceptable range: %s",
                             htalevel,
                             self._device_definition.device_ranges[HEAT_RANGE])
@@ -153,7 +153,7 @@ class PyDreoHeater(PyDreoBaseDevice):
     def ecolevel(self, ecolevel : int):
         """Set the target temperature."""
         _LOGGER.debug("ecolevel: ecolevel(%s)", ecolevel)
-        if self._device_definition.device_ranges[ECOLEVEL_RANGE][0] > ecolevel > self._device_definition.device_ranges[ECOLEVEL_RANGE][1]:
+        if not (self._device_definition.device_ranges[ECOLEVEL_RANGE][0] <= ecolevel <= self._device_definition.device_ranges[ECOLEVEL_RANGE][1]):
             _LOGGER.error("ecolevel: Target Temperature %s is not in the acceptable range: %s",
                             ecolevel,
                             self._device_definition.device_ranges[ECOLEVEL_RANGE])

--- a/tests/pydreo/test_pydreoheater.py
+++ b/tests/pydreo/test_pydreoheater.py
@@ -415,3 +415,54 @@ class TestPyDreoHeater(TestBase):
         heater.handle_server_update({REPORTED_KEY: {POWERON_KEY: False}})
         assert heater.poweron is False
         assert heater.mode == DreoHeaterMode.OFF
+
+    def test_HSH009S_htalevel_range_validation(self):  # pylint: disable=invalid-name
+        """Test that htalevel rejects values outside the valid range."""
+        self.get_devices_file_name = "get_devices_HSH009S.json"
+        self.pydreo_manager.load_devices()
+        assert len(self.pydreo_manager.devices) == 1
+        heater = self.pydreo_manager.devices[0]
+
+        # Range is (1, 3) for HSH009S
+        assert heater.htalevel_range == (1, 3)
+
+        # Value below range should be rejected (no command sent)
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            heater.htalevel = 0
+            mock_send_command.assert_not_called()
+
+        # Value above range should be rejected (no command sent)
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            heater.htalevel = 4
+            mock_send_command.assert_not_called()
+
+        # Value within range should be accepted
+        heater._htalevel = None  # reset to avoid duplicate check
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            heater.htalevel = 2
+            mock_send_command.assert_called_once_with(heater, {HTALEVEL_KEY: 2})
+
+    def test_HSH009S_ecolevel_range_validation(self):  # pylint: disable=invalid-name
+        """Test that ecolevel rejects values outside the valid range."""
+        self.get_devices_file_name = "get_devices_HSH009S.json"
+        self.pydreo_manager.load_devices()
+        assert len(self.pydreo_manager.devices) == 1
+        heater = self.pydreo_manager.devices[0]
+
+        eco_range = heater.ecolevel_range
+
+        # Value below range should be rejected
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            heater.ecolevel = eco_range[0] - 1
+            mock_send_command.assert_not_called()
+
+        # Value above range should be rejected
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            heater.ecolevel = eco_range[1] + 1
+            mock_send_command.assert_not_called()
+
+        # Boundary values should be accepted
+        heater._ecolevel = None
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            heater.ecolevel = eco_range[0]
+            mock_send_command.assert_called_once_with(heater, {ECOLEVEL_KEY: eco_range[0]})


### PR DESCRIPTION
## Problem
The chained comparison `min > val > max` in heater property setters is always `False` — no number can be simultaneously less than min AND greater than max. This meant range validation never triggered, allowing **any value** through to the Dreo API.

Affected setters:
- `htalevel` (heat level) — `pydreoheater.py:132`  
- `ecolevel` (target temperature) — `pydreoheater.py:156`  

## Fix
Changed to `not (min <= val <= max)` which correctly rejects out-of-range values and returns early without sending a command.

## Tests Added
- `test_HSH009S_htalevel_range_validation` — verifies below-range (0), above-range (4), and valid (2) for range (1,3)
- `test_HSH009S_ecolevel_range_validation` — verifies below-range, above-range, and boundary min value

Both tests confirm out-of-range values result in no command sent.