### PR TITLE
Add Spanish and German translations

### DIFF
--- a/custom_components/dreo/translations/de.json
+++ b/custom_components/dreo/translations/de.json
@@ -1,0 +1,29 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Dreo-Kontodaten eingeben",
+        "data": {
+          "username": "E-Mail-Adresse",
+          "password": "Passwort"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Authentifizierung fehlgeschlagen."
+    },
+    "abort": {
+      "single_instance_allowed": "Es ist nur eine Instanz erlaubt."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Dreo-Optionen",
+        "data": {
+          "auto_reconnect": "Automatisch neu verbinden, wenn die WebSocket-Verbindung unterbrochen wird."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/dreo/translations/es.json
+++ b/custom_components/dreo/translations/es.json
@@ -1,0 +1,29 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Introduce las credenciales de tu cuenta Dreo",
+        "data": {
+          "username": "Correo electrónico",
+          "password": "Contraseña"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Error de autenticación."
+    },
+    "abort": {
+      "single_instance_allowed": "Solo se permite una instancia."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Opciones de Dreo",
+        "data": {
+          "auto_reconnect": "Reconectar automáticamente si se pierde la conexión WebSocket."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Add Spanish (es.json) and German (de.json) translation files for the integration UI.

## Details
- Both files cover the config flow (login screen, error messages, abort messages) and options step (auto-reconnect toggle)
- Structure matches the existing en.json and it.json translations
- Based on analysis of GitHub issues showing users writing in Spanish and German