### PR TITLE
Add token refresh and 401 retry for expired auth

### DIFF
--- a/custom_components/dreo/pydreo/__init__.py
+++ b/custom_components/dreo/pydreo/__init__.py
@@ -418,7 +418,7 @@ class PyDreo:  # pylint: disable=function-redefined
     
     def call_dreo_api(self, api: str, json_object: Optional[dict] = None) -> tuple:
         """Call the Dreo API. This is used for login and the initial device list and states as well
-           as device settings."""
+           as device settings. Automatically retries once on 401 (token expired)."""
         _LOGGER.debug("call_dreo_api: Calling Dreo API: {%s}", api)
         api_url = DREO_API_URL_FORMAT.format(self.api_server_region)
 
@@ -427,13 +427,42 @@ class PyDreo:  # pylint: disable=function-redefined
 
         json_object_full = {**Helpers.req_body(self, api), **json_object}
 
-        return Helpers.call_api(
+        response, status_code = Helpers.call_api(
             api_url,
             DREO_APIS[api][DREO_API_PATH],
             DREO_APIS[api][DREO_API_METHOD],
             json_object_full,
             Helpers.req_headers(self),
         )
+
+        # If we got a 401 and this isn't the login call itself, try re-authenticating
+        if status_code == 401 and api != DREO_API_LOGIN:
+            _LOGGER.warning("call_dreo_api: Got 401 for %s — attempting re-login", api)
+            if self._re_login():
+                # Retry the original call with refreshed token
+                json_object_full = {**Helpers.req_body(self, api), **json_object}
+                response, status_code = Helpers.call_api(
+                    api_url,
+                    DREO_APIS[api][DREO_API_PATH],
+                    DREO_APIS[api][DREO_API_METHOD],
+                    json_object_full,
+                    Helpers.req_headers(self),
+                )
+
+        return response, status_code
+
+    def _re_login(self) -> bool:
+        """Re-authenticate to refresh the token. Updates transport if running."""
+        _LOGGER.info("_re_login: Attempting to refresh authentication token")
+        old_token = self.token
+        if self.login():
+            _LOGGER.info("_re_login: Re-login successful, token refreshed")
+            # Update the WebSocket transport with the new token
+            if not self.debug_test_mode and self.token != old_token:
+                self._transport.update_token(self.token)
+            return True
+        _LOGGER.error("_re_login: Re-login failed")
+        return False
 
     def start_transport(self) -> None:
         """Initialize the websocket and start transport"""

--- a/custom_components/dreo/pydreo/commandtransport.py
+++ b/custom_components/dreo/pydreo/commandtransport.py
@@ -96,6 +96,11 @@ class CommandTransport:
             if self._event_thread.is_alive():
                 _LOGGER.warning("stop_transport: WebSocket thread did not stop within timeout")
 
+    def update_token(self, token: str) -> None:
+        """Update the authentication token for WebSocket reconnections."""
+        _LOGGER.info("update_token: Updating WebSocket token")
+        self._token = token
+
     def testonly_interrupt_transport(self) -> None:
         '''Close down the monitoring socket'''
         _LOGGER.info("testonly_interrupt_transport: Interrupting Transport - May take up to 15s")
@@ -107,32 +112,42 @@ class CommandTransport:
         _LOGGER.info("_start_websocket: Starting WebSocket for incoming changes and commands.")
         self._loop = asyncio.get_event_loop()
         self._ws_send_lock = asyncio.Lock()
-        # open websocket
-        url = f"wss://wsb-{self._api_server_region}.dreo-tech.com/websocket?accessToken={self._token}&timestamp={Helpers.api_timestamp()}"
-        try:
-            async for ws in websockets.connect(url):
-                
-                if self._signal_close:
-                    _LOGGER.info("_start_websocket: Transport has been stopped")
-                    break # This break causes us not to connect
-                
-                try:
-                    self._ws = ws
-                    _LOGGER.info("_start_websocket: WebSocket successfully opened")
-                    await self._ws_handler(ws)
-                except websockets.exceptions.ConnectionClosed:
-                    pass
 
-                if not self._auto_reconnect:
-                    _LOGGER.error("_start_websocket: WebSocket appears closed.  Not Reconnecting.  Restart HA to reconnect.")
-                    break # This break causes us not to connect
-                else:
-                    continue
-        except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.error("_start_websocket: WebSocket connection failed: %s", ex)
+        while not self._signal_close:
+            # Build URL fresh each attempt so token updates are picked up
+            url = f"wss://wsb-{self._api_server_region}.dreo-tech.com/websocket?accessToken={self._token}&timestamp={Helpers.api_timestamp()}"
+            try:
+                async for ws in websockets.connect(url):
+
+                    if self._signal_close:
+                        _LOGGER.info("_start_websocket: Transport has been stopped")
+                        break
+
+                    try:
+                        self._ws = ws
+                        _LOGGER.info("_start_websocket: WebSocket successfully opened")
+                        await self._ws_handler(ws)
+                    except websockets.exceptions.ConnectionClosed:
+                        pass
+
+                    if not self._auto_reconnect:
+                        _LOGGER.error("_start_websocket: WebSocket appears closed.  Not Reconnecting.  Restart HA to reconnect.")
+                        self._loop = None
+                        _LOGGER.info("_start_websocket: Transport has been stopped and thread done")
+                        return
+
+                    # Break out of async for to rebuild URL with potentially refreshed token
+                    _LOGGER.info("_start_websocket: Reconnecting with current token")
+                    break
+
+            except Exception as ex:  # pylint: disable=broad-except
+                _LOGGER.error("_start_websocket: WebSocket connection failed: %s", ex)
+                if not self._auto_reconnect or self._signal_close:
+                    break
+                await asyncio.sleep(RETRY_DELAY)
 
         self._loop = None
-        _LOGGER.info("_start_websocket: Transport has been stopped and thread done")  
+        _LOGGER.info("_start_websocket: Transport has been stopped and thread done")
 
     async def _ws_handler(self, ws):
         consumer_task = asyncio.create_task(self._ws_consumer_handler(ws))

--- a/custom_components/dreo/pydreo/helpers.py
+++ b/custom_components/dreo/pydreo/helpers.py
@@ -157,6 +157,7 @@ class Helpers:
                         Helpers.redactor(json.dumps(response)),
                     )
             else:
+                status_code = r.status_code
                 _LOGGER.error("call_api: API request failed with status code %s for %s%s",
                              r.status_code, url, api)
         return response, status_code

--- a/tests/pydreo/test_commandtransport.py
+++ b/tests/pydreo/test_commandtransport.py
@@ -639,13 +639,16 @@ class TestCommandTransport:
             transport = CommandTransport(callback)
             transport._api_server_region = "eu"
             transport._token = "my_token_123"
-            transport._signal_close = True  # Exit immediately after checking URL
             
             captured_url = [None]
             
             async def mock_connect(url):
                 captured_url[0] = url
-                yield AsyncMock()
+                # Signal close after capturing URL so the loop exits
+                transport._signal_close = True
+                # Yield nothing — the async for won't iterate
+                return
+                yield  # Make this an async generator  # pylint: disable=unreachable
             
             with patch('custom_components.dreo.pydreo.commandtransport.websockets.connect', side_effect=mock_connect):
                 with patch.object(transport._recv_callback, '__call__'):
@@ -653,7 +656,7 @@ class TestCommandTransport:
             
             # Verify URL format
             assert captured_url[0] is not None
-            url = str(captured_url[0])  # Convert to string to satisfy pylint
+            url = str(captured_url[0])
             assert url.startswith("wss://wsb-eu.dreo-tech.com/websocket")
             assert "accessToken=my_token_123" in url
             assert "timestamp=" in url
@@ -785,3 +788,48 @@ class TestCommandTransport:
         finally:
             loop.call_soon_threadsafe(loop.stop)
             t.join(timeout=5)
+
+    def test_update_token(self):
+        """Test that update_token updates the stored token."""
+        callback = MagicMock()
+        transport = CommandTransport(callback)
+        transport._token = "old_token"
+
+        transport.update_token("new_token")
+        assert transport._token == "new_token"
+
+    def test_reconnect_uses_fresh_token(self):
+        """Test that WebSocket reconnect picks up a new token."""
+        async def _test():
+            callback = MagicMock()
+            transport = CommandTransport(callback)
+            transport._api_server_region = "us"
+            transport._token = "token_v1"
+
+            captured_urls = []
+            call_count = [0]
+
+            async def mock_connect(url):
+                captured_urls.append(url)
+                call_count[0] += 1
+                if call_count[0] == 1:
+                    # After first connection, update token and yield a mock WS
+                    transport._token = "token_v2"
+                    mock_ws = AsyncMock()
+                    mock_ws.__aiter__ = MagicMock(return_value=iter([]))
+                    yield mock_ws
+                elif call_count[0] == 2:
+                    # Second connection should use new token; signal close
+                    transport._signal_close = True
+                    return
+                    yield  # pylint: disable=unreachable
+
+            with patch('custom_components.dreo.pydreo.commandtransport.websockets.connect', side_effect=mock_connect):
+                transport._auto_reconnect = True
+                await transport._start_websocket()
+
+            assert len(captured_urls) == 2
+            assert "accessToken=token_v1" in captured_urls[0]
+            assert "accessToken=token_v2" in captured_urls[1]
+
+        asyncio.run(_test())

--- a/tests/pydreo/test_token_refresh.py
+++ b/tests/pydreo/test_token_refresh.py
@@ -1,0 +1,116 @@
+"""Tests for PyDreo token refresh and 401 retry logic."""
+import logging
+from unittest.mock import patch, MagicMock
+from .imports import * # pylint: disable=W0401,W0614
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+PATCH_BASE = 'custom_components.dreo.pydreo'
+PATCH_CALL_API = f'{PATCH_BASE}.helpers.Helpers.call_api'
+PATCH_LOGIN = f'{PATCH_BASE}.PyDreo.login'
+
+
+class TestTokenRefresh:
+    """Test token refresh and 401 retry logic."""
+
+    def _make_manager(self):
+        """Create a PyDreo manager for testing."""
+        manager = PyDreo('test@example.com', 'password', redact=True)
+        manager.enabled = True
+        manager.token = "old_token"
+        manager.account_id = "test_account"
+        return manager
+
+    def test_call_dreo_api_retries_on_401(self):
+        """Test that call_dreo_api retries once after a 401 response."""
+        manager = self._make_manager()
+
+        with patch(PATCH_CALL_API) as mock_call_api:
+            mock_call_api.side_effect = [
+                (None, 401),
+                ({"code": 0, "data": {}}, 200),
+            ]
+            with patch(PATCH_LOGIN, return_value=True):
+                response, status_code = manager.call_dreo_api(DREO_API_DEVICELIST)
+
+        assert status_code == 200
+        assert response is not None
+        assert mock_call_api.call_count == 2
+
+    def test_call_dreo_api_no_retry_on_login_api(self):
+        """Test that call_dreo_api does NOT retry the login API itself on 401."""
+        manager = self._make_manager()
+
+        with patch(PATCH_CALL_API) as mock_call_api:
+            mock_call_api.return_value = (None, 401)
+            response, status_code = manager.call_dreo_api(DREO_API_LOGIN)
+
+        assert mock_call_api.call_count == 1
+        assert status_code == 401
+
+    def test_call_dreo_api_no_retry_on_relogin_failure(self):
+        """Test that call_dreo_api doesn't retry if re-login fails."""
+        manager = self._make_manager()
+
+        with patch(PATCH_CALL_API) as mock_call_api:
+            mock_call_api.return_value = (None, 401)
+            with patch(PATCH_LOGIN, return_value=False):
+                response, status_code = manager.call_dreo_api(DREO_API_DEVICELIST)
+
+        assert mock_call_api.call_count == 1
+        assert status_code == 401
+
+    def test_call_dreo_api_no_retry_on_200(self):
+        """Test that call_dreo_api doesn't retry on success."""
+        manager = self._make_manager()
+
+        with patch(PATCH_CALL_API) as mock_call_api:
+            mock_call_api.return_value = ({"code": 0}, 200)
+            response, status_code = manager.call_dreo_api(DREO_API_DEVICELIST)
+
+        assert mock_call_api.call_count == 1
+        assert status_code == 200
+
+    def test_re_login_updates_transport_token(self):
+        """Test that _re_login updates the transport token on success."""
+        manager = self._make_manager()
+        manager.debug_test_mode = False
+
+        with patch(PATCH_LOGIN) as mock_login:
+            def login_side_effect():
+                manager.token = "new_token"
+                return True
+            mock_login.side_effect = login_side_effect
+
+            with patch.object(manager._transport, 'update_token') as mock_update:
+                result = manager._re_login()
+
+        assert result is True
+        mock_update.assert_called_once_with("new_token")
+
+    def test_re_login_failure_returns_false(self):
+        """Test that _re_login returns False when login fails."""
+        manager = self._make_manager()
+
+        with patch(PATCH_LOGIN, return_value=False):
+            result = manager._re_login()
+
+        assert result is False
+
+    def test_re_login_skips_transport_update_in_debug_mode(self):
+        """Test that _re_login skips transport update in debug test mode."""
+        manager = self._make_manager()
+        manager.debug_test_mode = True
+
+        with patch(PATCH_LOGIN) as mock_login:
+            def login_side_effect():
+                manager.token = "new_token"
+                return True
+            mock_login.side_effect = login_side_effect
+
+            with patch.object(manager._transport, 'update_token') as mock_update:
+                result = manager._re_login()
+
+        assert result is True
+        mock_update.assert_not_called()


### PR DESCRIPTION
Fixes High #2 from code review: **Token refresh / auth retry**

Tokens were fetched once at login with no refresh mechanism. If the token expired during runtime, all REST API calls and WebSocket reconnections would fail silently until a full HA restart.

## Changes

### `helpers.py`
- Return actual HTTP status code on non-200 responses (was returning `None` for error codes)

### `pydreo/__init__.py`
- **`_re_login()`** — Re-authenticates and updates the WebSocket transport token
- **`call_dreo_api()`** — Detects 401 responses and automatically retries once after re-login (login API itself is excluded to prevent infinite loops)

### `commandtransport.py`
- **`update_token()`** — Allows the PyDreo manager to inject a refreshed token
- **`_start_websocket()`** — Restructured to rebuild the WebSocket URL on each reconnect attempt, picking up any token updates. Previously the URL was built once and reused for all reconnection attempts.

## Tests

10 new tests:
- 401 retry with successful re-login
- No retry on login API itself (prevents infinite loop)
- No retry when re-login fails
- No retry on 200 (no false positives)
- `_re_login` updates transport token
- `_re_login` failure returns False
- `_re_login` skips transport update in debug mode
- `update_token` updates stored token
- WebSocket reconnect picks up fresh token
- URL format test updated for new loop structure