### PR TITLE
Add access_token and deviceId to diagnostics redaction

### DIFF
--- a/custom_components/dreo/diagnostics.py
+++ b/custom_components/dreo/diagnostics.py
@@ -27,7 +27,9 @@ KEYS_TO_REDACT = {
     "_username",
     "token",
     "_token",
-    "productId"
+    "access_token",
+    "productId",
+    "deviceId"
 }
 
 _LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
## Problem
The `KEYS_TO_REDACT` set in `diagnostics.py` was missing `access_token` and `deviceId`, so diagnostic dumps shared in support contexts could expose login tokens and device identifiers.

## Fix
Added both keys to the redaction set. The existing `_redact_values()` function handles the rest automatically.

## Testing
All 15 existing diagnostics tests pass. The `test_redact_values_all_keys` test dynamically reads `KEYS_TO_REDACT` so it covers the new keys.