### PR TITLE
fix: use round() instead of ceil() for light brightness conversion

### DIFF
--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -169,7 +169,7 @@ class DreoLightHA(DreoBaseDeviceHA, LightEntity):  # pylint: disable=abstract-me
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
             _LOGGER.debug("turn_on: Setting brightness to %s", brightness)
-            setattr(self.pydreo_device, self._brightness_attr, math.ceil(brightness_to_value(self._brightness_scale, brightness)))
+            setattr(self.pydreo_device, self._brightness_attr, round(brightness_to_value(self._brightness_scale, brightness)))
 
         # Handle color temperature adjustment (part of turn_on action, not a separate method)
         if ATTR_COLOR_TEMP_KELVIN in kwargs:
@@ -197,7 +197,7 @@ class DreoLightHA(DreoBaseDeviceHA, LightEntity):  # pylint: disable=abstract-me
             return None
 
         # Convert device's brightness scale (e.g., 1-100) to HA's 0-255 scale
-        return math.ceil(value_to_brightness(self._brightness_scale, getattr(self.pydreo_device, self._brightness_attr, 0)))
+        return round(value_to_brightness(self._brightness_scale, getattr(self.pydreo_device, self._brightness_attr, 0)))
 
     @property
     def color_temp_kelvin(self) -> int | None:

--- a/tests/dreo/integrationtests/test_dreoceilingfan.py
+++ b/tests/dreo/integrationtests/test_dreoceilingfan.py
@@ -101,9 +101,9 @@ class TestDreoCeilingFan(IntegrationTestBase):
 
                 with patch(PATCH_SEND_COMMAND) as mock_send_command:
                     # Brightness is converted from HA's 0-255 scale to device's 1-100 scale
-                    # 128/255 * 100 = ~50.2, which gets ceil'd to 51
+                    # 128/255 * 100 = ~50.2, which gets rounded to 50
                     light_switch.turn_on(brightness=128)
-                    mock_send_command.assert_called_once_with(pydreo_fan, {BRIGHTNESS_KEY: 51})
+                    mock_send_command.assert_called_once_with(pydreo_fan, {BRIGHTNESS_KEY: 50})
 
     def test_HCF002S(self):  # pylint: disable=invalid-name
         """Load fan and test sending commands."""
@@ -249,9 +249,9 @@ class TestDreoCeilingFan(IntegrationTestBase):
 
             with patch(PATCH_SEND_COMMAND) as mock_send_command:
                 # Brightness is converted from HA's 0-255 scale to device's 1-100 scale
-                # 128/255 * 100 = ~50.2, which gets ceil'd to 51
+                # 128/255 * 100 = ~50.2, which gets rounded to 50
                 light_switch.turn_on(brightness=128)
-                mock_send_command.assert_called_once_with(pydreo_fan, {BRIGHTNESS_KEY: 51})
+                mock_send_command.assert_called_once_with(pydreo_fan, {BRIGHTNESS_KEY: 50})
             pydreo_fan.handle_server_update({REPORTED_KEY: {BRIGHTNESS_KEY: 51}})
 
             # Test color temperature if supported


### PR DESCRIPTION
## Problem

Setting brightness to 1% in HA resulted in 2% on the device. Similarly, 10% → 11%, 96% → 97%.

## Root Cause

\\math.ceil()\\ was used to convert between HA's 0-255 brightness scale and Dreo's 0-100 scale. This consistently rounded up, causing off-by-one errors:
- User sets 1% → HA converts to brightness 3 (of 255) → \\ceil(3/255 * 100)\\ = **2** → device shows 2%

## Fix

Replace \\math.ceil()\\ with \\ound()\\ for brightness conversions in both directions (writing to device and reading back). Color temperature conversion is unaffected.

Closes #651