### PR TITLE
Fix power-on key None guard in fan base class

### DIFF
--- a/custom_components/dreo/pydreo/pydreofanbase.py
+++ b/custom_components/dreo/pydreo/pydreofanbase.py
@@ -127,6 +127,9 @@ class PyDreoFanBase(PyDreoBaseDevice):
     def is_on(self, value: bool):
         """Set if the fan is on or off"""
         _LOGGER.debug("is_on: is_on.setter - %s", value)
+        if self._power_on_key is None:
+            _LOGGER.error("is_on: Cannot set power state — power on key is unknown")
+            return
         self._send_command(self._power_on_key, value)
 
     @property
@@ -346,7 +349,9 @@ class PyDreoFanBase(PyDreoBaseDevice):
                 self._power_on_key = FANON_KEY
             else:
                 _LOGGER.error("update_state: Unable to get power on state from state. Check debug logs for more information.")
-                self._power_on_key = None
+                # Default to POWERON_KEY so is_on setter doesn't send None key
+                if self._power_on_key is None:
+                    self._power_on_key = POWERON_KEY
                 
         self._fan_speed = self.get_state_update_value(state, WINDLEVEL_KEY)
         if self._fan_speed is None:


### PR DESCRIPTION
Fixes High #10: When neither `POWERON_KEY` nor `FANON_KEY` is in the initial device state, `_power_on_key` was set to `None`, causing `_send_command(None, value)` in the `is_on` setter.

- Preserves existing `_power_on_key` if neither key found (or defaults to `POWERON_KEY` on first load)
- Adds guard in `is_on` setter to log error and bail instead of sending `None` key