### PR TITLE
Add VS Code extension recommendations for Ruff

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "charliermarsh.ruff"
+    ],
+    "unwantedRecommendations": [
+        "ms-python.pylint"
+    ]
+}


### PR DESCRIPTION
Recommend the Ruff extension and mark Pylint as unwanted for this workspace via \.vscode/extensions.json\.

Companion to #631 (pylint → Ruff migration).