### PR TITLE
fix: return HumidifierEntityFeature enum instead of int from supported_features

### DIFF
--- a/custom_components/dreo/dreodehumidifier.py
+++ b/custom_components/dreo/dreodehumidifier.py
@@ -53,12 +53,12 @@ class DreoDehumidifierHA(DreoBaseDeviceHA, HumidifierEntity):
         return HumidifierDeviceClass.DEHUMIDIFIER
 
     @property
-    def supported_features(self) -> int:
+    def supported_features(self) -> HumidifierEntityFeature:
         """Return the list of supported features."""
-        supported_features = 0
+        supported_features = HumidifierEntityFeature(0)
         if self.device.modes is not None:
             supported_features |= HumidifierEntityFeature.MODES
-        
+
         return supported_features
     
     @property

--- a/custom_components/dreo/dreohumidifier.py
+++ b/custom_components/dreo/dreohumidifier.py
@@ -48,9 +48,9 @@ class DreoHumidifierHA(DreoBaseDeviceHA, HumidifierEntity):
         )
 
     @property
-    def supported_features(self) -> int:
+    def supported_features(self) -> HumidifierEntityFeature:
         """Return the list of supported features."""
-        supported_features = 0
+        supported_features = HumidifierEntityFeature(0)
         if self.device.modes is not None:
             supported_features |= HumidifierEntityFeature.MODES
 


### PR DESCRIPTION
## Summary

- `DreoHumidifierHA.supported_features` and `DreoDehumidifierHA.supported_features` return `HumidifierEntityFeature(0)` instead of bare `int(0)`

## Problem

HA Core 2026.3+ changed `humidifier/__init__.py` line 183 to use:
```python
if HumidifierEntityFeature.MODES in self.supported_features:
```

The `in` operator requires a flags enum instance, not a plain int. When `supported_features` returns `0` (for devices like DR-HHM015S that have no modes), this causes:

```
TypeError: argument of type 'int' is not a container or iterable
```

The humidifier entity fails to register entirely.

## Fix

Return `HumidifierEntityFeature(0)` instead of `0` in both `dreohumidifier.py` and `dreodehumidifier.py`. The `|=` operator still works identically with the enum base.

## Test plan

- [ ] Verify DR-HHM015S (no modes) creates humidifier entity without errors
- [ ] Verify DR-HHM006S (with modes) still shows mode controls
- [ ] Verify dehumidifier entities still register correctly