### PR TITLE
Fix: Revert ACK timeout and reconnect behavior to v1.7.8 (#636)

### DIFF
--- a/custom_components/dreo/pydreo/__init__.py
+++ b/custom_components/dreo/pydreo/__init__.py
@@ -30,7 +30,7 @@ from .pydreoevaporativecooler import PyDreoEvaporativeCooler
 
 _LOGGER = logging.getLogger(__name__)
 
-_COMMAND_ACK_TIMEOUT = 8  # seconds to wait for server to confirm command
+_COMMAND_ACK_TIMEOUT = 2  # seconds to wait for server to confirm command
 _ACK_METHOD_NAME = "control-report"  # wait for device confirmation
 _MAX_COMMAND_RETRIES = 2  # retry failed commands up to this many times
 

--- a/custom_components/dreo/pydreo/commandtransport.py
+++ b/custom_components/dreo/pydreo/commandtransport.py
@@ -123,13 +123,21 @@ class CommandTransport:
                     except websockets.exceptions.ConnectionClosed:
                         pass
 
-                    break  # Exit inner loop; outer while handles reconnect with fresh URL
+                    if not self._auto_reconnect:
+                        _LOGGER.error("_start_websocket: WebSocket appears closed.  Not Reconnecting.  Restart HA to reconnect.")
+                        self._loop = None
+                        _LOGGER.info("_start_websocket: Transport has been stopped and thread done")
+                        return
+
+                    # Break out of async for to rebuild URL with potentially refreshed token
+                    _LOGGER.info("_start_websocket: Reconnecting with current token")
+                    break
+
             except Exception as ex:  # pylint: disable=broad-except
                 _LOGGER.error("_start_websocket: WebSocket connection failed: %s", ex)
-
-            if not self._auto_reconnect:
-                _LOGGER.error("_start_websocket: WebSocket appears closed.  Not Reconnecting.  Restart HA to reconnect.")
-                break
+                if not self._auto_reconnect or self._signal_close:
+                    break
+                await asyncio.sleep(RETRY_DELAY)
 
         self._loop = None
         _LOGGER.info("_start_websocket: Transport has been stopped and thread done")


### PR DESCRIPTION
## Summary

Restores command infrastructure to pre-PR #618 behavior to fix the AC regression reported in #636 (DR-HAC006S/DR-HAC008S controls greyed out on v1.7.11+).

## Changes

- **ACK timeout**: Reverted \_COMMAND_ACK_TIMEOUT\ from 8s back to 2s (original value from PR #505). The 8s timeout was introduced by PR #618 for humidifier support but causes AC commands to block for up to 24s when no ACK is received, potentially starving HA's executor thread pool and greying out entities.
- **WebSocket reconnect delay**: Restored \syncio.sleep(RETRY_DELAY)\ on connection failure, preventing tight retry loops.
- **Auto-reconnect check**: Restored inside the WebSocket inner loop with proper early return, matching v1.7.8 behavior.

## What's preserved

- Device-only ACK matching (no param check) — keeps humidifier compatibility since some devices don't echo back changed params in \control-report\.
- All formatting improvements and bug fixes from recent PRs.

## Root cause

PR #618 (cash83, humidifier support) modified shared command infrastructure. The 8s ACK timeout was kept in commit 51b95c8 when restoring retry logic, but ACs may not send \control-report\ ACKs at all — causing every command to time out for the full duration × 3 attempts = 24s blocking.

Fixes #636