### PR TITLE
Rework humidifier ambient light: replace switches with Light entity

### DIFF
--- a/.github/workflows/issue-template-check.yml
+++ b/.github/workflows/issue-template-check.yml
@@ -14,6 +14,23 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            // Skip check for collaborators with write/admin access
+            const sender = context.payload.sender.login;
+            try {
+              const { data: permLevel } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: sender,
+              });
+              const permission = permLevel.permission;
+              if (permission === 'admin' || permission === 'write') {
+                core.info(`Issue opened by collaborator ${sender} (${permission}). Skipping template check.`);
+                return;
+              }
+            } catch (e) {
+              core.info(`Could not check permissions for ${sender}: ${e.message}. Proceeding with template check.`);
+            }
+
             const body = context.payload.issue.body || '';
 
             // Each template produces specific ### headers in the issue body.

--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -48,6 +48,11 @@ def get_entries(pydreo_devices: list[PyDreoBaseDevice]) -> list[DreoLightHA]:
             _LOGGER.debug("get_entries: Adding RGB Light for %s", pydreo_device.name)
             light_ha_collection.append(DreoRGBLightHA(pydreo_device))
 
+        # Check if device has an ambient light ring (humidifiers, evaporative coolers)
+        if pydreo_device.is_feature_supported("rgblevel"):
+            _LOGGER.debug("get_entries: Adding Ambient Light for %s", pydreo_device.name)
+            light_ha_collection.append(DreoHumidifierLightHA(pydreo_device))
+
     return light_ha_collection
 
 
@@ -274,3 +279,120 @@ class DreoRGBLightHA(DreoLightHA):
             rgb = kwargs[ATTR_RGB_COLOR]
             _LOGGER.debug("turn_on: Setting RGB color to %s", rgb)
             setattr(self.pydreo_device, "atm_color_rgb", rgb)
+
+
+class DreoHumidifierLightHA(DreoBaseDeviceHA, LightEntity):  # pylint: disable=abstract-method
+    """Ambient light ring for Dreo humidifiers and evaporative coolers.
+
+    Controls the colored LED ring via the rgblevel API field.
+    - On/off: rgblevel 0=off, >0=on
+    - Brightness (if model supports 3 levels): rgblevel 0=off, 1=low, 2=full
+    - RGB color (if model supports rgbcolor): direct color picker
+    """
+
+    def __init__(self, pyDreoDevice: PyDreoBaseDevice) -> None:
+        """Initialize the ambient light entity."""
+        super().__init__(pyDreoDevice)
+        self.device = pyDreoDevice
+
+        self.entity_description = EntityDescription("Ambient Light")
+        self._attr_name = self.pydreo_device.name + " Ambient Light"
+        self._attr_unique_id = f"{self.pydreo_device.serial_number}-ambient-light"
+        self._attr_icon = "mdi:lightbulb"
+
+        # Determine brightness levels from model details
+        details = getattr(pyDreoDevice, "device_definition", None)
+        self._levels = getattr(details, "ambient_light_levels", None) if details else None
+        if self._levels is None:
+            self._levels = (0, 2)  # default: off/full only
+
+        # Determine supported color modes
+        self._has_rgb = pyDreoDevice.is_feature_supported("rgbcolor")
+        self._has_brightness = len(self._levels) > 2  # more than just off/on
+
+        modes: set[ColorMode] = set()
+        if self._has_rgb:
+            modes.add(ColorMode.RGB)
+        if self._has_brightness:
+            modes.add(ColorMode.BRIGHTNESS)
+        if not modes:
+            modes.add(ColorMode.ONOFF)
+        self._supported_modes = modes
+
+        _LOGGER.info("new DreoHumidifierLightHA instance(%s), unique ID %s, levels=%s, rgb=%s",
+                     self._attr_name, self._attr_unique_id, self._levels, self._has_rgb)
+
+    @property
+    def supported_color_modes(self) -> set[ColorMode]:
+        """Return the set of supported color modes."""
+        return self._supported_modes
+
+    @property
+    def color_mode(self) -> ColorMode:
+        """Return the active color mode."""
+        if self._has_rgb and getattr(self.device, "rgbmode", None) == 1:
+            return ColorMode.RGB
+        if self._has_brightness:
+            return ColorMode.BRIGHTNESS
+        return ColorMode.ONOFF
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if the ambient light is on."""
+        rgblevel = getattr(self.device, "rgblevel", None)
+        return rgblevel is not None and int(rgblevel) > 0
+
+    @property
+    def brightness(self) -> int | None:
+        """Return brightness on HA's 0-255 scale."""
+        if not self._has_brightness:
+            return None
+        rgblevel = getattr(self.device, "rgblevel", None)
+        if rgblevel is None or int(rgblevel) == 0:
+            return 0
+        # Map: 1 (low) -> 128, 2 (full) -> 255
+        return 128 if int(rgblevel) == 1 else 255
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the current RGB color."""
+        if not self._has_rgb:
+            return None
+        rgbcolor = getattr(self.device, "rgbcolor", None)
+        if rgbcolor is None:
+            return None
+        # Unpack 24-bit integer to (r, g, b)
+        r = (rgbcolor >> 16) & 0xFF
+        g = (rgbcolor >> 8) & 0xFF
+        b = rgbcolor & 0xFF
+        return (r, g, b)
+
+    def turn_on(self, **kwargs: Any) -> None:
+        """Turn on the ambient light, optionally setting brightness or color."""
+        _LOGGER.debug("turn_on: Turning on ambient light %s, kwargs=%s", self.pydreo_device.name, kwargs)
+
+        # Determine desired rgblevel
+        if ATTR_BRIGHTNESS in kwargs and self._has_brightness:
+            brightness = kwargs[ATTR_BRIGHTNESS]
+            # Map HA brightness (1-255) to rgblevel: 1-127 -> 1 (low), 128-255 -> 2 (full)
+            desired_level = 1 if brightness < 128 else 2
+        else:
+            # Default to full brightness
+            desired_level = max(self._levels)
+
+        self.device.rgblevel = desired_level
+
+        # Handle RGB color
+        if ATTR_RGB_COLOR in kwargs and self._has_rgb:
+            r, g, b = kwargs[ATTR_RGB_COLOR]
+            color_value = (r << 16) | (g << 8) | b
+            _LOGGER.debug("turn_on: Setting RGB color to (%d,%d,%d) -> %d", r, g, b, color_value)
+            # Auto-switch to color mode
+            if getattr(self.device, "rgbmode", None) != 1:
+                self.device.rgbmode = 1
+            self.device.rgbcolor = color_value
+
+    def turn_off(self, **kwargs: Any) -> None:
+        """Turn off the ambient light."""
+        _LOGGER.debug("turn_off: Turning off ambient light %s", self.pydreo_device.name)
+        self.device.rgblevel = 0

--- a/custom_components/dreo/pydreo/constant.py
+++ b/custom_components/dreo/pydreo/constant.py
@@ -61,6 +61,8 @@ LEDKEPTON_KEY = "ledkepton"
 LEDLEVEL_KEY = "ledlevel"
 RGB_LEVEL = "rgblevel"
 RGB_TH = "rgbth"
+RGB_MODE = "rgbmode"
+RGB_COLOR = "rgbcolor"
 LED_LEVEL_KEY = "ledlevel"
 SCHEDULE_ENABLE = "scheon"
 

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -73,6 +73,10 @@ class DreoDeviceDetails:
     override_fn: Callable | None
     """Optional function called once after initial state load to apply hardware-specific overrides."""
 
+    ambient_light_levels: tuple | None
+    """Valid rgblevel values for the ambient light ring. None = not set (use default).
+    Examples: (0, 2) = off/full only, (0, 1, 2) = off/low/full."""
+
     def __init__(
         self,
         device_type: DreoDeviceType = None,
@@ -84,6 +88,7 @@ class DreoDeviceDetails:
         cooking_modes: list[str] = None,
         cooking_range: dict = None,
         override_fn: Callable | None = None,
+        ambient_light_levels: tuple | None = None,
     ):
         if device_type is None:
             raise ValueError("device_type is required")
@@ -99,6 +104,7 @@ class DreoDeviceDetails:
         self.cooking_modes = cooking_modes
         self.cooking_range = cooking_range
         self.override_fn = override_fn
+        self.ambient_light_levels = ambient_light_levels
 
 
 @dataclass
@@ -331,7 +337,11 @@ SUPPORTED_DEVICES = {
         cooking_modes=COOKING_MODES,
         cooking_range=COOKING_RANGES,
     ),
-    "DR-HHM": DreoDeviceDetails(device_type=DreoDeviceType.HUMIDIFIER),
+    "DR-HHM": DreoDeviceDetails(device_type=DreoDeviceType.HUMIDIFIER, ambient_light_levels=(0, 2)),
+    "DR-HHM003S": DreoDeviceDetails(
+        device_type=DreoDeviceType.HUMIDIFIER,
+        ambient_light_levels=(0, 1, 2),
+    ),
     "DR-HHM014S": DreoDeviceDetails(
         device_type=DreoDeviceType.HUMIDIFIER,
         preset_modes=[

--- a/custom_components/dreo/pydreo/pydreohumidifier.py
+++ b/custom_components/dreo/pydreo/pydreohumidifier.py
@@ -18,6 +18,8 @@ from .constant import (
     LED_LEVEL_KEY,
     RGB_LEVEL,
     RGB_TH,
+    RGB_MODE,
+    RGB_COLOR,
     SCHEDULE_ENABLE,
 )
 
@@ -41,10 +43,6 @@ LIGHT_ON = "Enable"
 LIGHT_OFF = "Disabled"
 
 WATER_LEVEL_STATUS_MAP = {0: WATER_LEVEL_OK, 1: WATER_LEVEL_EMPTY, WATER_LEVEL_OK: 0, WATER_LEVEL_EMPTY: 1}
-
-RGB_LEVEL_PRESETS = (0, 1, 31, 61)
-
-RGB_MAP = {}
 
 LEDLEVEL_MAP = {0: LIGHT_OFF, 2: LIGHT_ON, LIGHT_OFF: 0, LIGHT_ON: 2}
 
@@ -87,8 +85,9 @@ class PyDreoHumidifier(PyDreoBaseDevice):
         self._worktime = None
         self._foglevel = None
         self._rgblevel = None
-        self._last_rgblevel = 2
         self._rgbth = None
+        self._rgbmode = None
+        self._rgbcolor = None
         self._scheon = None
         self._fog_level = None
         self._ledlevel = None
@@ -320,8 +319,18 @@ class PyDreoHumidifier(PyDreoBaseDevice):
 
     @property
     def rgblevel(self) -> int | None:
-        """Return raw ambient light level reported by the API."""
+        """Return raw ambient light level reported by the API (0=off, 1=low, 2=full)."""
         return self._rgblevel
+
+    @rgblevel.setter
+    def rgblevel(self, value: int) -> None:
+        """Set the raw rgblevel value (0=off, 1=low, 2=full)."""
+        _LOGGER.debug("rgblevel: rgblevel.setter(%s) --> %s", self.name, value)
+        if self._rgblevel == value:
+            _LOGGER.debug("rgblevel: value already %s, skipping command", value)
+            return
+        self._rgblevel = value  # optimistic update
+        self._send_command(RGB_LEVEL, value)
 
     @property
     def ambient_light(self) -> bool | None:
@@ -332,36 +341,44 @@ class PyDreoHumidifier(PyDreoBaseDevice):
 
     @ambient_light.setter
     def ambient_light(self, value: bool) -> None:
-        """Set ambient light on/off using the raw rgblevel values."""
+        """Set ambient light on/off. Sends rgblevel=2 for on, 0 for off."""
         _LOGGER.debug("ambient_light: ambient_light.setter(%s) --> %s", self.name, value)
-        desired = self._last_rgblevel if value else 0
+        desired = 2 if value else 0
         if self._rgblevel == desired:
             _LOGGER.debug("ambient_light: value already %s, skipping command", value)
             return
-        self._rgblevel = desired  # optimistic update so HA reflects state immediately
+        self._rgblevel = desired  # optimistic update
         self._send_command(RGB_LEVEL, desired)
 
     @property
-    def ambient_light_level(self) -> int | None:
-        """Return the raw ambient light slider value."""
-        return self._rgblevel
+    def rgbmode(self) -> int | None:
+        """Return the ambient light mode (0=humidity indicator, 1=fixed color)."""
+        return self._rgbmode
 
-    @ambient_light_level.setter
-    def ambient_light_level(self, value: int) -> None:
-        """Set the ambient light slider value."""
-        try:
-            requested = int(value)
-        except (TypeError, ValueError) as ex:
-            raise ValueError(f"ambient_light_level must be an integer, got {value!r}") from ex
-
-        desired = min(RGB_LEVEL_PRESETS, key=lambda preset: abs(preset - requested))
-        if self._rgblevel == desired:
-            _LOGGER.debug("ambient_light_level: value already %s, skipping command", desired)
+    @rgbmode.setter
+    def rgbmode(self, value: int) -> None:
+        """Set the ambient light mode."""
+        _LOGGER.debug("rgbmode: rgbmode.setter(%s) --> %s", self.name, value)
+        if self._rgbmode == value:
+            _LOGGER.debug("rgbmode: value already %s, skipping command", value)
             return
-        if desired > 0:
-            self._last_rgblevel = desired
-        self._rgblevel = desired
-        self._send_command(RGB_LEVEL, desired)
+        self._rgbmode = value  # optimistic update
+        self._send_command(RGB_MODE, value)
+
+    @property
+    def rgbcolor(self) -> int | None:
+        """Return the ambient light RGB color as a packed 24-bit integer."""
+        return self._rgbcolor
+
+    @rgbcolor.setter
+    def rgbcolor(self, value: int) -> None:
+        """Set the ambient light RGB color (packed 24-bit integer)."""
+        _LOGGER.debug("rgbcolor: rgbcolor.setter(%s) --> %s", self.name, value)
+        if self._rgbcolor == value:
+            _LOGGER.debug("rgbcolor: value already %s, skipping command", value)
+            return
+        self._rgbcolor = value  # optimistic update
+        self._send_command(RGB_COLOR, value)
 
     @property
     def rgbth(self):
@@ -411,24 +428,6 @@ class PyDreoHumidifier(PyDreoBaseDevice):
         self._send_command(RGB_TH, payload)
 
     @property
-    def rgb_indicator(self) -> bool | None:
-        """Return True if the water level RGB indicator is enabled."""
-        if self._rgblevel is None:
-            return None
-        return self._rgblevel == LIGHT_ON
-
-    @rgb_indicator.setter
-    def rgb_indicator(self, value: bool) -> None:
-        """Set the water level RGB indicator on/off."""
-        _LOGGER.debug("rgb_indicator: rgb_indicator.setter(%s) --> %s", self.name, value)
-        new_level = LIGHT_ON if value else LIGHT_OFF
-        if self._rgblevel == new_level:
-            _LOGGER.debug("rgb_indicator: rgb_indicator - value already %s, skipping command", value)
-            return
-        self._rgblevel = new_level
-        self._send_command(RGB_LEVEL, RGB_MAP[new_level])
-
-    @property
     def scheon(self):
         """Returns `True` if the device is on, `False` otherwise."""
         return self._scheon
@@ -472,6 +471,8 @@ class PyDreoHumidifier(PyDreoBaseDevice):
         self._foglevel = self.get_state_update_value(state, FOGLEVEL_INTERNAL_KEY)
         self._rgblevel = self.get_state_update_value(state, RGB_LEVEL)
         self._rgbth = self.get_state_update_value(state, RGB_TH)
+        self._rgbmode = self.get_state_update_value(state, RGB_MODE)
+        self._rgbcolor = self.get_state_update_value(state, RGB_COLOR)
         self._scheon = self.get_state_update_value(state, SCHEDULE_ENABLE)
         self._fog_level = self.get_state_update_value(state, FOG_LEVEL_KEY)
 
@@ -503,14 +504,19 @@ class PyDreoHumidifier(PyDreoBaseDevice):
 
         val_rgblevel = self.get_server_update_key_value(message, RGB_LEVEL)
         if isinstance(val_rgblevel, int):
-            if val_rgblevel > 0:
-                self._last_rgblevel = val_rgblevel
-            val_rgblevel = RGB_MAP.get(val_rgblevel, val_rgblevel)
             self._rgblevel = val_rgblevel
 
         val_rgbth = self.get_server_update_key_value(message, RGB_TH)
         if isinstance(val_rgbth, str):
             self._rgbth = val_rgbth
+
+        val_rgbmode = self.get_server_update_key_value(message, RGB_MODE)
+        if isinstance(val_rgbmode, int):
+            self._rgbmode = val_rgbmode
+
+        val_rgbcolor = self.get_server_update_key_value(message, RGB_COLOR)
+        if isinstance(val_rgbcolor, int):
+            self._rgbcolor = val_rgbcolor
 
         val_ledlevel = self.get_server_update_key_value(message, LED_LEVEL_KEY)
         if isinstance(val_ledlevel, int):

--- a/custom_components/dreo/select.py
+++ b/custom_components/dreo/select.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 import logging
 
@@ -28,6 +29,7 @@ class DreoSelectEntityDescription(SelectEntityDescription):
     attr_name: str | None = None
     options_list: list[str] = field(default_factory=list)
     raw_values: list[int] = field(default_factory=list)
+    exists_fn: Callable[[PyDreoBaseDevice], bool] | None = None
 
 
 SELECTS: tuple[DreoSelectEntityDescription, ...] = (
@@ -38,6 +40,17 @@ SELECTS: tuple[DreoSelectEntityDescription, ...] = (
         icon="mdi:weather-windy",
         options_list=["low", "medium", "high"],
         raw_values=[1, 2, 3],
+        exists_fn=lambda device: device.type == DreoDeviceType.HUMIDIFIER and device.is_feature_supported("mist_level"),
+    ),
+    DreoSelectEntityDescription(
+        key="Ambient Light Mode",
+        translation_key="ambient_light_mode",
+        attr_name="rgbmode",
+        icon="mdi:lightbulb-cog",
+        options_list=["humidity", "color"],
+        raw_values=[0, 1],
+        exists_fn=lambda device: device.type in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER}
+        and device.is_feature_supported("rgbmode"),
     ),
 )
 
@@ -48,7 +61,7 @@ def get_entries(pydreo_devices: list[PyDreoBaseDevice]) -> list["DreoSelectHA"]:
 
     for device in pydreo_devices:
         for sel in SELECTS:
-            if device.type != DreoDeviceType.HUMIDIFIER:
+            if sel.exists_fn is not None and not sel.exists_fn(device):
                 continue
             if not device.is_feature_supported(sel.attr_name):
                 continue

--- a/custom_components/dreo/sensor.py
+++ b/custom_components/dreo/sensor.py
@@ -36,6 +36,9 @@ from .pydreo.pydreohumidifier import (
     MODE_NORMAL,
     MODE_AUTO,
     MODE_SLEEP,
+    WATER_LEVEL_OK,
+    WATER_LEVEL_EMPTY,
+    WATER_LEVEL_STATUS_KEY,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -104,6 +107,14 @@ SENSORS: tuple[DreoSensorEntityDescription, ...] = (
         native_unit_of_measurement=CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
         value_fn=lambda device: device.pm25,
         exists_fn=lambda device: device.is_feature_supported(PM25_KEY),
+    ),
+    DreoSensorEntityDescription(
+        key="Water Level",
+        translation_key="water",
+        device_class=SensorDeviceClass.ENUM,
+        options=[WATER_LEVEL_OK, WATER_LEVEL_EMPTY],
+        value_fn=lambda device: device.water_level,
+        exists_fn=lambda device: device.is_feature_supported(WATER_LEVEL_STATUS_KEY),
     ),
     DreoSensorEntityDescription(
         key="Use since cleaning HM",

--- a/custom_components/dreo/strings.json
+++ b/custom_components/dreo/strings.json
@@ -47,8 +47,6 @@
         "light":                    { "name": "Light" },
         "humidify":                 { "name": "Humidify" },
         "display_light":            { "name": "Display Light" },
-        "ambient_light":            { "name": "Ambient Light" },
-        "rgb_indicator":            { "name": "Water Level Indicator" },
         "auto_mode":                { "name": "Auto Turn On" },
         "scheon":                   { "name": "Schedule" }
       },
@@ -60,8 +58,7 @@
         "status":            { "name": "Status" },
         "pm25":              { "name": "PM2.5" },
         "water":             { "name": "Water Level" },
-        "use_hours_hm":      { "name": "Use Since Cleaning" },
-        "light_hm":          { "name": "Ambient Light" }
+        "use_hours_hm":      { "name": "Use Since Cleaning" }
       },
       "number": {
         "horizontal_angle":             { "name": "Horizontal Angle" },
@@ -76,8 +73,8 @@
         "target_humidity":              { "name": "Target Humidity" },
         "fog_level":                    { "name": "Fog Level" },
         "sleep_target_humidity":        { "name": "Sleep Target Humidity" },
-        "ambient_light_threshold_low":  { "name": "Ambient Light Threshold Low" },
-        "ambient_light_threshold_high": { "name": "Ambient Light Threshold High" },
+        "ambient_light_threshold_low":  { "name": "Ambient Light Humidity Low Threshold" },
+        "ambient_light_threshold_high": { "name": "Ambient Light Humidity High Threshold" },
         "ambient_light_level":          { "name": "Ambient Light Level" }
       },
       "select": {
@@ -87,6 +84,13 @@
             "low": "Low",
             "medium": "Medium",
             "high": "High"
+          }
+        },
+        "ambient_light_mode": {
+          "name": "Ambient Light Mode",
+          "state": {
+            "humidity": "Humidity",
+            "color": "Color"
           }
         }
       }

--- a/custom_components/dreo/switch.py
+++ b/custom_components/dreo/switch.py
@@ -99,18 +99,6 @@ SWITCHES: tuple[DreoSwitchEntityDescription, ...] = (
         icon="mdi:led-on",
     ),
     DreoSwitchEntityDescription(
-        key="Ambient Light Mode",
-        translation_key="ambient_light",
-        attr_name="ambient_light",
-        icon="mdi:lightbulb",
-    ),
-    DreoSwitchEntityDescription(
-        key="Water Level Indicator",
-        translation_key="rgb_indicator",
-        attr_name="rgb_indicator",
-        icon="mdi:led-outline",
-    ),
-    DreoSwitchEntityDescription(
         key="Auto Turn On",
         translation_key="auto_mode",
         attr_name="auto_mode",

--- a/custom_components/dreo/translations/de.json
+++ b/custom_components/dreo/translations/de.json
@@ -47,7 +47,6 @@
       "light":                    { "name": "Licht" },
       "humidify":                 { "name": "Befeuchten" },
       "display_light":            { "name": "Display-Beleuchtung" },
-      "ambient_light":            { "name": "Umgebungslicht" },
       "auto_mode":                { "name": "Automatisches Einschalten" },
       "scheon":                   { "name": "Zeitplan" }
     },
@@ -59,8 +58,7 @@
       "status":            { "name": "Status" },
       "pm25":              { "name": "PM2.5" },
       "water":             { "name": "Wasserstand" },
-      "use_hours_hm":      { "name": "Nutzung seit Reinigung" },
-      "light_hm":          { "name": "Umgebungslicht" }
+      "use_hours_hm":      { "name": "Nutzung seit Reinigung" }
     },
     "number": {
       "horizontal_angle":             { "name": "Horizontaler Winkel" },
@@ -73,8 +71,8 @@
       "horizontal_oscillation_angle": { "name": "Horizontaler Oszillationswinkel" },
       "vertical_oscillation_angle":   { "name": "Vertikaler Oszillationswinkel" },
       "target_humidity":              { "name": "Ziel-Luftfeuchtigkeit" },
-      "ambient_light_threshold_low":  { "name": "Umgebungslicht-Schwelle niedrig" },
-      "ambient_light_threshold_high": { "name": "Umgebungslicht-Schwelle hoch" },
+      "ambient_light_threshold_low":  { "name": "Umgebungslicht Feuchtigkeitsschwelle niedrig" },
+      "ambient_light_threshold_high": { "name": "Umgebungslicht Feuchtigkeitsschwelle hoch" },
       "ambient_light_level":          { "name": "Umgebungslicht-Stufe" }
     },
     "select": {
@@ -84,6 +82,13 @@
           "low": "Niedrig",
           "medium": "Mittel",
           "high": "Hoch"
+        }
+      },
+      "ambient_light_mode": {
+        "name": "Umgebungslicht-Modus",
+        "state": {
+          "humidity": "Feuchtigkeit",
+          "color": "Farbe"
         }
       }
     }

--- a/custom_components/dreo/translations/en.json
+++ b/custom_components/dreo/translations/en.json
@@ -47,8 +47,6 @@
         "light":                    { "name": "Light" },
         "humidify":                 { "name": "Humidify" },
         "display_light":            { "name": "Display Light" },
-        "ambient_light":            { "name": "Ambient Light" },
-        "rgb_indicator":            { "name": "Water Level Indicator" },
         "auto_mode":                { "name": "Auto Turn On" },
         "scheon":                   { "name": "Schedule" }
       },
@@ -60,8 +58,7 @@
         "status":            { "name": "Status" },
         "pm25":              { "name": "PM2.5" },
         "water":             { "name": "Water Level" },
-        "use_hours_hm":      { "name": "Use Since Cleaning" },
-        "light_hm":          { "name": "Ambient Light" }
+        "use_hours_hm":      { "name": "Use Since Cleaning" }
       },
       "number": {
         "horizontal_angle":             { "name": "Horizontal Angle" },
@@ -76,8 +73,8 @@
         "target_humidity":              { "name": "Target Humidity" },
         "fog_level":                    { "name": "Fog Level" },
         "sleep_target_humidity":        { "name": "Sleep Target Humidity" },
-        "ambient_light_threshold_low":  { "name": "Ambient Light Threshold Low" },
-        "ambient_light_threshold_high": { "name": "Ambient Light Threshold High" },
+        "ambient_light_threshold_low":  { "name": "Ambient Light Humidity Low Threshold" },
+        "ambient_light_threshold_high": { "name": "Ambient Light Humidity High Threshold" },
         "ambient_light_level":          { "name": "Ambient Light Level" }
       },
       "select": {
@@ -87,6 +84,13 @@
             "low": "Low",
             "medium": "Medium",
             "high": "High"
+          }
+        },
+        "ambient_light_mode": {
+          "name": "Ambient Light Mode",
+          "state": {
+            "humidity": "Humidity",
+            "color": "Color"
           }
         }
       }

--- a/custom_components/dreo/translations/es.json
+++ b/custom_components/dreo/translations/es.json
@@ -47,7 +47,6 @@
       "light":                    { "name": "Luz" },
       "humidify":                 { "name": "Humidificar" },
       "display_light":            { "name": "Luz de pantalla" },
-      "ambient_light":            { "name": "Luz ambiental" },
       "auto_mode":                { "name": "Encendido automático" },
       "scheon":                   { "name": "Programación" }
     },
@@ -59,8 +58,7 @@
       "status":            { "name": "Estado" },
       "pm25":              { "name": "PM2.5" },
       "water":             { "name": "Nivel de agua" },
-      "use_hours_hm":      { "name": "Uso desde la limpieza" },
-      "light_hm":          { "name": "Luz ambiental" }
+      "use_hours_hm":      { "name": "Uso desde la limpieza" }
     },
     "number": {
       "horizontal_angle":             { "name": "Ángulo horizontal" },
@@ -73,8 +71,8 @@
       "horizontal_oscillation_angle": { "name": "Ángulo de oscilación horizontal" },
       "vertical_oscillation_angle":   { "name": "Ángulo de oscilación vertical" },
       "target_humidity":              { "name": "Humedad objetivo" },
-      "ambient_light_threshold_low":  { "name": "Umbral de luz ambiental bajo" },
-      "ambient_light_threshold_high": { "name": "Umbral de luz ambiental alto" },
+      "ambient_light_threshold_low":  { "name": "Umbral de humedad de luz ambiental bajo" },
+      "ambient_light_threshold_high": { "name": "Umbral de humedad de luz ambiental alto" },
       "ambient_light_level":          { "name": "Nivel de luz ambiental" }
     },
     "select": {
@@ -84,6 +82,13 @@
           "low": "Bajo",
           "medium": "Medio",
           "high": "Alto"
+        }
+      },
+      "ambient_light_mode": {
+        "name": "Modo de luz ambiental",
+        "state": {
+          "humidity": "Humedad",
+          "color": "Color"
         }
       }
     }

--- a/custom_components/dreo/translations/it.json
+++ b/custom_components/dreo/translations/it.json
@@ -47,7 +47,6 @@
       "light":                    { "name": "Luce" },
       "humidify":                 { "name": "Umidifica" },
       "display_light":            { "name": "Luce display" },
-      "ambient_light":            { "name": "Luce ambientale" },
       "auto_mode":                { "name": "Accensione automatica" },
       "scheon":                   { "name": "Programmazione" }
     },
@@ -59,8 +58,7 @@
       "status":            { "name": "Stato" },
       "pm25":              { "name": "PM2.5" },
       "water":             { "name": "Livello acqua" },
-      "use_hours_hm":      { "name": "Ore dalla pulizia" },
-      "light_hm":          { "name": "Luce ambientale" }
+      "use_hours_hm":      { "name": "Ore dalla pulizia" }
     },
     "number": {
       "horizontal_angle":             { "name": "Angolo orizzontale" },
@@ -73,8 +71,8 @@
       "horizontal_oscillation_angle": { "name": "Angolo oscillazione orizzontale" },
       "vertical_oscillation_angle":   { "name": "Angolo oscillazione verticale" },
       "target_humidity":              { "name": "Umidità target" },
-      "ambient_light_threshold_low":  { "name": "Soglia luce ambientale bassa" },
-      "ambient_light_threshold_high": { "name": "Soglia luce ambientale alta" },
+      "ambient_light_threshold_low":  { "name": "Soglia umidità luce ambientale bassa" },
+      "ambient_light_threshold_high": { "name": "Soglia umidità luce ambientale alta" },
       "ambient_light_level":          { "name": "Livello luce ambientale" }
     },
     "select": {
@@ -84,6 +82,13 @@
           "low":    "Bassa",
           "medium": "Media",
           "high":   "Alta"
+        }
+      },
+      "ambient_light_mode": {
+        "name": "Modalità luce ambientale",
+        "state": {
+          "humidity": "Umidità",
+          "color": "Colore"
         }
       }
     }

--- a/tests/dreo/integrationtests/test_dreodehumidifier.py
+++ b/tests/dreo/integrationtests/test_dreodehumidifier.py
@@ -65,9 +65,9 @@ class TestDreoDeHumidifier(IntegrationTestBase):
             assert target_humidity_number is not None, "Target Humidity number should exist"
             assert target_humidity_number.native_value == 50, "Target Humidity number value should be 50"
 
-            # Check sensors (no Water Level enum sensor; water status exposed via binary sensor)
+            # Check sensors
             sensors = sensor.get_entries([pydreo_dehumidifier])
-            self.verify_expected_entities(sensors, ["Humidity", "Temperature"])
+            self.verify_expected_entities(sensors, ["Humidity", "Temperature", "Water Level"])
 
             # Check water empty binary sensor (derived from error code)
             binary_sensors = binary_sensor.get_entries([pydreo_dehumidifier])
@@ -118,9 +118,9 @@ class TestDreoDeHumidifier(IntegrationTestBase):
             assert target_humidity_number is not None, "Target Humidity number should exist"
             assert target_humidity_number.native_value == 55, "Target Humidity number value should be 55"
 
-            # Check sensors (no Water Level enum sensor; water status exposed via binary sensor)
+            # Check sensors
             sensors = sensor.get_entries([pydreo_dehumidifier])
-            self.verify_expected_entities(sensors, ["Humidity", "Temperature"])
+            self.verify_expected_entities(sensors, ["Humidity", "Temperature", "Water Level"])
 
             # Check water empty binary sensor (derived from error code)
             binary_sensors = binary_sensor.get_entries([pydreo_dehumidifier])

--- a/tests/dreo/integrationtests/test_dreohumidifier.py
+++ b/tests/dreo/integrationtests/test_dreohumidifier.py
@@ -8,6 +8,7 @@ from custom_components.dreo import number
 from custom_components.dreo import humidifier
 from custom_components.dreo import sensor
 from custom_components.dreo import switch
+from custom_components.dreo import light
 from homeassistant.components.humidifier import HumidifierEntityFeature
 
 from .imports import *  # pylint: disable=W0401,W0614
@@ -56,13 +57,17 @@ class TestDreoHumidifier(IntegrationTestBase):
 
             # Check to see what sensors are added
             sensors = sensor.get_entries([pydreo_humidifier])
-            self.verify_expected_entities(sensors, ["Humidity", "Use since cleaning HM"])
+            self.verify_expected_entities(sensors, ["Humidity", "Use since cleaning HM", "Water Level"])
 
-            # Check to see what switches are added - ambient light, display, sound, schedule, water indicator
+            # Check to see what switches are added - display, sound, schedule
             switches = switch.get_entries([pydreo_humidifier])
             self.verify_expected_entities(
-                switches, ["Ambient Light Mode", "Display Light", "Panel Sound", "Schedule", "Water Level Indicator"]
+                switches, ["Display Light", "Panel Sound", "Schedule"]
             )
+
+            # Check to see what lights are added - ambient light entity
+            lights = light.get_entries([pydreo_humidifier])
+            self.verify_expected_entities(lights, ["Ambient Light"])
 
             # Check to see what binary sensors are added - water empty
             binary_sensors = binary_sensor.get_entries([pydreo_humidifier])
@@ -100,12 +105,16 @@ class TestDreoHumidifier(IntegrationTestBase):
 
             # Check to see what sensors are added
             sensors = sensor.get_entries([pydreo_humidifier])
-            self.verify_expected_entities(sensors, ["Humidity", "Use since cleaning HM"])
+            self.verify_expected_entities(sensors, ["Humidity", "Use since cleaning HM", "Water Level"])
+
+            # Check to see what lights are added
+            lights = light.get_entries([pydreo_humidifier])
+            self.verify_expected_entities(lights, ["Ambient Light"])
 
             # Check to see what switches are added - HHM014S has no Display Light
             switches = switch.get_entries([pydreo_humidifier])
             self.verify_expected_entities(
-                switches, ["Ambient Light Mode", "Panel Sound", "Schedule", "Water Level Indicator"]
+                switches, ["Panel Sound", "Schedule"]
             )
 
             # Check to see what binary sensors are added - water empty
@@ -167,13 +176,17 @@ class TestDreoHumidifier(IntegrationTestBase):
             assert worktime_sensor is not None, "Use since cleaning sensor should exist for HHM003S"
             assert worktime_sensor.native_value == 10, "Use since cleaning sensor value should be 10 for HHM003S"
 
-            self.verify_expected_entities(sensors, ["Humidity", "Use since cleaning HM"])
+            self.verify_expected_entities(sensors, ["Humidity", "Use since cleaning HM", "Water Level"])
 
             # Check to see what switches are added
             switches = switch.get_entries([pydreo_humidifier])
             self.verify_expected_entities(
-                switches, ["Ambient Light Mode", "Display Light", "Panel Sound", "Schedule", "Water Level Indicator"]
+                switches, ["Display Light", "Panel Sound", "Schedule"]
             )
+
+            # Check to see what lights are added
+            lights = light.get_entries([pydreo_humidifier])
+            self.verify_expected_entities(lights, ["Ambient Light"])
 
             # Check to see what binary sensors are added - water empty
             binary_sensors = binary_sensor.get_entries([pydreo_humidifier])
@@ -212,12 +225,16 @@ class TestDreoHumidifier(IntegrationTestBase):
 
             # Check to see what sensors are added
             sensors = sensor.get_entries([pydreo_humidifier])
-            self.verify_expected_entities(sensors, ["Humidity", "Use since cleaning HM"])
+            self.verify_expected_entities(sensors, ["Humidity", "Use since cleaning HM", "Water Level"])
+
+            # Check to see what lights are added
+            lights = light.get_entries([pydreo_humidifier])
+            self.verify_expected_entities(lights, ["Ambient Light"])
 
             # Check to see what switches are added
             switches = switch.get_entries([pydreo_humidifier])
             self.verify_expected_entities(
-                switches, ["Ambient Light Mode", "Display Light", "Panel Sound", "Schedule", "Water Level Indicator"]
+                switches, ["Display Light", "Panel Sound", "Schedule"]
             )
 
             # Check to see what binary sensors are added - water empty
@@ -258,12 +275,16 @@ class TestDreoHumidifier(IntegrationTestBase):
 
             # Check to see what sensors are added
             sensors = sensor.get_entries([pydreo_humidifier])
-            self.verify_expected_entities(sensors, ["Humidity", "Use since cleaning HM"])
+            self.verify_expected_entities(sensors, ["Humidity", "Use since cleaning HM", "Water Level"])
+
+            # Check to see what lights are added
+            lights = light.get_entries([pydreo_humidifier])
+            self.verify_expected_entities(lights, ["Ambient Light"])
 
             # Check to see what switches are added
             switches = switch.get_entries([pydreo_humidifier])
             self.verify_expected_entities(
-                switches, ["Ambient Light Mode", "Display Light", "Panel Sound", "Schedule", "Water Level Indicator"]
+                switches, ["Display Light", "Panel Sound", "Schedule"]
             )
 
             # Check to see what binary sensors are added - water empty

--- a/tests/pydreo/test_pydreohumidifier.py
+++ b/tests/pydreo/test_pydreohumidifier.py
@@ -417,7 +417,7 @@ class TestPyDreoHumidifier(TestBase):
         self.pydreo_manager.load_devices()
         humidifier: PyDreoHumidifier = self.pydreo_manager.devices[0]
         humidifier.handle_server_update({REPORTED_KEY: {"rgblevel": 2}})
-        assert humidifier.rgblevel == 2  # RGB_MAP is empty, so raw int is stored
+        assert humidifier.rgblevel == 2
 
     def test_handle_server_update_scheon(self):
         """Test handle_server_update processes scheon."""


### PR DESCRIPTION
## Summary

Fixes #660 — resolves the conflict between "Water Level Indicator" and "Ambient Light" switches that both used the `rgblevel` field.

Related to #662 (debug log collection for rgblevel behavior — still open for additional device data).

## What Changed

### Removed
- **Water Level Indicator switch** (`rgb_indicator`) — completely broken (`RGB_MAP` was always empty, used string values instead of ints)
- **Ambient Light Mode switch** (`ambient_light`) — replaced by proper Light entity
- **Ambient Light Humidifier sensor** — replaced by Light entity's on/off state
- Dead code: `RGB_MAP`, `RGB_LEVEL_PRESETS`, `_last_rgblevel` tracking

### Added
- **`DreoHumidifierLightHA`** Light entity for the ambient LED ring:
  - On/off via `rgblevel` (0=off, 2=full)
  - **Dimmable brightness** for 3-level models like HHM003S (0=off, 1=low, 2=full)
  - **RGB color support** for models with `rgbcolor` (HHM015S, HEC002S)
  - Auto-switches `rgbmode=1` (color mode) when setting an RGB color
- **Ambient Light Mode** Select entity for `rgbmode` (Humidity / Color) — only on models that support it
- `rgbmode` and `rgbcolor` properties on `PyDreoHumidifier`
- `ambient_light_levels` capability field in `DreoDeviceDetails`
- DR-HHM003S model entry with confirmed 3-level brightness support

### Changed
- Threshold Number entity display names: "Ambient Light Humidity Low/High Threshold" (entity IDs unchanged)
- All translations updated (en, de, es, it)

## Breaking Changes

Users who had the old "Ambient Light" switch or "Water Level Indicator" switch will see those entities disappear, replaced by the new Light entity. Automations referencing the old switch entity IDs will need updating.

## Testing

- All 656 tests pass
- Ruff: 0 errors
- Integration tests updated for all humidifier models (HHM001S, HHM003S, HHM006S, HHM014S, HHM015S)
- Tested on debug test server with all device types

## Open Questions (tracked in separate issues)

- #670 — Confirm `rgbmode` values (0=humidity, 1=color)
- #671 — Which models support `rgblevel=1` (low brightness)
- #672 — Does HHM005S have `rgblevel`
- #673 — Confirm `rgbcolor` 24-bit packing format
- #674 — Any additional `rgbmode` values beyond 0/1