### PR TITLE
Fix getattr on dict in get_device_range

### DIFF
--- a/custom_components/dreo/number.py
+++ b/custom_components/dreo/number.py
@@ -175,7 +175,10 @@ def get_device_range(device: PyDreoBaseDevice, number_definition: DreoNumberEnti
         _LOGGER.debug("get_device_range: range %s from device is %s", range_name, range_from_device)
         return range_from_device
 
-    range_from_device_definition = getattr(device.device_definition.device_ranges, range_name, None)
+    if device.device_definition.device_ranges is not None:
+        range_from_device_definition = device.device_definition.device_ranges.get(range_name)
+    else:
+        range_from_device_definition = None
     if range_from_device_definition is not None:
         _LOGGER.debug("get_device_range: range %s from device definition is %s", range_name,
                       range_from_device_definition)

--- a/tests/dreo/test_number.py
+++ b/tests/dreo/test_number.py
@@ -206,8 +206,7 @@ class TestDreoNumberHA(TestDeviceBase):
         device = MagicMock()
         device.horizontal_angle_range = None
         device.device_definition = MagicMock()
-        device.device_definition.device_ranges = MagicMock()
-        device.device_definition.device_ranges.horizontal_angle_range = (-50, 50)
+        device.device_definition.device_ranges = {"horizontal_angle_range": (-50, 50)}
 
         desc = DreoNumberEntityDescription(
             key="Horizontal Angle",
@@ -224,8 +223,7 @@ class TestDreoNumberHA(TestDeviceBase):
         device = MagicMock()
         device.horizontal_angle_range = None
         device.device_definition = MagicMock()
-        device.device_definition.device_ranges = MagicMock()
-        device.device_definition.device_ranges.horizontal_angle_range = None
+        device.device_definition.device_ranges = {}
 
         desc = DreoNumberEntityDescription(
             key="Horizontal Angle",


### PR DESCRIPTION
Fixes High #14: `get_device_range()` in `number.py` used `getattr()` on `device_definition.device_ranges`, which is a `dict`. Since `getattr` looks up object attributes (not dict keys), per-model range overrides were silently ignored.

Changed to `dict.get()` and added `None` guard. Updated tests to use real dicts instead of MagicMock.