### PR TITLE
Fix security: diagnostics data leak, incomplete log redaction, username logging

### DIFF
--- a/custom_components/dreo/__init__.py
+++ b/custom_components/dreo/__init__.py
@@ -17,7 +17,6 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     "HomeAssistant EntryPoint"
     _LOGGER.debug("async_setup_entry: Starting setup")
 
-    _LOGGER.debug("async_setup_entry: Username: %s", config_entry.data.get(CONF_USERNAME))
     username = config_entry.data.get(CONF_USERNAME)
     password = config_entry.data.get(CONF_PASSWORD)
     auto_reconnect = config_entry.options.get(CONF_AUTO_RECONNECT)

--- a/custom_components/dreo/diagnostics.py
+++ b/custom_components/dreo/diagnostics.py
@@ -29,7 +29,16 @@ KEYS_TO_REDACT = {
     "_token",
     "access_token",
     "productId",
-    "deviceId"
+    "deviceId",
+}
+
+# Keys whose values are non-serializable objects (live references, locks, callbacks)
+# and should be excluded entirely from diagnostics output.
+KEYS_TO_EXCLUDE = {
+    "_dreo",
+    "_device_definition",
+    "_lock",
+    "_attr_cbs",
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -54,8 +63,12 @@ def _get_diagnostics(pydreo_manager: PyDreo) -> dict[str, Any]:
 
     return data
 
+def _is_json_serializable(value) -> bool:
+    """Check if a value is a JSON-safe primitive type."""
+    return isinstance(value, (str, int, float, bool, type(None)))
+
 def _redact_values(data) -> dict:
-    """Rebuild and redact values of a dictionary, recursively"""
+    """Rebuild and redact values of a dictionary, recursively."""
 
     if not isinstance(data, dict):
         return data
@@ -63,19 +76,20 @@ def _redact_values(data) -> dict:
     new_data = {}
 
     for key, item in data.items():
-        if key not in KEYS_TO_REDACT:
-            if isinstance(item, dict):
-                new_data[key] = _redact_values(item)
-            elif isinstance(item, list):
-                new_data[key] = []
-                for listitem in item:
-                    if isinstance(listitem, dict):
-                        new_data[key].append(_redact_values(listitem))
-                    else:
-                        new_data[key].append(listitem)
-            else:
-                new_data[key] = item
-        else:
+        if key in KEYS_TO_EXCLUDE:
+            continue
+        if key in KEYS_TO_REDACT:
             new_data[key] = REDACTED
+        elif isinstance(item, dict):
+            new_data[key] = _redact_values(item)
+        elif isinstance(item, list):
+            new_data[key] = [
+                _redact_values(li) if isinstance(li, dict) else li
+                for li in item
+                if _is_json_serializable(li) or isinstance(li, (dict, list))
+            ]
+        elif _is_json_serializable(item):
+            new_data[key] = item
+        # Skip non-serializable values (objects, locks, callbacks, etc.)
 
     return new_data

--- a/custom_components/dreo/pydreo/helpers.py
+++ b/custom_components/dreo/pydreo/helpers.py
@@ -93,7 +93,10 @@ class Helpers:
                         '(?<=authKey": ")|',
                         '(?<=uuid": ")|',
                         '(?<=cid": ")|',
-                        '(?<=authorization": "))',
+                        '(?<=authorization": ")|',
+                        '(?<=client_secret": ")|',
+                        '(?<=client_id": ")|',
+                        '(?<=himei": "))',
                         '[^"]+',
                     )
                 ),


### PR DESCRIPTION
## Summary

Fixes three security issues identified during code review:

### S1 — Diagnostics leaks non-serializable objects
`diagnostics.py:52` passed `device.__dict__` through `_redact_values()`, which only handles dict/list/scalar types. Non-serializable objects like `_dreo` (live PyDreo with credentials), `_lock`, `_device_definition`, and `_attr_cbs` fell through unchanged.

**Fix**: Added `KEYS_TO_EXCLUDE` set for known non-serializable keys, and a `_is_json_serializable()` guard that skips any value that isn't a JSON-safe primitive. Non-serializable values are now silently dropped from diagnostics output.

### S2 — Incomplete log redaction in helpers.py
The `redactor()` regex covered `token`, `password`, `email`, etc., but missed `client_secret`, `client_id`, and `himei` — all present in the login request body.

**Fix**: Added these three fields to the redaction regex.

### S4 — Username logged in plaintext (#589)
`__init__.py:20` logged the user's email in plaintext at every startup via debug logging.

**Fix**: Removed the log line (it had no debugging value).

## Testing
- All 358 tests pass (2 pre-existing errors in debug test mode on Windows unchanged)
- Verified diagnostics, helpers, and init tests specifically

Closes #589