### PR TITLE
Fix HAF004S vertical angle range and add 5-degree step to angle entities

### DIFF
--- a/custom_components/dreo/number.py
+++ b/custom_components/dreo/number.py
@@ -42,6 +42,7 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         icon="mdi:angle-acute",
         min_value=-60,
         max_value=60,
+        step=5,
         exists_fn=lambda device: device.is_feature_supported("horizontal_angle"),
     ),
     DreoNumberEntityDescription(
@@ -51,6 +52,7 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         icon="mdi:angle-acute",
         min_value=0,
         max_value=90,
+        step=5,
         exists_fn=lambda device: device.is_feature_supported("vertical_angle"),
     ),
     DreoNumberEntityDescription(
@@ -60,6 +62,7 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         icon="mdi:vector-radius",
         min_value=-60,
         max_value=60,
+        step=5,
         exists_fn=lambda device: device.is_feature_supported("horizontal_osc_angle_left"),
     ),
     DreoNumberEntityDescription(
@@ -69,6 +72,7 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         icon="mdi:vector-radius",
         min_value=-60,
         max_value=60,
+        step=5,
         exists_fn=lambda device: device.is_feature_supported("horizontal_osc_angle_right"),
     ),
     DreoNumberEntityDescription(
@@ -78,6 +82,7 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         icon="mdi:vector-radius",
         min_value=0,
         max_value=90,
+        step=5,
         exists_fn=lambda device: device.is_feature_supported("vertical_osc_angle_top"),
     ),
     DreoNumberEntityDescription(
@@ -87,6 +92,7 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         icon="mdi:vector-radius",
         min_value=0,
         max_value=90,
+        step=5,
         exists_fn=lambda device: device.is_feature_supported("vertical_osc_angle_bottom"),
     ),
     DreoNumberEntityDescription(
@@ -106,6 +112,7 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         icon="mdi:angle-acute",
         min_value=-60,
         max_value=60,
+        step=5,
         exists_fn=lambda device: device.is_feature_supported("horizontal_oscillation_angle"),
     ),
     DreoNumberEntityDescription(
@@ -115,6 +122,7 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         icon="mdi:angle-acute",
         min_value=0,
         max_value=90,
+        step=5,
         exists_fn=lambda device: device.is_feature_supported("vertical_oscillation_angle"),
     ),
     DreoNumberEntityDescription(
@@ -156,6 +164,7 @@ def get_entries(pydreo_devices : list[PyDreoBaseDevice]) -> list[DreoNumberHA]:
                         icon=number_definition.icon,
                         min_value=device_range[0],
                         max_value=device_range[1],
+                        step=number_definition.step,
                         device_class=number_definition.device_class,
                         native_unit_of_measurement=number_definition.native_unit_of_measurement,
                         exists_fn=number_definition.exists_fn,

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -184,6 +184,11 @@ SUPPORTED_DEVICES = {
 
     # Air Circulators
     "DR-HAF": DreoDeviceDetails(device_type=DreoDeviceType.AIR_CIRCULATOR),
+    "DR-HAF004S": DreoDeviceDetails(
+        device_type=DreoDeviceType.AIR_CIRCULATOR,
+        device_ranges={
+            VERTICAL_ANGLE_RANGE: (0, 90)
+        }),
     "DR-HPF": DreoDeviceDetails(device_type=DreoDeviceType.AIR_CIRCULATOR),
     # HPF-series devices: The API returns controlsConf with only a template reference
     # (e.g. {"template": "DR-HPF002S"}) and no control/schedule.modes data, so

--- a/tests/pydreo/test_pydreoaircirculator.py
+++ b/tests/pydreo/test_pydreoaircirculator.py
@@ -25,13 +25,13 @@ class TestPyDreoAirCirculator(TestBase):
 
         # Test initial state values
         assert fan.horizontal_angle_range == (-60, 60)
-        assert fan.vertical_angle_range == (-30, 90)
+        assert fan.vertical_angle_range == (0, 90)
         assert fan.speed_range == (1, 9)
         assert fan.preset_modes == ['normal', 'natural', 'sleep', 'auto', 'turbo', 'custom']
         assert fan.oscillating is True
         assert fan.vertically_oscillating is True
-        assert fan.vertical_osc_angle_top_range == (-30, 90)
-        assert fan.vertical_osc_angle_bottom_range == (-30, 90)
+        assert fan.vertical_osc_angle_top_range == (0, 90)
+        assert fan.vertical_osc_angle_bottom_range == (0, 90)
         assert fan.horizontally_oscillating is False
         assert fan.horizontal_osc_angle_left_range == (-60, 60)
         assert fan.horizontal_osc_angle_right_range == (-60, 60)


### PR DESCRIPTION
## Changes

- **HAF004S vertical angle range**: Add explicit \DR-HAF004S\ entry in \models.py\ with \VERTICAL_ANGLE_RANGE: (0, 90)\ to prevent negative vertical angles that the Dreo app does not allow. The parser produces (-30, 90) from the API's \erAngle=120, verZeroAngle=30\, but the physical device only tilts upward from horizon.

- **5-degree step on angle entities**: All 8 angle number entities (horizontal/vertical position + oscillation angles) now use \step=5\ matching the device's \stepAngle\ from the API. The existing Oscillation Angle entity keeps its \step=30\.

- **Bug fix: step lost on range override**: When a device has a range override from \models.py\, the code creates a new \DreoNumberEntityDescription\ but wasn't copying \step\ from the original definition. This caused step to silently revert to 1 for any model with device_ranges.