### PR TITLE
feat(config_flow): add region selector for non-US Dreo accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Copy the `dreo` directory into your `/config/custom_components` directory, then 
 3. Click `Add integration` (blue button at the bottom right of the screen)
 4. Search `Dreo` and select it
 5. Enter your `Dreo` username & password (same login you use on the Dreo app)
+6. If your Dreo account is registered in Europe, pick **Europe** from the Region dropdown. Most users can leave this on **Auto-detect**.
 
 Once the Dreo app has been installed,
 

--- a/custom_components/dreo/__init__.py
+++ b/custom_components/dreo/__init__.py
@@ -20,7 +20,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         _LOGGER.debug("async_setup_entry: auto_reconnect is None.  Default to True")
         auto_reconnect = True
 
-    region = "us"
+    region = config_entry.data.get(CONF_REGION)
+    if region == "auto":
+        region = None
 
     from .pydreo import PyDreo  # pylint: disable=C0415
     from .pydreo.constant import DreoDeviceType  # pylint: disable=C0415
@@ -35,7 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             return False
         pydreo_manager = PyDreo("TEST_EMAIL", "TEST_PASSWORD", redact=True, debug_test_mode=True, debug_test_mode_payload=debug__test_mode_payload)
     else:
-        pydreo_manager = PyDreo(username, password, region)
+        pydreo_manager = PyDreo(username, password, region=region)
         pydreo_manager.auto_reconnect = auto_reconnect
 
     login = await hass.async_add_executor_job(pydreo_manager.login)

--- a/custom_components/dreo/config_flow.py
+++ b/custom_components/dreo/config_flow.py
@@ -4,12 +4,20 @@ import logging
 from typing import Any, Dict
 from collections import OrderedDict
 import voluptuous as vol
+from homeassistant.helpers import selector
 
 from .haimports import *  # pylint: disable=W0401,W0614
 from .const import DOMAIN, CONF_AUTO_RECONNECT
 from .pydreo import PyDreo
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_REGION_AUTO = "auto"
+REGION_OPTIONS = [
+    {"value": CONF_REGION_AUTO, "label": "Auto-detect"},
+    {"value": "NA", "label": "North America"},
+    {"value": "EU", "label": "Europe"},
+]
 
 OPTIONS_SCHEMA = vol.Schema({vol.Required(CONF_AUTO_RECONNECT): bool})
 
@@ -51,6 +59,12 @@ class DreoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.data_schema = OrderedDict()
         self.data_schema[vol.Required(CONF_USERNAME)] = str
         self.data_schema[vol.Required(CONF_PASSWORD)] = str
+        self.data_schema[vol.Optional(CONF_REGION, default=CONF_REGION_AUTO)] = selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=REGION_OPTIONS,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
+        )
 
     @callback
     def _show_form(self, errors=None):
@@ -71,15 +85,17 @@ class DreoFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         self._username = user_input[CONF_USERNAME]
         self._password = user_input[CONF_PASSWORD]
+        region = user_input.get(CONF_REGION, CONF_REGION_AUTO)
+        normalized_region = None if region == CONF_REGION_AUTO else region
 
-        pydreo_manager = PyDreo(self._username, self._password, "us")
+        pydreo_manager = PyDreo(self._username, self._password, region=normalized_region)
         login = await self.hass.async_add_executor_job(pydreo_manager.login)
         if not login:
             return self._show_form(errors={"base": "invalid_auth"})
 
         return self.async_create_entry(
             title=self._username,
-            data={CONF_USERNAME: self._username, CONF_PASSWORD: self._password},
+            data={CONF_USERNAME: self._username, CONF_PASSWORD: self._password, CONF_REGION: region},
         )
 
     @staticmethod

--- a/custom_components/dreo/pydreo/__init__.py
+++ b/custom_components/dreo/pydreo/__init__.py
@@ -51,11 +51,25 @@ _DREO_DEVICE_TYPE_TO_CLASS = {
 class PyDreo:  # pylint: disable=function-redefined
     """Dreo API functions."""
 
-    def __init__(self, username, password, redact=True, debug_test_mode=False, debug_test_mode_payload=None, token=None) -> None:
+    def __init__(
+        self,
+        username,
+        password,
+        redact=True,
+        debug_test_mode=False,
+        debug_test_mode_payload=None,
+        token=None,
+        region: str | None = None,
+    ) -> None:
         """Initialize Dreo class with username, password and time zone."""
         self._transport = CommandTransport(self._transport_consume_message)
 
-        self.auth_region = DREO_AUTH_REGION_NA  # Will get the region from the auth call
+        if region in (DREO_AUTH_REGION_NA, DREO_AUTH_REGION_EU):
+            self.auth_region = region
+        else:
+            self.auth_region = DREO_AUTH_REGION_NA
+            if region not in (None, "auto"):
+                _LOGGER.warning("__init__: Invalid auth region %s. Defaulting to %s", region, DREO_AUTH_REGION_NA)
 
         self._redact = redact
         if redact:

--- a/custom_components/dreo/strings.json
+++ b/custom_components/dreo/strings.json
@@ -5,7 +5,11 @@
           "title": "Enter Dreo Username and Password",
           "data": {
             "username": "[%key:common::config_flow::data::email%]",
-            "password": "[%key:common::config_flow::data::password%]"
+            "password": "[%key:common::config_flow::data::password%]",
+            "region": "Region"
+          },
+          "data_description": {
+            "region": "Pick the Dreo cloud region for your account. Auto-detect works for most users."
           }
         }
       },

--- a/custom_components/dreo/translations/de.json
+++ b/custom_components/dreo/translations/de.json
@@ -5,7 +5,11 @@
         "title": "Dreo-Kontodaten eingeben",
         "data": {
           "username": "E-Mail-Adresse",
-          "password": "Passwort"
+          "password": "Passwort",
+          "region": "Region"
+        },
+        "data_description": {
+          "region": "Wählen Sie die Dreo-Cloud-Region für Ihr Konto. Automatische Erkennung funktioniert für die meisten Benutzer."
         }
       }
     },

--- a/custom_components/dreo/translations/en.json
+++ b/custom_components/dreo/translations/en.json
@@ -5,7 +5,11 @@
           "title": "Enter Dreo Username and Password",
           "data": {
             "username": "Email Address",
-            "password": "Password"
+            "password": "Password",
+            "region": "Region"
+          },
+          "data_description": {
+            "region": "Pick the Dreo cloud region for your account. Auto-detect works for most users."
           }
         }
       },

--- a/custom_components/dreo/translations/es.json
+++ b/custom_components/dreo/translations/es.json
@@ -5,7 +5,11 @@
         "title": "Introduce las credenciales de tu cuenta Dreo",
         "data": {
           "username": "Correo electrónico",
-          "password": "Contraseña"
+          "password": "Contraseña",
+          "region": "Región"
+        },
+        "data_description": {
+          "region": "Selecciona la región de la nube de Dreo para tu cuenta. La detección automática funciona para la mayoría de usuarios."
         }
       }
     },

--- a/custom_components/dreo/translations/it.json
+++ b/custom_components/dreo/translations/it.json
@@ -5,7 +5,11 @@
         "title": "Inserisci username e password Dreo",
         "data": {
           "username": "Indirizzo email",
-          "password": "Password"
+          "password": "Password",
+          "region": "Regione"
+        },
+        "data_description": {
+          "region": "Seleziona la regione cloud di Dreo per il tuo account. Il rilevamento automatico funziona per la maggior parte degli utenti."
         }
       }
     },

--- a/tests/dreo/test_config_flow.py
+++ b/tests/dreo/test_config_flow.py
@@ -18,12 +18,13 @@ class TestDreoFlowHandler:
         assert flow._username is None
         assert flow._password is None
         assert isinstance(flow.data_schema, OrderedDict)
-        assert len(flow.data_schema) == 2
+        assert len(flow.data_schema) == 3
 
-        # Check that username and password fields are in the schema
+        # Check that username, password, and region fields are in the schema
         keys = list(flow.data_schema.keys())
         assert any("username" in str(key) for key in keys)
         assert any("password" in str(key) for key in keys)
+        assert any("region" in str(key) for key in keys)
 
     def test_show_form_no_errors(self):
         """Test _show_form with no errors returns form with empty errors dict."""
@@ -99,13 +100,41 @@ class TestDreoFlowHandler:
         assert flow._password == "testpass123"
 
         # Verify PyDreo was instantiated correctly
-        mock_pydreo.assert_called_once_with("test@example.com", "testpass123", "us")
+        mock_pydreo.assert_called_once_with("test@example.com", "testpass123", region=None)
 
         # Verify login was called
         mock_hass.async_add_executor_job.assert_called_once_with(mock_manager.login)
 
         # Verify entry was created
-        flow.async_create_entry.assert_called_once_with(title="test@example.com", data={"username": "test@example.com", "password": "testpass123"})
+        flow.async_create_entry.assert_called_once_with(
+            title="test@example.com",
+            data={"username": "test@example.com", "password": "testpass123", "region": "auto"},
+        )
+
+    def test_async_step_user_login_success_with_eu_region(self):
+        """Test async_step_user stores and passes an explicit EU region."""
+        flow = DreoFlowHandler()
+        flow._async_current_entries = MagicMock(return_value=[])
+        flow.async_create_entry = MagicMock(return_value="entry_result")
+
+        mock_hass = MagicMock()
+        mock_hass.async_add_executor_job = AsyncMock(return_value=True)
+        flow.hass = mock_hass
+
+        user_input = {"username": "test@example.com", "password": "testpass123", "region": "EU"}
+
+        with patch("custom_components.dreo.config_flow.PyDreo") as mock_pydreo:
+            mock_manager = MagicMock()
+            mock_pydreo.return_value = mock_manager
+
+            result = asyncio.run(flow.async_step_user(user_input=user_input))
+
+        assert result == "entry_result"
+        mock_pydreo.assert_called_once_with("test@example.com", "testpass123", region="EU")
+        flow.async_create_entry.assert_called_once_with(
+            title="test@example.com",
+            data={"username": "test@example.com", "password": "testpass123", "region": "EU"},
+        )
 
     def test_async_step_user_login_failure(self):
         """Test async_step_user with failed login shows form with invalid_auth error."""
@@ -130,7 +159,7 @@ class TestDreoFlowHandler:
         assert flow._password == "wrongpassword"
 
         # Verify PyDreo was instantiated
-        mock_pydreo.assert_called_once_with("test@example.com", "wrongpassword", "us")
+        mock_pydreo.assert_called_once_with("test@example.com", "wrongpassword", region=None)
 
         # Verify login was attempted
         mock_hass.async_add_executor_job.assert_called_once_with(mock_manager.login)

--- a/tests/pydreo/test_pydreo.py
+++ b/tests/pydreo/test_pydreo.py
@@ -31,6 +31,32 @@ class TestPyDreoApiServerRegion:
             _ = pydreo.api_server_region
 
 
+class TestPyDreoAuthRegionInit:
+    """Test auth region initialization."""
+
+    def test_region_default_is_na(self):
+        """Test missing region defaults to NA."""
+        pydreo = PyDreo("user", "pass")
+        assert pydreo.auth_region == DREO_AUTH_REGION_NA
+
+    def test_region_explicit_eu(self):
+        """Test explicit EU region is used."""
+        pydreo = PyDreo("user", "pass", region=DREO_AUTH_REGION_EU)
+        assert pydreo.auth_region == DREO_AUTH_REGION_EU
+
+    def test_region_invalid_falls_back_to_na(self, caplog):
+        """Test invalid region falls back to NA."""
+        caplog.set_level(logging.WARNING)
+        pydreo = PyDreo("user", "pass", region="ZZ")
+        assert pydreo.auth_region == DREO_AUTH_REGION_NA
+        assert "Invalid auth region ZZ" in caplog.text
+
+    def test_region_none_uses_default(self):
+        """Test None region defaults to NA."""
+        pydreo = PyDreo("user", "pass", region=None)
+        assert pydreo.auth_region == DREO_AUTH_REGION_NA
+
+
 class TestPyDreoRedact:
     """Test redact property setter."""
 


### PR DESCRIPTION
## Summary

Adds an optional **Region** dropdown (Auto-detect / North America / Europe) to the Dreo config flow. Pinning a region skips the auth-detect retry round trip on every restart for non-NA accounts. Auto-detect is the default and preserves today's behavior, so existing config entries keep working without migration.

hi jeff :)

## Why this matters

Issue [#544](https://github.com/JeffSteinbok/hass-dreo/issues/544) lays out the gap clearly: `region` is hard-coded to `"us"` in `config_flow.py` and `__init__.py`, so non-NA accounts have no way to pick a region at setup. Two related auth-failure issues hint at the same surface ([#360](https://github.com/JeffSteinbok/hass-dreo/issues/360), [#397](https://github.com/JeffSteinbok/hass-dreo/issues/397)).

While reviewing the call sites, I noticed a latent bug: the third positional `"us"` arg actually binds to `redact=True` in `PyDreo.__init__`, not to anything region-related. The auto-detect retry at `pydreo/__init__.py:312-317` is what currently makes EU logins succeed. 

The hard-coded `"us"` does nothing on its own... so this PR fixes that wiring and surfaces the choice in the config flow.

## Testing

- `ruff check .`: clean
- `pytest`: 650 passed (4 new tests for `PyDreo` region init + 1 new test for the EU config-flow path; the existing `async_step_user_login_failure` test was updated to match the keyword-form call)
- Existing entries (no `region` key in `config_entry.data`) round-trip through the new code as `None -> auto-detect`, matching the prior behavior.

The third-region case (`AP`) is intentionally not in this PR. `pydreo/constant.py` only defines `NA` and `EU` today, and adding a guess without test coverage felt like the wrong call. Easy follow-up once someone with an AP account provides diagnostics.

Closes #544

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
