### PR TITLE
Add test coverage for DR-HPF002S air circulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Dreo Smart Device Integration for Home Assistant (Unofficial)
 
+<p align="center">
+  <img src="custom_components/dreo/brand/logo@2x.png" alt="Dreo" width="300">
+</p>
+
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
 [![CI Validation](https://github.com/JeffSteinbok/hass-dreo/actions/workflows/ci.yaml/badge.svg)](https://github.com/JeffSteinbok/hass-dreo/actions/workflows/ci.yaml)
@@ -15,6 +19,8 @@ Dreo also maintains an [official Home Assistant integration](https://github.com/
 | | **hass-dreo** (this project) | **hass-dreoverse** (official) |
 |---|---|---|
 | API used | Mobile app API | Dreo Open API |
+| Device types | Fans, Heaters, ACs, Humidifiers, Dehumidifiers, Air Purifiers, Cookers, Evaporative Coolers | Fans, Ceiling Fans, ACs, Evaporative Coolers |
+| Missing from official | — | Space Heaters, Humidifiers, Dehumidifiers, Air Purifiers, ChefMaker |
 | Device feature coverage | ~61 state fields — more controls exposed | ~36 state fields — fewer controls |
 | Notable extras here | Timers, PTC heater status, PM2.5 sensors, ChefMaker, cruise control, work time, and more | Not available |
 | Support model | Community-maintained | Officially maintained by Dreo |

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Dreo Smart Device Integration for Home Assistant (Unofficial)
 
-<p align="center">
-  <img src="custom_components/dreo/brand/logo@2x.png" alt="Dreo" width="300">
-</p>
-
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
 [![CI Validation](https://github.com/JeffSteinbok/hass-dreo/actions/workflows/ci.yaml/badge.svg)](https://github.com/JeffSteinbok/hass-dreo/actions/workflows/ci.yaml)
 [![Release Automation](https://github.com/JeffSteinbok/hass-dreo/actions/workflows/release.yaml/badge.svg)](https://github.com/JeffSteinbok/hass-dreo/actions/workflows/release.yaml)
+
+<p align="center">
+  <img src="custom_components/dreo/brand/logo@2x.png" alt="Dreo" width="300">
+</p>
 
 
 Unofficial HomeAssistant integration for Dreo brand smart devices. Currently supports most models of Fans, Air Conditioners, Humidifiers, Dehumidifiers and Space Heaters as well as ChefMaker. I do not work for Dreo; just something I'm doing for fun.

--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -31,6 +31,7 @@ This document lists all Dreo device models that have been tested and confirmed t
 - DR-HPF005S
 - DR-HPF007S
 - DR-HPF008S
+- DR-HPF020S
 - DR-HPF025S
 
 ### Ceiling Fans (DR-HCF Series)
@@ -52,14 +53,13 @@ All DR-HAP models should be supported. Tested models include:
 - DR-HHM001S
 - DR-HHM003S (HM713S/813S)
 - DR-HHM004S
+- DR-HHM006S
 - DR-HHM014S (HM774S)
 - DR-HHM015S (HM755S)
 
 All DR-HHM* models should have basic support.
 
 ## Dehumidifiers (DR-HDH Series)
-
-*Beta-level support*
 
 - DR-HDH001S
 - DR-HDH002S
@@ -95,8 +95,6 @@ All DR-HHM* models should have basic support.
 - DR-KCM001S
 
 ## Evaporative Coolers (DR-HEC Series)
-
-*Beta-level support*
 
 - DR-HEC002S
 

--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -42,7 +42,6 @@ This document lists all Dreo device models that have been tested and confirmed t
 
 ### Air Purifiers (DR-HAP Series)
 
-All DR-HAP models should be supported. Tested models include:
 - DR-HAP001S
 - DR-HAP002S
 - DR-HAP003S
@@ -57,9 +56,7 @@ All DR-HAP models should be supported. Tested models include:
 - DR-HHM014S (HM774S)
 - DR-HHM015S (HM755S)
 
-All DR-HHM* models should have basic support.
-
-## Dehumidifiers (DR-HDH Series)
+## Dehumidifiers(DR-HDH Series)
 
 - DR-HDH001S
 - DR-HDH002S

--- a/tests/dreo/integrationtests/test_dreoaircirculator.py
+++ b/tests/dreo/integrationtests/test_dreoaircirculator.py
@@ -439,6 +439,71 @@ class TestDreoAirCirculator(IntegrationTestBase):
             switches = switch.get_entries([pydreo_fan])
             self.verify_expected_entities(switches, ["Horizontally Oscillating", "Panel Sound", "Vertically Oscillating"])
 
+    def test_HPF002S(self):  # pylint: disable=invalid-name
+        """Test HPF002S fan."""
+        with patch(PATCH_SCHEDULE_UPDATE_HA_STATE) as mock_update_ha_state:
+            self.get_devices_file_name = "get_devices_HPF002S.json"
+            self.pydreo_manager.load_devices()
+            assert len(self.pydreo_manager.devices) == 1
+
+            pydreo_fan = self.pydreo_manager.devices[0]
+            ha_fan = fan.DreoFanHA(pydreo_fan)
+            assert ha_fan.is_on is False
+            assert ha_fan.speed_count == 8
+            assert ha_fan.supported_features & FanEntityFeature.PRESET_MODE
+            assert pydreo_fan.model == "DR-HPF002S"
+            assert pydreo_fan.speed_range == (1, 8)
+
+            # Verify preset modes (auto-detected from controlsConf)
+            assert pydreo_fan.preset_modes == ["normal", "natural", "sleep", "auto", "turbo", "custom"]
+            assert pydreo_fan.preset_mode == "sleep"  # Initial mode is 3
+            assert ha_fan.preset_modes == ["normal", "natural", "sleep", "auto", "turbo", "custom"]
+            assert ha_fan.preset_mode == "sleep"
+
+            # Verify temperature sensor
+            assert pydreo_fan.temperature is not None
+            assert isinstance(pydreo_fan.temperature, (int, float))
+
+            # Test power commands
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.turn_on()
+                mock_send_command.assert_called_once_with(pydreo_fan, {POWERON_KEY: True})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: True}})
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.turn_off()
+                mock_send_command.assert_called_once_with(pydreo_fan, {POWERON_KEY: False})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: False}})
+
+            # Test oscillation (HPF002S uses oscmode, initial state is 1/on)
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.oscillate(False)
+                mock_send_command.assert_called_once_with(pydreo_fan, {OSCMODE_KEY: 0})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {OSCMODE_KEY: 0}})
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.oscillate(True)
+                mock_send_command.assert_called_once_with(pydreo_fan, {OSCMODE_KEY: 1})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {OSCMODE_KEY: 1}})
+
+            # Test preset modes (device is off after turn_off, so set_preset_mode also powers on)
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_preset_mode("turbo")
+                assert mock_send_command.call_count == 2
+                calls = [call[0][1] for call in mock_send_command.call_args_list]
+                assert {POWERON_KEY: True} in calls
+                assert {WIND_MODE_KEY: 5} in calls
+            pydreo_fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: True, WIND_MODE_KEY: 5}})
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_preset_mode("custom")
+                mock_send_command.assert_called_once_with(pydreo_fan, {WIND_MODE_KEY: 6})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: 6}})
+
+            # Check entities
+            switches = switch.get_entries([pydreo_fan])
+            self.verify_expected_entities(switches, ["Horizontally Oscillating", "Panel Sound", "Vertically Oscillating"])
+
     def test_HPF005S(self):  # pylint: disable=invalid-name
         """Test HPF005S fan with hangleadj support."""
         with patch(PATCH_SCHEDULE_UPDATE_HA_STATE) as mock_update_ha_state:

--- a/tests/pydreo/api_responses/get_device_state_HPF002S_1.json
+++ b/tests/pydreo/api_responses/get_device_state_HPF002S_1.json
@@ -1,0 +1,121 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "mixed": {
+      "wifi_rssi": {
+        "state": -44,
+        "timestamp": 1777076324
+      },
+      "poweron": {
+        "state": false,
+        "timestamp": 1777076324
+      },
+      "scheid": {
+        "state": 0,
+        "timestamp": 1777076324
+      },
+      "cruiseconf": {
+        "state": "20,10,-10,-20",
+        "timestamp": 1777076324
+      },
+      "timeron": {
+        "state": {
+          "du": 0,
+          "ts": 1776589737
+        },
+        "timestamp": null
+      },
+      "fixedconf": {
+        "state": "0,0",
+        "timestamp": 1777076324
+      },
+      "scheon": {
+        "state": false,
+        "timestamp": 1777076324
+      },
+      "mode": {
+        "state": 3,
+        "timestamp": 1777076324
+      },
+      "mcuon": {
+        "state": true,
+        "timestamp": 1777076324
+      },
+      "network_latency": {
+        "state": 69,
+        "timestamp": 1777076324
+      },
+      "module_hardware_model": {
+        "state": "HeFi",
+        "timestamp": 1777076324
+      },
+      "mcu_firmware_version": {
+        "state": "0.1.3",
+        "timestamp": 1777076324
+      },
+      "oscmode": {
+        "state": 1,
+        "timestamp": 1777076324
+      },
+      "customconf": {
+        "state": "temp:12222223333334444447777778",
+        "timestamp": 1777076324
+      },
+      "temperature": {
+        "state": 82,
+        "timestamp": 1777127842
+      },
+      "module_hardware_mac": "**REDACTED**",
+      "alignon": {
+        "state": true,
+        "timestamp": 1777076324
+      },
+      "muteon": {
+        "state": true,
+        "timestamp": 1777076324
+      },
+      "lighton": {
+        "state": false,
+        "timestamp": 1777076324
+      },
+      "wifi_ssid": "**REDACTED**",
+      "mcu_hardware_model": {
+        "state": "SC95F8615B/EU",
+        "timestamp": 1777076324
+      },
+      "windlevel": {
+        "state": 1,
+        "timestamp": 1777076324
+      },
+      "wrong": {
+        "state": 0,
+        "timestamp": 1777076324
+      },
+      "module_firmware_version": {
+        "state": "3.8.4",
+        "timestamp": 1777076324
+      },
+      "connected": {
+        "state": true,
+        "timestamp": 1777076324
+      },
+      "timeroff": {
+        "state": {
+          "du": 0,
+          "ts": 1776589737
+        },
+        "timestamp": null
+      },
+      "_ota": {
+        "state": 2,
+        "timestamp": 1777076324
+      },
+      "childlockon": {
+        "state": false,
+        "timestamp": 1777076324
+      }
+    },
+    "sn": "HPF002S_1"
+  }
+}

--- a/tests/pydreo/api_responses/get_devices_HPF002S.json
+++ b/tests/pydreo/api_responses/get_devices_HPF002S.json
@@ -1,0 +1,341 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "currentPage": 1,
+    "pageSize": 100,
+    "totalNum": 1,
+    "totalPage": 1,
+    "familyRooms": null,
+    "list": [
+      {
+        "deviceId": "2045436012651950082",
+        "sn": "HPF002S_1",
+        "brand": "Dreo",
+        "model": "DR-HPF002S",
+        "productId": "**REDACTED**",
+        "productName": "Air Circulator",
+        "deviceName": "DEBUGTEST - Air Circulator - DR-HPF002S",
+        "shared": false,
+        "series": null,
+        "seriesName": "502S",
+        "type": 0,
+        "owner": true,
+        "familyId": null,
+        "familyName": null,
+        "roomId": null,
+        "roomName": null,
+        "roomNameI18Key": "",
+        "color": "s",
+        "widgetOnImage": "https://resources.dreo-tech.com/app/preSigned202411/13f3f2c533ac26427398427aa12214065d.png",
+        "widgetOffImage": "https://resources.dreo-tech.com/app/preSigned202411/13336d33026387410cb18e8681b53e74da.png",
+        "widgetAbnormalImage": null,
+        "variantIconMd5": null,
+        "controlsConf": {
+          "template": "DR-HPF002S",
+          "lottie": {
+            "key": "poweron",
+            "frames": [
+              {
+                "value": 0,
+                "frame": [0]
+              },
+              {
+                "value": 1,
+                "frame": [2]
+              }
+            ]
+          },
+          "schedule": {
+            "modes": [
+              {
+                "icon": "ic_normal_wind_color",
+                "title": "device_fans_mode_straight",
+                "cmd": "mode",
+                "value": 1,
+                "valueType": 1,
+                "isSelected": true,
+                "attention": ["mode", "windlevel", "poweron", "cruiseconf", "oscmode", "fixedconf"],
+                "controls": [
+                  {
+                    "type": 0,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": ["windlevel"],
+                    "value": 5,
+                    "valueType": 1,
+                    "startValue": 1,
+                    "endValue": 8,
+                    "groupId": 0,
+                    "icon": "ic_sch_wind_speed",
+                    "isSelected": false
+                  }
+                ]
+              },
+              {
+                "icon": "ic_natural_wind_color",
+                "title": "device_fans_mode_natural",
+                "cmd": "mode",
+                "value": 2,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": ["mode", "windlevel", "poweron", "cruiseconf", "oscmode", "fixedconf"],
+                "controls": [
+                  {
+                    "type": 0,
+                    "valueType": 1,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": ["windlevel"],
+                    "value": 5,
+                    "startValue": 1,
+                    "endValue": 8,
+                    "groupId": 0,
+                    "icon": "ic_sch_wind_speed",
+                    "isSelected": false
+                  }
+                ]
+              },
+              {
+                "icon": "ic_sleep_wind_color",
+                "title": "device_fans_mode_sleep",
+                "cmd": "mode",
+                "value": 3,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": ["mode", "windlevel", "poweron", "cruiseconf", "oscmode", "fixedconf"],
+                "controls": [
+                  {
+                    "type": 0,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": ["windlevel"],
+                    "value": 5,
+                    "valueType": 1,
+                    "startValue": 1,
+                    "endValue": 8,
+                    "groupId": 0,
+                    "isSelected": false,
+                    "icon": "ic_sch_wind_speed"
+                  }
+                ]
+              },
+              {
+                "icon": "ic_auto_wind_color",
+                "title": "device_control_mode_auto",
+                "cmd": "mode",
+                "value": 4,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": ["mode", "windlevel", "poweron", "cruiseconf", "oscmode", "fixedconf"],
+                "controls": [
+                  {
+                    "type": 0,
+                    "title": "device_control_mode_manual_level",
+                    "startColor": "#0051CF",
+                    "endColor": "#0051CF",
+                    "cmd": ["windlevel"],
+                    "value": 5,
+                    "valueType": 1,
+                    "startValue": 1,
+                    "endValue": 8,
+                    "groupId": 0,
+                    "isSelected": false,
+                    "icon": "ic_sch_wind_speed"
+                  }
+                ]
+              },
+              {
+                "icon": "ic_turbo_wind_color",
+                "title": "device_control_mode_turbo",
+                "cmd": "mode",
+                "value": 5,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": ["mode", "windlevel", "poweron", "cruiseconf", "oscmode", "fixedconf"],
+                "controls": []
+              },
+              {
+                "icon": "ic_custom_wind",
+                "title": "device_control_custom",
+                "cmd": "mode",
+                "value": 6,
+                "valueType": 1,
+                "isSelected": false,
+                "attention": ["mode", "windlevel", "poweron", "cruiseconf", "oscmode", "fixedconf"],
+                "controls": []
+              }
+            ]
+          },
+          "cards": [
+            {
+              "type": 8,
+              "title": "",
+              "icon": "",
+              "image": "",
+              "url": "dreo://nav/device/schedule?deviceSn={sn}",
+              "show": true,
+              "key": ""
+            },
+            {
+              "type": 2,
+              "title": "device_control_temp",
+              "icon": "",
+              "image": "",
+              "url": "",
+              "show": true
+            },
+            {
+              "type": 6,
+              "title": "device_settings_title",
+              "icon": "ic_setting",
+              "image": "",
+              "url": "dreo://nav/device/setting?deviceSn=${sn}",
+              "show": true,
+              "key": "setting"
+            }
+          ],
+          "feature": {
+            "schedule": {
+              "enable": "",
+              "localSupport": true,
+              "module": [
+                {
+                  "type": "HeFi",
+                  "version": "0.0.1"
+                }
+              ]
+            }
+          },
+          "swingAngle": {
+            "fixedAngle": {
+              "verAngle": 120,
+              "horAngle": 120,
+              "verZeroAngle": 30,
+              "horZeroAngle": 60,
+              "imgColumn": 9,
+              "imgRow": 9
+            },
+            "horSwingAngle": {
+              "angle": 120,
+              "dottedLines": [30, 150],
+              "quickStep": [30, 60, 90, 120]
+            },
+            "verSwingAngle": {
+              "startAngle": 150,
+              "sweepAngle": 120,
+              "stepAngle": 5,
+              "dottedLines": [150, 270],
+              "quickStep": [30, 60, 90, 120]
+            }
+          },
+          "preference": [
+            {
+              "id": "210",
+              "type": "Display Auto Off",
+              "title": "device_fans_mode_auto_display",
+              "image": "ic_display",
+              "reverse": true,
+              "cmd": "lighton"
+            },
+            {
+              "id": "200",
+              "type": "Panel Sound",
+              "title": "device_control_panelsound",
+              "image": "ic_mute",
+              "reverse": true,
+              "cmd": "muteon"
+            },
+            {
+              "id": "220",
+              "type": "Child Lock",
+              "title": "device_control_childlock",
+              "image": "ic_child_lock",
+              "reverse": false,
+              "cmd": "childlockon"
+            }
+          ],
+          "control": [
+            {
+              "id": "100",
+              "type": "Mode",
+              "title": "device_mode",
+              "items": [
+                {
+                  "text": "device_fans_mode_straight",
+                  "cmd": "mode",
+                  "value": 1
+                },
+                {
+                  "text": "device_control_mode_auto",
+                  "cmd": "mode",
+                  "value": 4
+                },
+                {
+                  "text": "device_control_mode_sleep",
+                  "cmd": "mode",
+                  "value": 3
+                },
+                {
+                  "text": "device_fans_mode_natural",
+                  "cmd": "mode",
+                  "value": 2
+                }
+              ]
+            },
+            {
+              "id": "110",
+              "type": "Speed",
+              "title": "device_control_speed",
+              "items": [
+                {
+                  "text": "1",
+                  "cmd": "windlevel",
+                  "value": 1
+                },
+                {
+                  "text": "8",
+                  "cmd": "windlevel",
+                  "value": 8
+                }
+              ]
+            },
+            {
+              "id": "130",
+              "type": "DPad",
+              "step": 5
+            }
+          ],
+          "category": "Air Circulators",
+          "version": {
+            "minControlVer": "2.0.7",
+            "minPairingVer": "2.0.7"
+          }
+        },
+        "mainConf": {
+          "isSmart": true,
+          "isWifi": true,
+          "isBluetooth": null,
+          "isVoiceControl": true
+        },
+        "resourcesConf": {
+          "imageSmallSrc": "https://resources.dreo-tech.com/app/preSigned202409/11dd8b567bcc7f4005a00a6dbe20349493.png",
+          "imageFullSrc": "https://resources.dreo-tech.com/app/202402/4/4ef9061a1f974cc5b33277d8d4c5bdde.zip",
+          "imageSmallDarkSrc": null,
+          "imageFullDarkSrc": null
+        },
+        "userManuals": [
+          {
+            "url": "https://resources.dreo-tech.com/app/preSigned202409/9d659d1c0ba1d462495f274ab61238105.pdf",
+            "icon": null,
+            "desc": "DR-HPF002S User Manual V1",
+            "lang": "en"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/pydreo/test_pydreoaircirculator.py
+++ b/tests/pydreo/test_pydreoaircirculator.py
@@ -246,6 +246,82 @@ class TestPyDreoAirCirculator(TestBase):
             with pytest.raises(ValueError):
                 fan.preset_mode = "invalid_mode_xyz"
 
+    def test_HPF002S(self):  # pylint: disable=invalid-name
+        """Test HPF002S fan."""
+        self.get_devices_file_name = "get_devices_HPF002S.json"
+        self.pydreo_manager.load_devices()
+
+        assert len(self.pydreo_manager.devices) == 1
+
+        fan: PyDreoAirCirculator = self.pydreo_manager.devices[0]
+
+        # Test initial state values
+        assert fan.is_on is False
+        assert fan.speed_range == (1, 8)
+        assert fan.preset_modes == ["normal", "natural", "sleep", "auto", "turbo", "custom"]
+        assert fan.preset_mode == "sleep"  # Initial mode is 3 which is "sleep"
+        assert fan.temperature == 82
+        assert fan.model == "DR-HPF002S"
+        assert fan.device_name is not None
+        assert fan.serial_number is not None
+        assert fan.fan_speed == 1
+
+        # Test power commands
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.is_on = True
+            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: True})
+        fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: True}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.is_on = False
+            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: False})
+        fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: False}})
+
+        # Test fan speed commands
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.fan_speed = 4
+            mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 4})
+        fan.handle_server_update({REPORTED_KEY: {WINDLEVEL_KEY: 4}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.fan_speed = 8
+            mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 8})
+        fan.handle_server_update({REPORTED_KEY: {WINDLEVEL_KEY: 8}})
+
+        # Test speed boundaries
+        with pytest.raises(ValueError):
+            fan.fan_speed = 0
+
+        with pytest.raises(ValueError):
+            fan.fan_speed = 9
+
+        # Test oscillation commands (HPF002S uses oscmode, initial state is 1/on)
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.oscillating = False
+            assert mock_send_command.call_count == 1
+        fan.handle_server_update({REPORTED_KEY: {OSCMODE_KEY: 0}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.oscillating = True
+            assert mock_send_command.call_count == 1
+        fan.handle_server_update({REPORTED_KEY: {OSCMODE_KEY: 1}})
+
+        # Test preset mode commands
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "normal"
+            mock_send_command.assert_called_once_with(fan, {WIND_MODE_KEY: 1})
+        fan.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: 1}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "turbo"
+            mock_send_command.assert_called_once_with(fan, {WIND_MODE_KEY: 5})
+        fan.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: 5}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "custom"
+            mock_send_command.assert_called_once_with(fan, {WIND_MODE_KEY: 6})
+        fan.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: 6}})
+
     def test_HPF008S(self):  # pylint: disable=invalid-name
         """Test HPF008S fan."""
         self.get_devices_file_name = "get_devices_HPF008S.json"


### PR DESCRIPTION
Add test fixtures and tests for the DR-HPF002S (PolyFan 502S) based on diagnostics from issue #616. The device already works via the \DR-HPF\ prefix match with auto-detected modes and speed range from \controlsConf\.

## Changes
- Add \get_devices_HPF002S.json\ API response fixture
- Add \get_device_state_HPF002S_1.json\ device state fixture
- Add PyDreo unit test verifying speed range (1-8), 6 preset modes, oscillation, and power commands
- Add HA integration test verifying fan entity, switches, and preset mode behavior

## Test results
All 633 tests pass, ruff lint clean.

Closes #616