### PR TITLE
Fix medium code quality issues: RGB validation, type annotations

### DIFF
--- a/custom_components/dreo/pydreo/helpers.py
+++ b/custom_components/dreo/pydreo/helpers.py
@@ -177,7 +177,7 @@ class Helpers:
         return str(int(time.time() * 1000))
 
     @staticmethod
-    def name_from_value(name_value_list : list[tuple], value) -> str:
+    def name_from_value(name_value_list : list[tuple], value) -> str | None:
         """Return name from list of tuples."""
         if not name_value_list:
             _LOGGER.error("Helpers::name_from_value - name_value_list is None")

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -54,7 +54,7 @@ class DreoDeviceDetails:
     preset_modes: list[str]
     """List of possible preset mode names"""
 
-    device_ranges: dict[range]
+    device_ranges: dict[str, tuple]
     """Dictionary of different ranges"""
 
     mode_names: list[str] | dict

--- a/custom_components/dreo/pydreo/pydreoceilingfan.py
+++ b/custom_components/dreo/pydreo/pydreoceilingfan.py
@@ -32,6 +32,8 @@ class PyDreoCeilingFan(PyDreoFanBase):
     @staticmethod
     def _clamp_rgb_tuple(rgb: tuple) -> tuple[int, int, int]:
         """Clamp RGB tuple values to 0-255 integers."""
+        if len(rgb) != 3:
+            raise ValueError(f"RGB tuple must have exactly 3 elements, got {len(rgb)}")
         return tuple(max(0, min(255, int(round(c)))) for c in rgb)
 
     @staticmethod


### PR DESCRIPTION
Fixes Medium #26, #29, #34:

- **RGB validation** (#26): `_clamp_rgb_tuple` now raises `ValueError` if tuple doesn't have exactly 3 elements
- **name_from_value return type** (#29): Changed `-> str` to `-> str | None` since function returns `None` on no match
- **device_ranges type** (#34): Changed `dict[range]` (invalid) to `dict[str, tuple]`