### PR TITLE
Fix fan speed validation to use speed range minimum

### DIFF
--- a/custom_components/dreo/pydreo/pydreofanbase.py
+++ b/custom_components/dreo/pydreo/pydreofanbase.py
@@ -137,7 +137,7 @@ class PyDreoFanBase(PyDreoBaseDevice):
     @fan_speed.setter
     def fan_speed(self, fan_speed: int):
         """Set the fan speed."""
-        if fan_speed < 1 or fan_speed > self._speed_range[1]:
+        if fan_speed < self._speed_range[0] or fan_speed > self._speed_range[1]:
             _LOGGER.error("fan_speed: Fan speed %s is not in the acceptable range: %s",
                           fan_speed,
                           self._speed_range)


### PR DESCRIPTION
Fixes Medium #21: The `fan_speed` setter hardcoded the lower bound check as `fan_speed < 1` instead of using `self._speed_range[0]`. If a device had a minimum speed other than 1, the validation would be wrong.