### PR TITLE
Fix entity naming and ambient light sensor bugs

### DIFF
--- a/custom_components/dreo/number.py
+++ b/custom_components/dreo/number.py
@@ -261,10 +261,11 @@ class DreoNumberHA(DreoBaseDeviceHA, NumberEntity): # pylint: disable=abstract-m
         self.entity_description = description
 
         self._attr_has_entity_name = True
+        del self._attr_name
         self._attr_translation_key = description.translation_key
         self._attr_unique_id = f"{super().unique_id}-{description.key}"
 
-        self._attr_native_min_value = description.min_value
+        self._attr_native_min_value= description.min_value
         self._attr_native_max_value = description.max_value
         self._attr_native_step = description.step
         self._attr_native_unit_of_measurement = description.native_unit_of_measurement

--- a/custom_components/dreo/select.py
+++ b/custom_components/dreo/select.py
@@ -79,6 +79,7 @@ class DreoSelectHA(DreoBaseDeviceHA, SelectEntity):
         self.entity_description = description
 
         self._attr_has_entity_name = True
+        del self._attr_name
         self._attr_translation_key = description.translation_key
         self._attr_unique_id = f"{super().unique_id}-{description.key}"
         self._attr_options = description.options_list

--- a/custom_components/dreo/sensor.py
+++ b/custom_components/dreo/sensor.py
@@ -129,7 +129,7 @@ SENSORS: tuple[DreoSensorEntityDescription, ...] = (
         translation_key="light_hm",
         device_class=SensorDeviceClass.ENUM,
         options=[LIGHT_ON, LIGHT_OFF],
-        value_fn=lambda device: device.rgblevel,
+        value_fn=lambda device: LIGHT_ON if device.rgblevel and int(device.rgblevel) > 0 else LIGHT_OFF,
         exists_fn=lambda device: (device.type in { DreoDeviceType.HUMIDIFIER }) and device.is_feature_supported(RGB_LEVEL),
     ),
     DreoSensorEntityDescription(

--- a/custom_components/dreo/strings.json
+++ b/custom_components/dreo/strings.json
@@ -44,6 +44,7 @@
         "humidify":                 { "name": "Humidify" },
         "display_light":            { "name": "Display Light" },
         "ambient_light":            { "name": "Ambient Light" },
+        "rgb_indicator":            { "name": "Water Level Indicator" },
         "auto_mode":                { "name": "Auto Turn On" },
         "scheon":                   { "name": "Schedule" }
       },
@@ -69,6 +70,8 @@
         "horizontal_oscillation_angle": { "name": "Horizontal Oscillation Angle" },
         "vertical_oscillation_angle":   { "name": "Vertical Oscillation Angle" },
         "target_humidity":              { "name": "Target Humidity" },
+        "fog_level":                    { "name": "Fog Level" },
+        "sleep_target_humidity":        { "name": "Sleep Target Humidity" },
         "ambient_light_threshold_low":  { "name": "Ambient Light Threshold Low" },
         "ambient_light_threshold_high": { "name": "Ambient Light Threshold High" },
         "ambient_light_level":          { "name": "Ambient Light Level" }

--- a/custom_components/dreo/switch.py
+++ b/custom_components/dreo/switch.py
@@ -211,6 +211,7 @@ class DreoSwitchHA(DreoBaseDeviceHA, SwitchEntity):
         self.entity_description = description
 
         self._attr_has_entity_name = True
+        del self._attr_name
         self._attr_translation_key = description.translation_key
         self._attr_unique_id = f"{super().unique_id}-{description.key}"
 

--- a/custom_components/dreo/translations/en.json
+++ b/custom_components/dreo/translations/en.json
@@ -44,6 +44,7 @@
         "humidify":                 { "name": "Humidify" },
         "display_light":            { "name": "Display Light" },
         "ambient_light":            { "name": "Ambient Light" },
+        "rgb_indicator":            { "name": "Water Level Indicator" },
         "auto_mode":                { "name": "Auto Turn On" },
         "scheon":                   { "name": "Schedule" }
       },
@@ -69,6 +70,8 @@
         "horizontal_oscillation_angle": { "name": "Horizontal Oscillation Angle" },
         "vertical_oscillation_angle":   { "name": "Vertical Oscillation Angle" },
         "target_humidity":              { "name": "Target Humidity" },
+        "fog_level":                    { "name": "Fog Level" },
+        "sleep_target_humidity":        { "name": "Sleep Target Humidity" },
         "ambient_light_threshold_low":  { "name": "Ambient Light Threshold Low" },
         "ambient_light_threshold_high": { "name": "Ambient Light Threshold High" },
         "ambient_light_level":          { "name": "Ambient Light Level" }

--- a/tests/dreo/test_switch.py
+++ b/tests/dreo/test_switch.py
@@ -224,7 +224,7 @@ class TestDreoSwitchHA(TestDeviceBase):
         assert len(entities) == 4
 
         # Verify correct device association
-        fan_switches = [e for e in entities if "Fan" in e.name]
-        heater_switches = [e for e in entities if "Heater" in e.name]
+        fan_switches = [e for e in entities if "Fan" in e.pydreo_device.name]
+        heater_switches = [e for e in entities if "Heater" in e.pydreo_device.name]
         assert len(fan_switches) == 2
         assert len(heater_switches) == 2

--- a/tests/pydreo/api_responses/get_device_state_HAF003S_DEVICE1_NEWER_FW.json
+++ b/tests/pydreo/api_responses/get_device_state_HAF003S_DEVICE1_NEWER_FW.json
@@ -109,7 +109,7 @@
         "timestamp": 1765507391
       },
       "connected": {
-        "state": false,
+        "state": true,
         "timestamp": 1765510043
       },
       "timeroff": {


### PR DESCRIPTION
## Changes

- **Fix switch/number/select entity naming**: delete _attr_name after base class __init__ so translation_key provides the display name instead of duplicating the device name
- **Add missing translation strings**: fog_level, sleep_target_humidity, rgb_indicator
- **Fix ambient light humidifier sensor**: map raw rgblevel int to ENUM options (Enable/Disabled) to prevent ValueError
- **Fix HAF003S newer FW test data**: set connected state to true so entities are available
- **Fix test**: update test_switch_multiple_devices to use pydreo_device.name