### PR TITLE
Add Tower Fan DR-HTF024S

### DIFF
--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -15,6 +15,7 @@ This document lists all Dreo device models that have been tested and confirmed t
 - DR-HTF009S
 - DR-HTF010S
 - DR-HTF018S
+- DR-HTF024S
 
 ### Air Circulators
 

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -202,6 +202,17 @@ SUPPORTED_DEVICES = {
         device_ranges={
             SPEED_RANGE: (1, 9)
         }),
+    "DR-HTF024S": DreoDeviceDetails(
+        device_type=DreoDeviceType.TOWER_FAN,
+        preset_modes=[
+            ("normal", 1),
+            ("natural", 2),
+            ("sleep", 3),
+            ("auto", 4),
+        ],
+        device_ranges={
+            SPEED_RANGE: (1, 9)
+        }),
 
     # Air Circulators
     "DR-HAF": DreoDeviceDetails(device_type=DreoDeviceType.AIR_CIRCULATOR),

--- a/tests/dreo/integrationtests/test_dreotowerfan.py
+++ b/tests/dreo/integrationtests/test_dreotowerfan.py
@@ -163,3 +163,79 @@ class TestDreoTowerFan(IntegrationTestBase):
             fan.oscillating = False
             mock_send_command.assert_called_once_with(fan, {SHAKEHORIZON_KEY: False})
         fan.handle_server_update({REPORTED_KEY: {SHAKEHORIZON_KEY: False}})
+
+    def test_HTF024S(self):  # pylint: disable=invalid-name
+        """Load HTF024S fan and test sending commands."""
+
+        self.get_devices_file_name = "get_devices_HTF024S.json"
+        self.pydreo_manager.load_devices()
+        assert len(self.pydreo_manager.devices) == 1
+        fan = self.pydreo_manager.devices[0]
+
+        # Test initial state values - speed_range and preset_modes come from SUPPORTED_DEVICES
+        # since controlsConf only has a template reference
+        assert fan.speed_range == (1, 9)
+        assert fan.preset_modes == ["normal", "natural", "sleep", "auto"]
+        assert fan.model == "DR-HTF024S"
+        assert fan.serial_number is not None
+        assert fan.is_on is True
+        assert fan.oscillating is False
+
+        # Test power commands
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.is_on = False
+            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: False})
+        fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: False}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.is_on = True
+            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: True})
+        fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: True}})
+
+        # Test all preset modes
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "natural"
+            mock_send_command.assert_called_once_with(fan, {WINDTYPE_KEY: 2})
+        fan.handle_server_update({REPORTED_KEY: {WINDTYPE_KEY: 2}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "sleep"
+            mock_send_command.assert_called_once_with(fan, {WINDTYPE_KEY: 3})
+        fan.handle_server_update({REPORTED_KEY: {WINDTYPE_KEY: 3}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "auto"
+            mock_send_command.assert_called_once_with(fan, {WINDTYPE_KEY: 4})
+        fan.handle_server_update({REPORTED_KEY: {WINDTYPE_KEY: 4}})
+
+        with pytest.raises(ValueError):
+            fan.preset_mode = "not_a_mode"
+
+        # Test speed commands
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.fan_speed = 5
+            mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 5})
+        fan.handle_server_update({REPORTED_KEY: {WINDLEVEL_KEY: 5}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.fan_speed = 9
+            mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 9})
+        fan.handle_server_update({REPORTED_KEY: {WINDLEVEL_KEY: 9}})
+
+        # Test speed boundaries
+        with pytest.raises(ValueError):
+            fan.fan_speed = 0
+
+        with pytest.raises(ValueError):
+            fan.fan_speed = 10
+
+        # Test oscillation
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.oscillating = True
+            mock_send_command.assert_called_once_with(fan, {SHAKEHORIZON_KEY: True})
+        fan.handle_server_update({REPORTED_KEY: {SHAKEHORIZON_KEY: True}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.oscillating = False
+            mock_send_command.assert_called_once_with(fan, {SHAKEHORIZON_KEY: False})
+        fan.handle_server_update({REPORTED_KEY: {SHAKEHORIZON_KEY: False}})

--- a/tests/pydreo/api_responses/get_device_state_HTF024S_1.json
+++ b/tests/pydreo/api_responses/get_device_state_HTF024S_1.json
@@ -1,0 +1,108 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "mixed": {
+      "wifi_ssid": "**REDACTED**",
+      "mcu_hardware_model": {
+        "state": "SC95F8613B/US",
+        "timestamp": 1776382926
+      },
+      "windlevel": {
+        "state": 9,
+        "timestamp": 1776382990
+      },
+      "wifi_rssi": {
+        "state": -38,
+        "timestamp": 1776382926
+      },
+      "windtype": {
+        "state": 1,
+        "timestamp": 1776382926
+      },
+      "poweron": {
+        "state": true,
+        "timestamp": 1776382926
+      },
+      "scheid": {
+        "state": 0,
+        "timestamp": 1776382926
+      },
+      "timeron": {
+        "state": {
+          "du": 0,
+          "ts": 1776382925
+        },
+        "timestamp": null
+      },
+      "scheon": {
+        "state": false,
+        "timestamp": 1776382926
+      },
+      "voiceon": {
+        "state": false,
+        "timestamp": 1776382968
+      },
+      "wrong": {
+        "state": 0,
+        "timestamp": 1776382926
+      },
+      "module_firmware_version": {
+        "state": "3.8.0",
+        "timestamp": 1776382926
+      },
+      "mcuon": {
+        "state": true,
+        "timestamp": 1776382926
+      },
+      "connected": {
+        "state": true,
+        "timestamp": 1776382926
+      },
+      "timeroff": {
+        "state": {
+          "du": 0,
+          "ts": 1776382925
+        },
+        "timestamp": null
+      },
+      "shakehorizon": {
+        "state": false,
+        "timestamp": 1776383008
+      },
+      "network_latency": {
+        "state": 38,
+        "timestamp": 1776382927
+      },
+      "_ota": {
+        "state": 0,
+        "timestamp": 1776382926
+      },
+      "module_hardware_model": {
+        "state": "HeFi",
+        "timestamp": 1776382926
+      },
+      "mcu_firmware_version": {
+        "state": "0.2.1",
+        "timestamp": 1776382926
+      },
+      "temperature": {
+        "state": 82,
+        "timestamp": 1776382926
+      },
+      "module_hardware_mac": "**REDACTED**",
+      "ledalwayson": {
+        "state": false,
+        "timestamp": 1776382926
+      },
+      "tempoffset": {
+        "state": 0,
+        "timestamp": 1776382926
+      }
+    },
+    "sn": "HTF024S_1",
+    "productId": "**REDACTED**",
+    "region": "us-east-2/emq",
+    "deviceInfo": null
+  }
+}

--- a/tests/pydreo/api_responses/get_devices_HTF024S.json
+++ b/tests/pydreo/api_responses/get_devices_HTF024S.json
@@ -1,0 +1,65 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "currentPage": 1,
+    "pageSize": 100,
+    "totalNum": 1,
+    "totalPage": 1,
+    "familyRooms": null,
+    "list": [
+      {
+        "deviceId": "2044924297905967106",
+        "sn": "HTF024S_1",
+        "brand": "Dreo",
+        "model": "DR-HTF024S",
+        "productId": "**REDACTED**",
+        "productName": "Tower Fan",
+        "deviceName": "DEBUGTEST - Tower Fan - DR-HTF024S",
+        "shared": false,
+        "series": null,
+        "seriesName": "TF554S",
+        "type": 0,
+        "owner": true,
+        "familyId": null,
+        "familyName": null,
+        "roomId": null,
+        "roomName": null,
+        "roomNameI18Key": "",
+        "color": "b",
+        "widgetOnImage": "https://resources.dreo-tech.com/app/preSigned202512/31a83a64fd779e4860bb3a0a0996cb0d58.png",
+        "widgetOffImage": "https://resources.dreo-tech.com/app/preSigned202512/311032ffa8e5e94fc68da491e9ab1cbfb5.png",
+        "widgetAbnormalImage": null,
+        "variantIconMd5": null,
+        "controlsConf": {},
+        "mainConf": {
+          "isSmart": true,
+          "isWifi": true,
+          "isBluetooth": null,
+          "isVoiceControl": true
+        },
+        "resourcesConf": {
+          "imageSmallSrc": "https://resources.dreo-tech.com/app/preSigned202512/31ffb8a097ed61438da52d0e82c7a769c8.png",
+          "imageFullSrc": "https://resources.dreo-tech.com/app/preSigned202512/318e4c8286721d47a29de311af035cd7a2.lottie.zip",
+          "imageSmallDarkSrc": null,
+          "imageFullDarkSrc": null
+        },
+        "servicesConf": [],
+        "userManuals": [
+          {
+            "url": "https://resources.dreo-tech.com/app/preSigned202601/28af49b43c3a704d3eb397aecd32d55090.pdf",
+            "icon": null,
+            "desc": "DR-HTF024S User Manual",
+            "lang": "en"
+          },
+          {
+            "url": "https://resources.dreo-tech.com/app/preSigned202604/1596e2954ab3d64abbb9b7aafac55d76ea.pdf",
+            "icon": null,
+            "desc": "DR-HTF024S_User-Manual_V1",
+            "lang": "en"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/pydreo/test_pydreotowerfan.py
+++ b/tests/pydreo/test_pydreotowerfan.py
@@ -397,3 +397,80 @@ class TestPyDreoTowerFan(TestBase):
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.oscillating = False
             mock_send_command.assert_called_once_with(fan, {SHAKEHORIZON_KEY: False})
+
+    def test_HTF024S(self):  # pylint: disable=invalid-name
+        """Load HTF024S tower fan and test sending commands."""
+
+        self.get_devices_file_name = "get_devices_HTF024S.json"
+        self.pydreo_manager.load_devices()
+        assert len(self.pydreo_manager.devices) == 1
+        fan = self.pydreo_manager.devices[0]
+
+        # Test initial state values - speed_range and preset_modes come from SUPPORTED_DEVICES
+        # since controlsConf only has a template reference
+        assert fan.speed_range == (1, 9)
+        assert fan.preset_modes == ["normal", "natural", "sleep", "auto"]
+        assert fan.model == "DR-HTF024S"
+        assert fan.device_name is not None
+        assert fan.serial_number is not None
+        assert fan.is_on is True
+        assert fan.fan_speed == 9
+        assert fan.oscillating is False
+
+        # Test power commands
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.is_on = False
+            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: False})
+        fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: False}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.is_on = True
+            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: True})
+        fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: True}})
+
+        # Test preset mode commands
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "natural"
+            mock_send_command.assert_called_once_with(fan, {WINDTYPE_KEY: 2})
+        fan.handle_server_update({REPORTED_KEY: {WINDTYPE_KEY: 2}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "sleep"
+            mock_send_command.assert_called_once_with(fan, {WINDTYPE_KEY: 3})
+        fan.handle_server_update({REPORTED_KEY: {WINDTYPE_KEY: 3}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "auto"
+            mock_send_command.assert_called_once_with(fan, {WINDTYPE_KEY: 4})
+        fan.handle_server_update({REPORTED_KEY: {WINDTYPE_KEY: 4}})
+
+        with pytest.raises(ValueError):
+            fan.preset_mode = "not_a_mode"
+
+        # Test fan speed commands (1-9 speed range)
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.fan_speed = 5
+            mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 5})
+        fan.handle_server_update({REPORTED_KEY: {WINDLEVEL_KEY: 5}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.fan_speed = 1
+            mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 1})
+        fan.handle_server_update({REPORTED_KEY: {WINDLEVEL_KEY: 1}})
+
+        # Test speed boundaries
+        with pytest.raises(ValueError):
+            fan.fan_speed = 0
+
+        with pytest.raises(ValueError):
+            fan.fan_speed = 10
+
+        # Test oscillation commands
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.oscillating = True
+            mock_send_command.assert_called_once_with(fan, {SHAKEHORIZON_KEY: True})
+        fan.handle_server_update({REPORTED_KEY: {SHAKEHORIZON_KEY: True}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.oscillating = False
+            mock_send_command.assert_called_once_with(fan, {SHAKEHORIZON_KEY: False})


### PR DESCRIPTION
This pull request adds support for the Dreo DR-HTF024S tower fan model to the codebase. It updates the supported models documentation, device details, and includes comprehensive integration and unit tests with new API response fixtures for this device.

**Support for DR-HTF024S Tower Fan**

* Added the `DR-HTF024S` model to the list of supported devices in `SUPPORTED_MODELS.md` and defined its device details (type, preset modes, speed range) in `models.py`. [[1]](diffhunk://#diff-bf75ffb19fafc96f30f795238ab851d082648bf9c6ac7b9db0e6ce8dadfa5becR18) [[2]](diffhunk://#diff-cdadd0568e4a8350663bd47160470780391d85a446d82f6a2b9eb7254435c4f6R205-R215)

**Testing and Fixtures**

* Added integration and unit tests for `DR-HTF024S` in `test_dreotowerfan.py` and `test_pydreotowerfan.py`, covering state initialization, power, preset modes, speed commands, boundary checks, and oscillation. [[1]](diffhunk://#diff-dfbb9e5f71f8a92e1acbdb4489432eb091208ffea639a34311c95204af8cbdcdR166-R241) [[2]](diffhunk://#diff-d659d9dbe2ef0935f69e93cdd2624b080e0b62ff29ae5424681f270376d4fcd4R400-R476)
* Introduced new API response fixtures for the device list and device state of `DR-HTF024S` to enable realistic test scenarios. [[1]](diffhunk://#diff-a7033b65ef28c73f01c9d8d395d663c2ccc370b0d82bc030b3cc6f6687ae7d64R1-R65) [[2]](diffhunk://#diff-2cf8cfc1a3d40b744e0b3e3b592f481986b0e635fcca39ec51ac12f115da55a6R1-R108)

Fixes #614 