### PR TITLE
Fix logger namespace typo in manifest.json

### DIFF
--- a/custom_components/dreo/manifest.json
+++ b/custom_components/dreo/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://github.com/jeffsteinbok/hass-dreo/blob/master/README.md",
   "iot_class": "cloud_push",
   "issue_tracker": "https://github.com/jeffsteinbok/hass-dreo/issues",  
-  "loggers": ["custom_compoments.dreo"],
+  "loggers": ["custom_components.dreo"],
   "requirements": ["websockets"],
   "version": "1.7.0"
 }


### PR DESCRIPTION
Fixes Medium #31: `custom_compoments` was missing an 'n' — should be `custom_components`.

This caused HA's debug logging filter to never match the integration's logger namespace, preventing users from enabling debug logs via the UI (Settings -> Integrations -> Dreo -> Enable debug logging).