### PR TITLE
Fix unchecked dict access in timer parsing

### DIFF
--- a/custom_components/dreo/pydreo/pydreoheater.py
+++ b/custom_components/dreo/pydreo/pydreoheater.py
@@ -375,13 +375,13 @@ class PyDreoHeater(PyDreoBaseDevice):
         self._mute_on = self.get_state_update_value(state, MUTEON_KEY)
         self._dev_on = self.get_state_update_value(state, DEVON_KEY)
         timeron = self.get_state_update_value(state, TIMERON_KEY)
-        self._timer_on = timeron["du"]
+        self._timer_on = timeron.get("du") if isinstance(timeron, dict) else None
         self._cooldown = self.get_state_update_value(state, COOLDOWN_KEY)
         self._ptc_on = self.get_state_update_value(state, PTCON_KEY)
         self._light_on = self.get_state_update_value(state, LIGHTON_KEY)
         self._ctlstatus = self.get_state_update_value(state, CTLSTATUS_KEY)
         timeroff = self.get_state_update_value(state, TIMEROFF_KEY)
-        self._timer_off = timeroff["du"]
+        self._timer_off = timeroff.get("du") if isinstance(timeroff, dict) else None
         self._ecolevel = self.get_state_update_value(state, ECOLEVEL_KEY)
         self._childlockon = self.get_state_update_value(state, CHILDLOCKON_KEY)
         self._tempoffset = self.get_state_update_value(state, TEMPOFFSET_KEY)

--- a/tests/pydreo/test_pydreoheater.py
+++ b/tests/pydreo/test_pydreoheater.py
@@ -466,3 +466,29 @@ class TestPyDreoHeater(TestBase):
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             heater.ecolevel = eco_range[0]
             mock_send_command.assert_called_once_with(heater, {ECOLEVEL_KEY: eco_range[0]})
+
+    def test_HSH009S_timer_parsing_safe(self):  # pylint: disable=invalid-name
+        """Test that timer parsing handles None and missing 'du' gracefully."""
+        self.get_devices_file_name = "get_devices_HSH009S.json"
+        self.pydreo_manager.load_devices()
+        heater = self.pydreo_manager.devices[0]
+
+        # Timer with valid dict
+        heater.update_state({TIMERON_KEY: {"state": {"du": 120}}, TIMEROFF_KEY: {"state": {"du": 60}}})
+        assert heater._timer_on == 120
+        assert heater._timer_off == 60
+
+        # Timer with None value in state
+        heater.update_state({TIMERON_KEY: {"state": None}, TIMEROFF_KEY: {"state": None}})
+        assert heater._timer_on is None
+        assert heater._timer_off is None
+
+        # Timer key absent from state entirely
+        heater.update_state({})
+        assert heater._timer_on is None
+        assert heater._timer_off is None
+
+        # Timer with dict missing 'du' key
+        heater.update_state({TIMERON_KEY: {"state": {"other": 1}}, TIMEROFF_KEY: {"state": {"other": 2}}})
+        assert heater._timer_on is None
+        assert heater._timer_off is None


### PR DESCRIPTION
Fixes Critical #4: `timeron['du']` and `timeroff['du']` in `pydreoheater.py` crash with `TypeError` if the timer value is `None` (key absent from state) or `KeyError` if the dict lacks a `du` entry.

Uses `isinstance` check and `.get()` for safe access.

Includes tests for valid dict, None, absent key, and missing 'du' key scenarios.