### PR TITLE
Improve test coverage: heater, climate, fan, humidifier platforms

### DIFF
--- a/tests/dreo/test_climate.py
+++ b/tests/dreo/test_climate.py
@@ -1,7 +1,9 @@
 """Tests for the Dreo Climate platform (climate.py get_entries)."""
-from unittest.mock import patch
+import asyncio
+from unittest.mock import patch, MagicMock, AsyncMock
 
 from custom_components.dreo import climate
+from custom_components.dreo.const import DOMAIN, PYDREO_MANAGER
 
 from .testdevicebase import TestDeviceBase
 from .custommocks import PyDreoDeviceMock
@@ -9,7 +11,10 @@ from .custommocks import PyDreoDeviceMock
 from custom_components.dreo.pydreo.constant import (
     HEAT_RANGE,
     ECOLEVEL_RANGE,
-    DreoHeaterMode
+    DreoHeaterMode,
+    DreoDeviceType,
+    DreoACMode,
+    DreoACFanMode,
 )
 
 PATCH_BASE_PATH = 'homeassistant.helpers.entity.Entity'
@@ -94,3 +99,111 @@ class TestDreoClimatePlatform(TestDeviceBase):
         """Test get_entries with empty device list."""
         entities = climate.get_entries([])
         assert len(entities) == 0
+
+    def test_climate_get_entries_air_conditioner(self):
+        """Test that get_entries creates an AC entity for air conditioner devices."""
+        with patch(PATCH_UPDATE_HA_STATE):
+            device = self.create_mock_device(
+                name="Test AC",
+                serial_number="AC001",
+                type=DreoDeviceType.AIR_CONDITIONER,
+                features={
+                    "poweron": True,
+                    "temperature": 72,
+                    "target_temperature": 70,
+                    "mode": DreoACMode.COOL,
+                    "oscon": False,
+                    "fan_mode": DreoACFanMode.LOW,
+                },
+                modes=[DreoACMode.COOL, DreoACMode.DRY, DreoACMode.FAN],
+                swing_modes=None,
+            )
+
+            entities = climate.get_entries([device])
+            assert len(entities) == 1
+            assert type(entities[0]).__name__ == "DreoAirConditionerHA"
+
+    def test_climate_get_entries_heater_and_ac(self):
+        """Test get_entries with both heater and AC devices."""
+        with patch(PATCH_UPDATE_HA_STATE):
+            heater = self.create_mock_device(
+                name="Test Heater",
+                serial_number="HTR001",
+                type=DreoDeviceType.HEATER,
+                features={
+                    "poweron": True,
+                    "temperature": 72,
+                    "device_ranges": {HEAT_RANGE: (1, 3), ECOLEVEL_RANGE: (41, 95)},
+                    "htalevel": 2,
+                    "ecolevel": 70,
+                    "mode": DreoHeaterMode.HOTAIR,
+                },
+                modes=[
+                    DreoHeaterMode.COOLAIR,
+                    DreoHeaterMode.HOTAIR,
+                    DreoHeaterMode.ECO,
+                    DreoHeaterMode.OFF,
+                ],
+                swing_modes=None,
+            )
+            ac = self.create_mock_device(
+                name="Test AC",
+                serial_number="AC001",
+                type=DreoDeviceType.AIR_CONDITIONER,
+                features={
+                    "poweron": True,
+                    "temperature": 72,
+                    "target_temperature": 70,
+                    "mode": DreoACMode.COOL,
+                    "oscon": False,
+                    "fan_mode": DreoACFanMode.LOW,
+                },
+                modes=[DreoACMode.COOL, DreoACMode.DRY, DreoACMode.FAN],
+                swing_modes=None,
+            )
+
+            entities = climate.get_entries([heater, ac])
+            assert len(entities) == 2
+            type_names = [type(e).__name__ for e in entities]
+            assert "DreoHeaterHA" in type_names
+            assert "DreoAirConditionerHA" in type_names
+
+    def test_async_setup_entry(self):
+        """Test async_setup_entry sets up climate entities from hass.data."""
+        with patch(PATCH_UPDATE_HA_STATE):
+            heater = self.create_mock_device(
+                name="Test Heater",
+                serial_number="HTR001",
+                type=DreoDeviceType.HEATER,
+                features={
+                    "poweron": True,
+                    "temperature": 72,
+                    "device_ranges": {HEAT_RANGE: (1, 3), ECOLEVEL_RANGE: (41, 95)},
+                    "htalevel": 2,
+                    "ecolevel": 70,
+                    "mode": DreoHeaterMode.HOTAIR,
+                },
+                modes=[
+                    DreoHeaterMode.COOLAIR,
+                    DreoHeaterMode.HOTAIR,
+                    DreoHeaterMode.ECO,
+                    DreoHeaterMode.OFF,
+                ],
+                swing_modes=None,
+            )
+
+            mock_pydreo = MagicMock()
+            mock_pydreo.devices = [heater]
+
+            mock_hass = MagicMock()
+            mock_hass.data = {DOMAIN: {PYDREO_MANAGER: mock_pydreo}}
+
+            mock_config_entry = MagicMock()
+            mock_add_entities = MagicMock()
+
+            asyncio.run(climate.async_setup_entry(mock_hass, mock_config_entry, mock_add_entities))
+
+            mock_add_entities.assert_called_once()
+            entities = mock_add_entities.call_args[0][0]
+            assert len(entities) == 1
+            assert type(entities[0]).__name__ == "DreoHeaterHA"

--- a/tests/dreo/test_fan.py
+++ b/tests/dreo/test_fan.py
@@ -194,3 +194,37 @@ class TestDreoFanHA(TestDeviceBase):
             # Test mid-range
             test_fan.set_percentage(50)
             assert mocked_pydreo_fan.fan_speed == 5
+
+    def test_fan_entries_evaporative_cooler(self):
+        """Test the creation of fan entry for evaporative cooler."""
+        with patch(PATCH_UPDATE_HA_STATE):
+            mocked_devices = [
+                self.create_mock_device(name="Test Cooler", type="Evaporative Cooler"),
+            ]
+            entity_list = fan.get_entries(mocked_devices)
+            assert len(entity_list) == 1
+
+    def test_async_setup_entry(self):
+        """Test async_setup_entry sets up fan entities from hass.data."""
+        import asyncio
+        from unittest.mock import MagicMock
+        from custom_components.dreo.const import DOMAIN, PYDREO_MANAGER
+
+        with patch(PATCH_UPDATE_HA_STATE):
+            mocked_fan = self.create_mock_device(name="Test Fan", type="Tower Fan")
+
+            mock_pydreo = MagicMock()
+            mock_pydreo.devices = [mocked_fan]
+
+            mock_hass = MagicMock()
+            mock_hass.data = {DOMAIN: {PYDREO_MANAGER: mock_pydreo}}
+
+            mock_config_entry = MagicMock()
+            mock_add_entities = MagicMock()
+
+            asyncio.run(fan.async_setup_entry(mock_hass, mock_config_entry, mock_add_entities))
+
+            mock_add_entities.assert_called_once()
+            entities = mock_add_entities.call_args[0][0]
+            assert len(entities) == 1
+            assert type(entities[0]).__name__ == "DreoFanHA"

--- a/tests/dreo/test_heater.py
+++ b/tests/dreo/test_heater.py
@@ -1,12 +1,17 @@
 """Tests for the Dreo Ceiling heater HA class."""
 
+import pytest
 from custom_components.dreo import climate
 from .testdevicebase import TestDeviceBase
 from .custommocks import PyDreoDeviceMock
 
 from homeassistant.components.climate import (
     HVACMode,
-    ClimateEntityFeature
+    ClimateEntityFeature,
+    SWING_OFF,
+    SWING_ON,
+    PRESET_NONE,
+    ATTR_TEMPERATURE,
 )
 
 from custom_components.dreo.pydreo.constant import (
@@ -14,7 +19,9 @@ from custom_components.dreo.pydreo.constant import (
     ECOLEVEL_RANGE,
     PRESET_ECO,
     HeaterOscillationAngles,
-    DreoHeaterMode
+    DreoHeaterMode,
+    ANGLE_OSCANGLE_MAP,
+    OSCANGLE_ANGLE_MAP,
 )
 
 class TestDreoHeaterHA(TestDeviceBase):
@@ -317,3 +324,333 @@ class TestDreoHeaterHA(TestDeviceBase):
         test_heater.set_temperature(**{ATTR_TEMPERATURE: 71.6})
         assert mocked_pydreo_heater.ecolevel == 72
         assert test_heater.target_temperature == 72
+
+    def _create_full_heater(self, **overrides):
+        """Helper to create a heater with all modes and swing modes."""
+        features = {
+            "poweron": True,
+            "temperature": 75,
+            "device_ranges": {HEAT_RANGE: (1, 3), ECOLEVEL_RANGE: (41, 95)},
+            "htalevel": 2,
+            "ecolevel": 70,
+            "mode": DreoHeaterMode.HOTAIR,
+            "oscon": None,
+            "oscmode": None,
+            "oscangle": None,
+        }
+        features.update(overrides.pop("features_override", {}))
+        swing_modes = overrides.pop("swing_modes", [
+            HeaterOscillationAngles.OSC,
+            HeaterOscillationAngles.SIXTY,
+            HeaterOscillationAngles.NINETY,
+            HeaterOscillationAngles.ONE_TWENTY,
+        ])
+        kwargs = {
+            "name": "Test Heater",
+            "serial_number": "123456",
+            "features": features,
+            "modes": [
+                DreoHeaterMode.COOLAIR,
+                DreoHeaterMode.HOTAIR,
+                DreoHeaterMode.ECO,
+                DreoHeaterMode.OFF,
+            ],
+            "swing_modes": swing_modes,
+        }
+        kwargs.update(overrides)
+        mock = self.create_mock_device(**kwargs)
+        # Wire up device_definition to return real values
+        device_ranges = features.get("device_ranges", {})
+        mock.device_definition.device_ranges = device_ranges
+        mock.device_definition.swing_modes = swing_modes
+        mock.heat_range = device_ranges.get(HEAT_RANGE, (1, 3))
+        return mock, climate.DreoHeaterHA(mock)
+
+    def test_device_info(self):
+        """Test device_info property returns expected DeviceInfo."""
+        mock, heater = self._create_full_heater()
+        info = heater.device_info
+        assert info is not None
+
+    def test_oscon_property(self):
+        """Test oscon property returns device oscon value."""
+        mock, heater = self._create_full_heater(features_override={"oscon": True})
+        assert heater.oscon is True
+
+    def test_oscangle_property_mapped(self):
+        """Test oscangle property when value is in ANGLE_OSCANGLE_MAP."""
+        mock, heater = self._create_full_heater(features_override={"oscangle": 60})
+        assert heater.oscangle == ANGLE_OSCANGLE_MAP[60]
+
+    def test_oscangle_property_unmapped(self):
+        """Test oscangle property returns None for unmapped value."""
+        mock, heater = self._create_full_heater(features_override={"oscangle": 999})
+        assert heater.oscangle is None
+
+    def test_htalevels_count(self):
+        """Test htalevels_count returns correct count from heat_range."""
+        mock, heater = self._create_full_heater()
+        assert heater.htalevels_count == 3  # range (1,3) = 3 states
+
+    def test_extra_state_attributes(self):
+        """Test extra_state_attributes returns model."""
+        mock, heater = self._create_full_heater()
+        attrs = heater.extra_state_attributes
+        assert "model" in attrs
+
+    def test_preset_mode_when_off(self):
+        """Test preset_mode returns PRESET_NONE when device is off."""
+        mock, heater = self._create_full_heater(features_override={"poweron": False, "mode": DreoHeaterMode.OFF})
+        assert heater.preset_mode == PRESET_NONE
+
+    def test_set_preset_mode_invalid(self):
+        """Test set_preset_mode with invalid preset logs warning."""
+        mock, heater = self._create_full_heater()
+        # Should not raise, just log a warning
+        heater.set_preset_mode("INVALID_PRESET")
+        # Mode should not have changed
+        assert mock.mode == DreoHeaterMode.HOTAIR
+
+    def test_set_preset_mode_none(self):
+        """Test set_preset_mode with PRESET_NONE does nothing."""
+        mock, heater = self._create_full_heater()
+        original_mode = mock.mode
+        heater.set_preset_mode(PRESET_NONE)
+        # PRESET_NONE is not in HVAC_PRESET_TO_DREO_HEATER_MODE and is excluded from warning
+        assert mock.mode == original_mode
+
+    def test_turn_on_default(self):
+        """Test turn_on sets HOTAIR mode by default."""
+        mock, heater = self._create_full_heater(features_override={"poweron": False, "mode": DreoHeaterMode.OFF})
+        heater.turn_on()
+        assert mock.poweron is True
+        assert mock.mode == DreoHeaterMode.HOTAIR
+
+    def test_turn_on_preserves_eco_preset(self):
+        """Test turn_on preserves ECO mode when preset is ECO."""
+        mock, heater = self._create_full_heater(features_override={"mode": DreoHeaterMode.ECO})
+        heater.turn_on()
+        assert mock.poweron is True
+        assert mock.mode == DreoHeaterMode.ECO
+
+    def test_turn_on_restores_fan_only(self):
+        """Test turn_on restores FAN_ONLY if last HVAC mode was FAN_ONLY."""
+        mock, heater = self._create_full_heater(features_override={"mode": DreoHeaterMode.COOLAIR})
+        # Turn off first to set _last_hvac_mode
+        heater.turn_off()
+        assert mock.poweron is False
+        # Now turn on - should restore COOLAIR since last mode was FAN_ONLY
+        heater.turn_on()
+        assert mock.poweron is True
+        assert mock.mode == DreoHeaterMode.COOLAIR
+
+    def test_turn_on_restores_heat(self):
+        """Test turn_on restores HEAT mode if last mode was HEAT."""
+        mock, heater = self._create_full_heater(features_override={"mode": DreoHeaterMode.HOTAIR})
+        heater.turn_off()
+        heater.turn_on()
+        assert mock.mode == DreoHeaterMode.HOTAIR
+
+    def test_turn_off(self):
+        """Test turn_off sets poweron to False."""
+        mock, heater = self._create_full_heater()
+        heater.turn_off()
+        assert mock.poweron is False
+
+    def test_oscon_setter(self):
+        """Test oscon setter sets device oscon."""
+        mock, heater = self._create_full_heater(features_override={"oscon": False})
+        heater.oscon = True
+        assert mock.oscon is True
+
+    def test_oscangle_setter(self):
+        """Test oscangle setter maps string to int angle."""
+        mock, heater = self._create_full_heater(features_override={"oscangle": 0})
+        heater.oscangle = "60°"
+        assert mock.oscangle == OSCANGLE_ANGLE_MAP["60°"]
+
+    def test_panel_sound(self):
+        """Test panel_sound sets muteon to opposite."""
+        mock, heater = self._create_full_heater()
+        heater.panel_sound(True)
+        assert mock.muteon is False
+        heater.panel_sound(False)
+        assert mock.muteon is True
+
+    def test_muteon(self):
+        """Test muteon sets device muteon."""
+        mock, heater = self._create_full_heater()
+        heater.muteon(True)
+        assert mock.muteon is True
+        heater.muteon(False)
+        assert mock.muteon is False
+
+    def test_min_temp(self):
+        """Test min_temp returns first value of ECOLEVEL_RANGE."""
+        mock, heater = self._create_full_heater()
+        assert heater.min_temp == 41
+
+    def test_max_temp(self):
+        """Test max_temp returns second value of ECOLEVEL_RANGE."""
+        mock, heater = self._create_full_heater()
+        assert heater.max_temp == 95
+
+    def test_target_temperature_step(self):
+        """Test target_temperature_step returns 1."""
+        mock, heater = self._create_full_heater()
+        assert heater.target_temperature_step == 1
+
+    def test_hvac_modes_property(self):
+        """Test hvac_modes returns the list of available modes."""
+        mock, heater = self._create_full_heater()
+        modes = heater.hvac_modes
+        assert isinstance(modes, list)
+        assert HVACMode.HEAT in modes
+
+    def test_set_hvac_mode_unsupported(self):
+        """Test set_hvac_mode with unsupported mode does nothing."""
+        mock, heater = self._create_full_heater()
+        original_mode = mock.mode
+        # HVACMode.COOL is not in the supported modes
+        heater.set_hvac_mode(HVACMode.COOL)
+        assert mock.mode == original_mode
+
+    def test_set_hvac_mode_heat_already_eco(self):
+        """Test set_hvac_mode HEAT when already in ECO doesn't change mode."""
+        mock, heater = self._create_full_heater(features_override={"mode": DreoHeaterMode.ECO})
+        heater.set_hvac_mode(HVACMode.HEAT)
+        # ECO is already a HEAT-compatible mode, should not change
+        assert mock.mode == DreoHeaterMode.ECO
+
+    def test_set_hvac_mode_heat_from_coolair(self):
+        """Test set_hvac_mode HEAT from COOLAIR changes to HOTAIR."""
+        mock, heater = self._create_full_heater(features_override={"mode": DreoHeaterMode.COOLAIR})
+        heater.set_hvac_mode(HVACMode.HEAT)
+        assert mock.mode == DreoHeaterMode.HOTAIR
+
+    def test_swing_modes_property(self):
+        """Test swing_modes returns the configured swing modes."""
+        mock, heater = self._create_full_heater()
+        modes = heater.swing_modes
+        assert modes is not None
+
+    def test_swing_mode_with_oscmode(self):
+        """Test swing_mode when oscmode is set (newer firmware)."""
+        mock, heater = self._create_full_heater(features_override={"oscmode": 1})
+        mode = heater.swing_mode
+        assert mode == HeaterOscillationAngles.OSC
+
+    def test_swing_mode_with_oscmode_off(self):
+        """Test swing_mode when oscmode is 0."""
+        mock, heater = self._create_full_heater(features_override={"oscmode": 0})
+        mode = heater.swing_mode
+        assert mode == SWING_OFF
+
+    def test_swing_mode_with_oscon_true(self):
+        """Test swing_mode when oscon is True."""
+        mock, heater = self._create_full_heater(features_override={"oscon": True, "oscmode": None})
+        mode = heater.swing_mode
+        assert mode == SWING_ON
+
+    def test_swing_mode_with_oscangle(self):
+        """Test swing_mode when oscangle is set."""
+        mock, heater = self._create_full_heater(features_override={"oscon": None, "oscmode": None, "oscangle": 60})
+        mode = heater.swing_mode
+        assert mode == ANGLE_OSCANGLE_MAP[60]
+
+    def test_swing_mode_fallback_off(self):
+        """Test swing_mode returns SWING_OFF when nothing is set."""
+        mock, heater = self._create_full_heater(features_override={"oscon": None, "oscmode": None, "oscangle": None})
+        mode = heater.swing_mode
+        assert mode == SWING_OFF
+
+    def test_set_swing_mode_oscmode(self):
+        """Test set_swing_mode with oscmode-based device."""
+        mock, heater = self._create_full_heater(features_override={"oscmode": 0})
+        heater.set_swing_mode(HeaterOscillationAngles.SIXTY)
+        assert mock.oscmode == 2  # HEATER_SWING_OSCMODE_MAP maps SIXTY to 2
+
+    def test_set_swing_mode_oscon(self):
+        """Test set_swing_mode with oscon-based device."""
+        mock, heater = self._create_full_heater(features_override={"oscon": False, "oscmode": None})
+        heater.set_swing_mode(SWING_ON)
+        assert mock.oscon is True
+
+    def test_set_swing_mode_oscon_off(self):
+        """Test set_swing_mode to non-SWING_ON value via oscon."""
+        mock, heater = self._create_full_heater(
+            features_override={"oscon": True, "oscmode": None},
+            swing_modes=[SWING_ON, SWING_OFF]
+        )
+        heater.set_swing_mode(SWING_OFF)
+        assert mock.oscon is False
+
+    def test_set_swing_mode_oscangle(self):
+        """Test set_swing_mode with oscangle-based device."""
+        mock, heater = self._create_full_heater(features_override={"oscon": None, "oscmode": None, "oscangle": 0})
+        heater.set_swing_mode("60°")
+        assert mock.oscangle == OSCANGLE_ANGLE_MAP["60°"]
+
+    def test_set_fan_mode_raises(self):
+        """Test set_fan_mode raises NotImplementedError."""
+        mock, heater = self._create_full_heater()
+        with pytest.raises(NotImplementedError):
+            heater.set_fan_mode("auto")
+
+    def test_set_humidity_raises(self):
+        """Test set_humidity raises NotImplementedError."""
+        mock, heater = self._create_full_heater()
+        with pytest.raises(NotImplementedError):
+            heater.set_humidity(50)
+
+    def test_set_swing_horizontal_mode_raises(self):
+        """Test set_swing_horizontal_mode raises NotImplementedError."""
+        mock, heater = self._create_full_heater()
+        with pytest.raises(NotImplementedError):
+            heater.set_swing_horizontal_mode("auto")
+
+    def test_toggle_on_to_off(self):
+        """Test toggle turns off when on."""
+        mock, heater = self._create_full_heater(features_override={"poweron": True})
+        heater.toggle()
+        assert mock.poweron is False
+
+    def test_toggle_off_to_on(self):
+        """Test toggle turns on when off."""
+        mock, heater = self._create_full_heater(features_override={"poweron": False, "mode": DreoHeaterMode.OFF})
+        heater.toggle()
+        assert mock.poweron is True
+
+    def test_turn_aux_heat_off_raises(self):
+        """Test turn_aux_heat_off raises NotImplementedError."""
+        mock, heater = self._create_full_heater()
+        with pytest.raises(NotImplementedError):
+            heater.turn_aux_heat_off()
+
+    def test_turn_aux_heat_on_raises(self):
+        """Test turn_aux_heat_on raises NotImplementedError."""
+        mock, heater = self._create_full_heater()
+        with pytest.raises(NotImplementedError):
+            heater.turn_aux_heat_on()
+
+    def test_supported_features_swing_mode(self):
+        """Test supported_features includes SWING_MODE when oscon is set."""
+        mock, heater = self._create_full_heater(features_override={"oscon": True})
+        assert heater.supported_features & ClimateEntityFeature.SWING_MODE
+
+    def test_supported_features_swing_mode_via_oscmode(self):
+        """Test supported_features includes SWING_MODE when oscmode is set."""
+        mock, heater = self._create_full_heater(features_override={"oscmode": 0})
+        assert heater.supported_features & ClimateEntityFeature.SWING_MODE
+
+    def test_set_temperature_no_temp_key(self):
+        """Test set_temperature with no ATTR_TEMPERATURE key does nothing."""
+        mock, heater = self._create_full_heater()
+        original = mock.ecolevel
+        heater.set_temperature(some_other_key=42)
+        assert mock.ecolevel == original
+
+    def test_target_temperature_none_when_no_ecolevel(self):
+        """Test target_temperature returns None when ecolevel is None."""
+        mock, heater = self._create_full_heater(features_override={"ecolevel": None})
+        assert heater.target_temperature is None

--- a/tests/dreo/test_humidifer.py
+++ b/tests/dreo/test_humidifer.py
@@ -99,3 +99,33 @@ class TestDreoHumidifier(TestDeviceBase):
             # Test mode switching
             test_dehumidifier.set_mode("manual")
             assert mocked_pydreo_dehumidifier.mode == "manual"
+
+    def test_async_setup_entry(self):
+        """Test async_setup_entry sets up humidifier/dehumidifier entities from hass.data."""
+        import asyncio
+        from unittest.mock import MagicMock
+        from custom_components.dreo.const import DOMAIN, PYDREO_MANAGER
+
+        mocked_devices = [
+            self.create_mock_device(name="Test Humidifier", type="Humidifier"),
+            self.create_mock_device(name="Test Dehumidifier", type="Dehumidifier"),
+            self.create_mock_device(name="Test Fan", type="Tower Fan"),
+        ]
+
+        mock_pydreo = MagicMock()
+        mock_pydreo.devices = mocked_devices
+
+        mock_hass = MagicMock()
+        mock_hass.data = {DOMAIN: {PYDREO_MANAGER: mock_pydreo}}
+
+        mock_config_entry = MagicMock()
+        mock_add_entities = MagicMock()
+
+        asyncio.run(humidifier.async_setup_entry(mock_hass, mock_config_entry, mock_add_entities))
+
+        mock_add_entities.assert_called_once()
+        entities = mock_add_entities.call_args[0][0]
+        assert len(entities) == 2
+        type_names = [type(e).__name__ for e in entities]
+        assert "DreoHumidifierHA" in type_names
+        assert "DreoDehumidifierHA" in type_names


### PR DESCRIPTION
## Summary

Continues test coverage improvements from PR #621. Targets the HA platform wrappers and heater device class.

### Coverage Improvements

| File | Before | After |
|------|--------|-------|
| dreoheater.py | 76% | 99% |
| climate.py | 68% | 100% |
| fan.py | 73% | 100% |
| humidifier.py | 78% | 100% |

### Overall: 82% → 89% (577 tests, all passing, pylint clean)

### What's tested
- **dreoheater.py**: Properties, swing modes, HVAC validation, presets, turn on/off, toggle, NotImplementedError paths
- **climate.py**: async_setup_entry with heaters, ACs, mixed devices
- **fan.py**: async_setup_entry with fans and evaporative coolers
- **humidifier.py**: async_setup_entry with humidifiers and dehumidifiers