### PR TITLE
fix(DR-HHM001S): restore ambient light after HA restart

### DIFF
--- a/custom_components/dreo/pydreo/pydreohumidifier.py
+++ b/custom_components/dreo/pydreo/pydreohumidifier.py
@@ -42,7 +42,8 @@ LIGHT_OFF = "Disabled"
 
 WATER_LEVEL_STATUS_MAP = {0: WATER_LEVEL_OK, 1: WATER_LEVEL_EMPTY, WATER_LEVEL_OK: 0, WATER_LEVEL_EMPTY: 1}
 
-RGB_LEVEL_PRESETS = (0, 1, 31, 61)
+DEFAULT_RGB_LEVEL = 2
+RGB_LEVEL_PRESETS = (0, 1, DEFAULT_RGB_LEVEL, 31, 61)
 
 RGB_MAP = {}
 
@@ -87,7 +88,7 @@ class PyDreoHumidifier(PyDreoBaseDevice):
         self._worktime = None
         self._foglevel = None
         self._rgblevel = None
-        self._last_rgblevel = 1
+        self._last_rgblevel = DEFAULT_RGB_LEVEL
         self._rgbth = None
         self._scheon = None
         self._fog_level = None
@@ -113,6 +114,11 @@ class PyDreoHumidifier(PyDreoBaseDevice):
             modes = None
         _LOGGER.debug("parse_modes: Detected preset modes - %s", modes)
         return modes
+
+    def _remember_rgblevel(self, value: int | None) -> None:
+        """Remember the last known non-off ambient light level."""
+        if isinstance(value, int) and value > 0:
+            self._last_rgblevel = value
 
     @property
     def is_on(self):
@@ -471,6 +477,7 @@ class PyDreoHumidifier(PyDreoBaseDevice):
         self._worktime = self.get_state_update_value(state, WORKTIME_KEY)
         self._foglevel = self.get_state_update_value(state, FOGLEVEL_INTERNAL_KEY)
         self._rgblevel = self.get_state_update_value(state, RGB_LEVEL)
+        self._remember_rgblevel(self._rgblevel)
         self._rgbth = self.get_state_update_value(state, RGB_TH)
         self._scheon = self.get_state_update_value(state, SCHEDULE_ENABLE)
         self._fog_level = self.get_state_update_value(state, FOG_LEVEL_KEY)
@@ -503,9 +510,7 @@ class PyDreoHumidifier(PyDreoBaseDevice):
 
         val_rgblevel = self.get_server_update_key_value(message, RGB_LEVEL)
         if isinstance(val_rgblevel, int):
-            if val_rgblevel > 0:
-                self._last_rgblevel = val_rgblevel
-            val_rgblevel = RGB_MAP.get(val_rgblevel, val_rgblevel)
+            self._remember_rgblevel(val_rgblevel)
             self._rgblevel = val_rgblevel
 
         val_rgbth = self.get_server_update_key_value(message, RGB_TH)

--- a/custom_components/dreo/pydreo/pydreohumidifier.py
+++ b/custom_components/dreo/pydreo/pydreohumidifier.py
@@ -421,18 +421,19 @@ class PyDreoHumidifier(PyDreoBaseDevice):
         """Return True if the water level RGB indicator is enabled."""
         if self._rgblevel is None:
             return None
-        return self._rgblevel == LIGHT_ON
+        return self._rgblevel > 0
 
     @rgb_indicator.setter
     def rgb_indicator(self, value: bool) -> None:
         """Set the water level RGB indicator on/off."""
         _LOGGER.debug("rgb_indicator: rgb_indicator.setter(%s) --> %s", self.name, value)
-        new_level = LIGHT_ON if value else LIGHT_OFF
-        if self._rgblevel == new_level:
-            _LOGGER.debug("rgb_indicator: rgb_indicator - value already %s, skipping command", value)
+        current = self._rgblevel is not None and self._rgblevel > 0
+        if current == value:
+            _LOGGER.debug("rgb_indicator: value already %s, skipping command", value)
             return
-        self._rgblevel = new_level
-        self._send_command(RGB_LEVEL, RGB_MAP[new_level])
+        send_value = self._last_rgblevel if value else 0
+        self._rgblevel = send_value
+        self._send_command(RGB_LEVEL, send_value)
 
     @property
     def scheon(self):


### PR DESCRIPTION
## Problem

On the DR-HHM001S (HM311S/411S), after a Home Assistant restart the ambient light cannot be turned on from HA unless the Dreo app is used first.

**Root cause:** the device only activates the ambient light when sent `rgblevel=2`, but `_last_rgblevel` initialises to `1`. After restart the device reports `rgblevel=0`; toggling the light from HA sends `1`, which the device silently ignores.

Diagnostics confirm the only relevant difference between a working state (after Dreo-app command) and a broken state (after HA restart) is `_last_rgblevel`: `2` vs `1`.

## Changes

- Add `DEFAULT_RGB_LEVEL = 2` constant for the correct restored level
- Add `_remember_rgblevel()` helper that persists any non-zero rgblevel
- Call it from `update_state` (REST poll) and `handle_server_update` (WebSocket push) so the level is kept up to date automatically
- Remove the `RGB_MAP.get()` no-op in `handle_server_update` (map is empty, result was always the input value)

Closes #649