### PR TITLE
Improve WebSocket transport robustness

### DIFF
--- a/custom_components/dreo/pydreo/commandtransport.py
+++ b/custom_components/dreo/pydreo/commandtransport.py
@@ -31,7 +31,7 @@ class CommandTransport:
 
         self._event_thread = None
         self._ws = None
-        self._ws_send_lock = threading.Lock()
+        self._ws_send_lock = None  # asyncio.Lock, created on the WS event loop
         self._transport_enabled = False
         self._signal_close = False
         self._testonly_signal_interrupt = False
@@ -106,6 +106,7 @@ class CommandTransport:
         This function exits when monitoring is stopped."""
         _LOGGER.info("_start_websocket: Starting WebSocket for incoming changes and commands.")
         self._loop = asyncio.get_event_loop()
+        self._ws_send_lock = asyncio.Lock()
         # open websocket
         url = f"wss://wsb-{self._api_server_region}.dreo-tech.com/websocket?accessToken={self._token}&timestamp={Helpers.api_timestamp()}"
         try:
@@ -180,7 +181,7 @@ class CommandTransport:
                         await ws.close()
                     except CancelledError:
                         pass
-                with self._ws_send_lock:
+                async with self._ws_send_lock:
                     await ws.send(WEBSOCKET_PING_MESSAGE)
                 await asyncio.sleep(WEBSOCKET_PING_INTERVAL)
                
@@ -213,7 +214,7 @@ class CommandTransport:
                 try:
                     if self._ws is None or self._ws.closed:
                         raise RuntimeError("WebSocket not connected")
-                    with self._ws_send_lock: 
+                    async with self._ws_send_lock: 
                         await self._ws.send(content)
                     break
                 except Exception:  # pylint: disable=broad-except

--- a/tests/pydreo/test_commandtransport.py
+++ b/tests/pydreo/test_commandtransport.py
@@ -17,8 +17,7 @@ class TestCommandTransport:
         
         assert transport._event_thread is None
         assert transport._ws is None
-        assert transport._ws_send_lock is not None
-        assert isinstance(transport._ws_send_lock, threading.Lock)
+        assert transport._ws_send_lock is None  # created lazily on WS event loop
         assert transport._transport_enabled is False
         assert transport._signal_close is False
         assert transport._testonly_signal_interrupt is False
@@ -186,6 +185,7 @@ class TestCommandTransport:
         # Use a real event loop running in a thread to test send_message
         loop = asyncio.new_event_loop()
         transport._loop = loop
+        transport._ws_send_lock = asyncio.Lock()
         
         def run_loop():
             loop.run_forever()
@@ -220,6 +220,7 @@ class TestCommandTransport:
         
         loop = asyncio.new_event_loop()
         transport._loop = loop
+        transport._ws_send_lock = asyncio.Lock()
         
         def run_loop():
             loop.run_forever()
@@ -251,6 +252,7 @@ class TestCommandTransport:
         
         loop = asyncio.new_event_loop()
         transport._loop = loop
+        transport._ws_send_lock = asyncio.Lock()
         
         def run_loop():
             loop.run_forever()
@@ -352,6 +354,7 @@ class TestCommandTransport:
         async def _test():
             callback = MagicMock()
             transport = CommandTransport(callback)
+            transport._ws_send_lock = asyncio.Lock()
             
             # Set signal_close immediately
             transport._signal_close = True
@@ -376,6 +379,7 @@ class TestCommandTransport:
         async def _test():
             callback = MagicMock()
             transport = CommandTransport(callback)
+            transport._ws_send_lock = asyncio.Lock()
             
             # Set test interrupt flag
             transport._testonly_signal_interrupt = True
@@ -402,6 +406,7 @@ class TestCommandTransport:
         async def _test():
             callback = MagicMock()
             transport = CommandTransport(callback)
+            transport._ws_send_lock = asyncio.Lock()
             
             mock_ws = AsyncMock()
             
@@ -429,6 +434,7 @@ class TestCommandTransport:
         async def _test():
             callback = MagicMock()
             transport = CommandTransport(callback)
+            transport._ws_send_lock = asyncio.Lock()
             
             mock_ws = AsyncMock()
             mock_ws.send.side_effect = websockets.exceptions.ConnectionClosedError(None, None)
@@ -446,6 +452,7 @@ class TestCommandTransport:
         async def _test():
             callback = MagicMock()
             transport = CommandTransport(callback)
+            transport._ws_send_lock = asyncio.Lock()
             
             mock_ws = AsyncMock()
             mock_ws.send.side_effect = asyncio.CancelledError()
@@ -665,6 +672,7 @@ class TestCommandTransport:
         
         loop = asyncio.new_event_loop()
         transport._loop = loop
+        transport._ws_send_lock = asyncio.Lock()
         
         def run_loop():
             loop.run_forever()
@@ -690,6 +698,7 @@ class TestCommandTransport:
         
         loop = asyncio.new_event_loop()
         transport._loop = loop
+        transport._ws_send_lock = asyncio.Lock()
         
         def run_loop():
             loop.run_forever()
@@ -755,6 +764,7 @@ class TestCommandTransport:
         
         loop = asyncio.new_event_loop()
         transport._loop = loop
+        transport._ws_send_lock = asyncio.Lock()
         
         def run_loop():
             loop.run_forever()


### PR DESCRIPTION
## Problem
Several critical reliability issues in `commandtransport.py` identified during code review:

1. **`send_message` used `asyncio.run()`** — created a new event loop each call, racing with the WS thread's loop. Commands could fail silently or hang.
2. **No error handling around `websockets.connect()`** — DNS errors, handshake failures, or network outages crashed the background thread permanently.
3. **`stop_transport` didn't close WS or join thread** — leaked WebSocket connections and threads on shutdown.
4. **Done task exceptions silently discarded** in `_ws_handler`.
5. **One bad message/callback crashed the entire consumer** pipeline.

## Fix

### `send_message` (Critical)
Replaced `asyncio.run()` with `asyncio.run_coroutine_threadsafe()` targeting the WS thread's event loop. Added null/closed WS check and event-loop-availability guard.

### `stop_transport` (High)
Now actively closes the WebSocket via the WS thread's loop and joins the thread with a 20s timeout.

### `_start_websocket` (High)
Stores event loop reference for cross-thread use. Wraps the entire `websockets.connect()` in try/except so connection failures are logged and the thread exits cleanly.

### Error handling (Medium)
- `_ws_handler`: Logs exceptions from completed tasks
- `_ws_consumer_handler`: Catches JSON decode and callback errors per-message
- `_ws_consume_message`: Wraps callback in try/except

### Constants (Low)
Extracted magic numbers: `WEBSOCKET_PING_INTERVAL`, `WEBSOCKET_PING_MESSAGE`, `MAX_RETRY_COUNT`, `RETRY_DELAY`