### PR TITLE
Add support for DR-HPF020S pedestal fan (350S)

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -264,6 +264,21 @@ SUPPORTED_DEVICES = {
             SPEED_RANGE: (1, 10),
             HORIZONTAL_ANGLE_RANGE: (-60, 60)
         }),
+    "DR-HPF020S": DreoDeviceDetails(
+        device_type=DreoDeviceType.AIR_CIRCULATOR,
+        preset_modes=[
+            ("normal", 1),
+            ("auto", 2),
+            ("sleep", 3),
+            ("natural", 4),
+            ("turbo", 5),
+            ("custom", 6)
+        ],
+        device_ranges={
+            SPEED_RANGE: (1, 9),
+            HORIZONTAL_ANGLE_RANGE: (-60, 60),
+            VERTICAL_ANGLE_RANGE: (-30, 90)
+        }),
     "DR-HPF025S": DreoDeviceDetails(                                                                                                                                                  
       device_type=DreoDeviceType.AIR_CIRCULATOR,                                                                                                                                  
       preset_modes=[                                                                                                                                                                

--- a/tests/dreo/integrationtests/test_dreoaircirculator.py
+++ b/tests/dreo/integrationtests/test_dreoaircirculator.py
@@ -381,6 +381,77 @@ class TestDreoAirCirculator(IntegrationTestBase):
                 mock_send_command.assert_called_once_with(pydreo_fan, {VERTICAL_OSCILLATION_ANGLE_KEY: 45})
             pydreo_fan.handle_server_update({ REPORTED_KEY: {VERTICAL_OSCILLATION_ANGLE_KEY: 45} })
 
+    def test_HPF020S(self):  # pylint: disable=invalid-name
+        """Test HPF020S fan (Costco 350S pedestal fan)."""
+        with patch(PATCH_SCHEDULE_UPDATE_HA_STATE) as mock_update_ha_state:
+
+            self.get_devices_file_name = "get_devices_HPF020S.json"
+            self.pydreo_manager.load_devices()
+            assert len(self.pydreo_manager.devices) == 1
+
+            pydreo_fan = self.pydreo_manager.devices[0]
+            ha_fan = fan.DreoFanHA(pydreo_fan)
+            assert ha_fan.is_on is False
+            assert ha_fan.speed_count == 9
+            assert ha_fan.supported_features & FanEntityFeature.OSCILLATE
+            assert ha_fan.supported_features & FanEntityFeature.PRESET_MODE
+            assert ha_fan.unique_id is not None
+            assert pydreo_fan.model == "DR-HPF020S"
+            assert pydreo_fan.speed_range == (1, 9)
+
+            # Verify preset modes
+            assert len(ha_fan.preset_modes) == 6
+            assert "normal" in ha_fan.preset_modes
+            assert "custom" in ha_fan.preset_modes
+
+            # Test power on/off
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.turn_on()
+                mock_send_command.assert_called_once_with(pydreo_fan, {POWERON_KEY: True})
+            pydreo_fan.handle_server_update({ REPORTED_KEY: {POWERON_KEY: True} })
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.turn_off()
+                mock_send_command.assert_called_once_with(pydreo_fan, {POWERON_KEY: False})
+            pydreo_fan.handle_server_update({ REPORTED_KEY: {POWERON_KEY: False} })
+
+            # Test oscillation (HPF020S uses oscmode)
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.oscillate(True)
+                mock_send_command.assert_called_once_with(pydreo_fan, {OSCMODE_KEY: 1})
+            pydreo_fan.handle_server_update({ REPORTED_KEY: {OSCMODE_KEY: 1} })
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.oscillate(False)
+                mock_send_command.assert_called_once_with(pydreo_fan, {OSCMODE_KEY: 0})
+            pydreo_fan.handle_server_update({ REPORTED_KEY: {OSCMODE_KEY: 0} })
+
+            # Test speed range (1-9)
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_percentage(100)  # Speed 9 (max)
+                # Fan is off, so this triggers power on + speed
+                assert mock_send_command.call_count == 2
+                calls = [call[0][1] for call in mock_send_command.call_args_list]
+                assert {POWERON_KEY: True} in calls
+                assert {WINDLEVEL_KEY: 9} in calls
+            pydreo_fan.handle_server_update({ REPORTED_KEY: {POWERON_KEY: True, WINDLEVEL_KEY: 9} })
+
+            # Test preset modes
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_preset_mode("custom")
+                mock_send_command.assert_called_once_with(pydreo_fan, {WIND_MODE_KEY: 6})
+            pydreo_fan.handle_server_update({ REPORTED_KEY: {WIND_MODE_KEY: 6} })
+
+            # Test cruise_conf angles
+            assert pydreo_fan.vertical_osc_angle_top == 30
+            assert pydreo_fan.horizontal_osc_angle_right == 15
+            assert pydreo_fan.vertical_osc_angle_bottom == 0
+            assert pydreo_fan.horizontal_osc_angle_left == -15
+
+            # Check entities
+            switches = switch.get_entries([pydreo_fan])
+            self.verify_expected_entities(switches, ['Horizontally Oscillating', 'Panel Sound', 'Vertically Oscillating'])
+
     def test_HPF005S(self):  # pylint: disable=invalid-name
         """Test HPF005S fan with hangleadj support."""
         with patch(PATCH_SCHEDULE_UPDATE_HA_STATE) as mock_update_ha_state:

--- a/tests/pydreo/api_responses/get_device_state_HPF020S_1.json
+++ b/tests/pydreo/api_responses/get_device_state_HPF020S_1.json
@@ -1,0 +1,40 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "mixed": {
+      "poweron": {"state": false, "timestamp": 1775266902},
+      "windlevel": {"state": 3, "timestamp": 1775266360},
+      "mode": {"state": 4, "timestamp": 1775266380},
+      "temperature": {"state": 79, "timestamp": 1775267293},
+      "oscmode": {"state": 0, "timestamp": 1775266728},
+      "cruiseconf": {"state": "30,15,0,-15", "timestamp": 1775266634},
+      "fixedconf": {"state": "-10,-5", "timestamp": 1775266745},
+      "customconf": {"state": "temp:23333334444446666668888889", "timestamp": 1775262958},
+      "muteon": {"state": false, "timestamp": 1775266380},
+      "lighton": {"state": true, "timestamp": 1775266380},
+      "childlockon": {"state": false, "timestamp": 1775262958},
+      "alignon": {"state": true, "timestamp": 1775262958},
+      "tempoffset": {"state": 0, "timestamp": 1775262958},
+      "wifi_rssi": {"state": -44, "timestamp": 1775262958},
+      "network_latency": {"state": 878, "timestamp": 1775262958},
+      "module_hardware_model": {"state": "HeFi", "timestamp": 1775262958},
+      "module_hardware_mac": {"state": "REDACTED", "timestamp": 1775262958},
+      "mcu_firmware_version": {"state": "0.3.3", "timestamp": 1775262958},
+      "module_firmware_version": {"state": "3.8.3", "timestamp": 1775262958},
+      "wifi_ssid": {"state": "REDACTED", "timestamp": 1775262958},
+      "connected": {"state": true, "timestamp": 1775262958},
+      "mcuon": {"state": true, "timestamp": 1775262958},
+      "wrong": {"state": 0, "timestamp": 1775262958},
+      "scheid": {"state": 0, "timestamp": 1775262958},
+      "scheon": {"state": false, "timestamp": 1775262958},
+      "timeron": {"state": {"du": 0, "ts": 1775262388}, "timestamp": null},
+      "timeroff": {"state": {"du": 0, "ts": 1775262388}, "timestamp": null},
+      "_ota": {"state": 0, "timestamp": 1775262958}
+    },
+    "sn": "HPF020S_1",
+    "productId": "1914861046110695425",
+    "region": "us-east-2/emq",
+    "deviceInfo": null
+  }
+}

--- a/tests/pydreo/api_responses/get_devices_HPF020S.json
+++ b/tests/pydreo/api_responses/get_devices_HPF020S.json
@@ -1,0 +1,47 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "currentPage": 1,
+    "pageSize": 100,
+    "totalNum": 1,
+    "totalPage": 1,
+    "familyRooms": null,
+    "list": [
+      {
+        "deviceId": "2040222339882291201",
+        "sn": "HPF020S_1",
+        "brand": "Dreo",
+        "model": "DR-HPF020S",
+        "productId": "1914861046110695425",
+        "productName": "Air Circulator",
+        "deviceName": "DEBUGTEST - Air Circulator - DR-HPF020S",
+        "shared": false,
+        "series": null,
+        "seriesName": "350S",
+        "type": 0,
+        "owner": true,
+        "familyId": null,
+        "familyName": null,
+        "roomId": null,
+        "roomName": null,
+        "roomNameI18Key": "",
+        "color": "l",
+        "controlsConf": {},
+        "mainConf": {
+          "isSmart": true,
+          "isWifi": true,
+          "isBluetooth": null,
+          "isVoiceControl": true
+        },
+        "resourcesConf": {
+          "imageSmallSrc": null,
+          "imageFullSrc": null,
+          "imageSmallDarkSrc": null,
+          "imageFullDarkSrc": null
+        },
+        "userManuals": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Adds support for the DR-HPF020S (Costco TurboPoly Pedestal Fan 350S).

## Changes
- Added model entry in \models.py\ with hardcoded speed range (1-9), 6 preset modes (normal/auto/sleep/natural/turbo/custom), and oscillation angle ranges
- Added integration test with full coverage (power, speed, oscillation, preset modes, cruise_conf angles, switches)
- Added API response test data files from user diagnostics

## Why hardcoded?
The DR-HPF020S returns empty \controlsConf\ (\{}\) from the API, so speed range and preset modes cannot be auto-detected and must be specified in the model entry.

## Device capabilities
- 9 speeds
- 6 modes: normal, auto, sleep, natural, turbo, custom
- 3D oscillation: 100° vertical (-30 to 90) & 120° horizontal (-60 to 60)
- Panel sound (mute), child lock, display light

Closes #610