### PR TITLE
Enable light platform for air circulators

### DIFF
--- a/custom_components/dreo/__init__.py
+++ b/custom_components/dreo/__init__.py
@@ -74,7 +74,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         platforms.add(Platform.SWITCH)
         platforms.add(Platform.NUMBER)
 
-    if (DreoDeviceType.CEILING_FAN in device_types):
+    if (DreoDeviceType.CEILING_FAN in device_types or
+        DreoDeviceType.AIR_CIRCULATOR in device_types):
         platforms.add(Platform.LIGHT)
 
     if (DreoDeviceType.HEATER in device_types or 

--- a/tests/dreo/test_init.py
+++ b/tests/dreo/test_init.py
@@ -164,6 +164,43 @@ class TestInit:
         assert Platform.SWITCH in platforms
         assert Platform.NUMBER in platforms
 
+    def test_successful_setup_with_air_circulator(self):
+        """Test successful setup with an AIR_CIRCULATOR device includes LIGHT platform."""
+        from custom_components.dreo import async_setup_entry
+        from custom_components.dreo.pydreo.constant import DreoDeviceType
+        from homeassistant.const import Platform
+
+        mock_hass = MagicMock()
+        mock_hass.data = {}
+        mock_hass.async_add_executor_job = AsyncMock(side_effect=[True, True])
+        mock_hass.config_entries = MagicMock()
+        mock_hass.config_entries.async_forward_entry_setups = AsyncMock()
+
+        mock_entry = MagicMock()
+        mock_entry.data = {"username": "test@example.com", "password": "password"}
+        mock_entry.options = {}
+        mock_entry.add_update_listener = MagicMock(return_value=MagicMock())
+        mock_entry.async_on_unload = MagicMock()
+
+        mock_device = MagicMock()
+        mock_device.type = DreoDeviceType.AIR_CIRCULATOR
+
+        mock_pydreo = MagicMock()
+        mock_pydreo.devices = [mock_device]
+        mock_pydreo.start_transport = MagicMock()
+        mock_pydreo.auto_reconnect = True
+
+        with patch('custom_components.dreo.pydreo.PyDreo', return_value=mock_pydreo):
+            result = asyncio.run(async_setup_entry(mock_hass, mock_entry))
+
+        assert result is True
+        platforms = mock_hass.data["dreo"]["platforms"]
+        assert Platform.FAN in platforms
+        assert Platform.LIGHT in platforms
+        assert Platform.SENSOR in platforms
+        assert Platform.SWITCH in platforms
+        assert Platform.NUMBER in platforms
+
     def test_successful_setup_with_humidifier(self):
         """Test successful setup with a HUMIDIFIER device."""
         from custom_components.dreo import async_setup_entry


### PR DESCRIPTION
Fixes #485

## Problem
The `Platform.LIGHT` was only registered for `CEILING_FAN` devices in `__init__.py`. Air circulators like the DR-HPF008S have full RGB atmosphere light support in `PyDreoAirCirculator` (atmon, atmbri, atmcolor, atmmode), but the light entity was never created in Home Assistant because the platform wasn't loaded.

## Fix
Add `AIR_CIRCULATOR` to the `Platform.LIGHT` registration condition alongside `CEILING_FAN`.

## Changes
- **`custom_components/dreo/__init__.py`** — Include `AIR_CIRCULATOR` in `Platform.LIGHT` condition
- **`tests/dreo/test_init.py`** — Add `test_successful_setup_with_air_circulator` verifying `Platform.LIGHT` is registered

## Testing
- All 359 tests pass
- Pylint 10.00/10
- Existing HPF008S integration test already verifies RGB light entity creation and commands