### PR TITLE
Add DR-HAF008S air circulator support (565S series)

### DIFF
--- a/DEVICE_OWNERS.md
+++ b/DEVICE_OWNERS.md
@@ -94,7 +94,7 @@ Sourced from GitHub issues, PRs, and contributed test data.
 |---|---|---|
 | DR-HAP002S | [@cameronbowe](https://github.com/cameronbowe), [@CSSGeek94](https://github.com/CSSGeek94), [@Monsterray](https://github.com/Monsterray) | [#63](https://github.com/JeffSteinbok/hass-dreo/issues/63), [#260](https://github.com/JeffSteinbok/hass-dreo/issues/260), [#76](https://github.com/JeffSteinbok/hass-dreo/issues/76) |
 | DR-HAP003S | [@nertwork](https://github.com/nertwork), [@UberMentch](https://github.com/UberMentch) | [#22](https://github.com/JeffSteinbok/hass-dreo/issues/22), [#149](https://github.com/JeffSteinbok/hass-dreo/issues/149) |
-| DR-HAP005S | [@TheShai1](https://github.com/TheShai1) | [#282](https://github.com/JeffSteinbok/hass-dreo/issues/282) |
+| DR-HAP005S | [@TheShai1](https://github.com/TheShai1), [@calpay2000-afk](https://github.com/calpay2000-afk) | [#282](https://github.com/JeffSteinbok/hass-dreo/issues/282), [#612](https://github.com/JeffSteinbok/hass-dreo/issues/612) |
 
 ## Floor Fans (DR-HAF)
 

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -215,6 +215,11 @@ SUPPORTED_DEVICES = {
         device_type=DreoDeviceType.AIR_CIRCULATOR,
         override_fn=_haf004s_mcu_override,
     ),
+    "DR-HAF008S": DreoDeviceDetails(
+        device_type=DreoDeviceType.AIR_CIRCULATOR,
+        preset_modes=[("normal", 1), ("natural", 2), ("sleep", 3), ("auto", 4)],
+        device_ranges={SPEED_RANGE: (1, 9)},
+    ),
     "DR-HPF": DreoDeviceDetails(device_type=DreoDeviceType.AIR_CIRCULATOR),
     # HPF-series devices: The API returns controlsConf with only a template reference
     # (e.g. {"template": "DR-HPF002S"}) and no control/schedule.modes data, so

--- a/tests/dreo/integrationtests/test_dreoaircirculator.py
+++ b/tests/dreo/integrationtests/test_dreoaircirculator.py
@@ -169,6 +169,90 @@ class TestDreoAirCirculator(IntegrationTestBase):
             assert pydreo_fan.model == "DR-HAF004S"
             assert pydreo_fan.vertical_angle_range == (-30, 90)
 
+    def test_HAF008S(self):  # pylint: disable=invalid-name
+        """Test HAF008S air circulator (565S series)."""
+        with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):
+            self.get_devices_file_name = "get_devices_HAF008S.json"
+            self.pydreo_manager.load_devices()
+            assert len(self.pydreo_manager.devices) == 1
+
+            pydreo_fan = self.pydreo_manager.devices[0]
+            ha_fan = fan.DreoFanHA(pydreo_fan)
+            assert ha_fan.is_on is False
+            assert ha_fan.speed_count == 9
+            assert ha_fan.supported_features & FanEntityFeature.OSCILLATE
+            assert ha_fan.supported_features & FanEntityFeature.PRESET_MODE
+            assert ha_fan.unique_id is not None
+            assert pydreo_fan.model == "DR-HAF008S"
+            assert pydreo_fan.speed_range == (1, 9)
+
+            # Verify preset modes
+            assert pydreo_fan.preset_modes == ["normal", "natural", "sleep", "auto"]
+            assert pydreo_fan.preset_mode == "normal"
+            assert ha_fan.preset_modes == ["normal", "natural", "sleep", "auto"]
+            assert ha_fan.preset_mode == "normal"
+
+            # Test percentage calculation doesn't crash (was the bug in #678)
+            assert ha_fan.percentage is not None
+            assert ha_fan.percentage >= 0 and ha_fan.percentage <= 100
+
+            # Test power commands
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.turn_on()
+                mock_send_command.assert_called_once_with(pydreo_fan, {POWERON_KEY: True})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: True}})
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.turn_off()
+                mock_send_command.assert_called_once_with(pydreo_fan, {POWERON_KEY: False})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: False}})
+
+            # Test speed settings
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_percentage(11)  # Speed 1
+                # Fan is off, so this also turns it on
+                assert mock_send_command.call_count == 2
+                calls = [call[0][1] for call in mock_send_command.call_args_list]
+                assert {POWERON_KEY: True} in calls
+                assert {WINDLEVEL_KEY: 1} in calls
+            pydreo_fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: True, WINDLEVEL_KEY: 1}})
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_percentage(100)  # Speed 9 (max)
+                mock_send_command.assert_called_once_with(pydreo_fan, {WINDLEVEL_KEY: 9})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {WINDLEVEL_KEY: 9}})
+
+            # Test oscillation (oscmode-based)
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.oscillate(True)
+                mock_send_command.assert_called_once_with(pydreo_fan, {OSCMODE_KEY: 1})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {OSCMODE_KEY: 1}})
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.oscillate(False)
+                mock_send_command.assert_called_once_with(pydreo_fan, {OSCMODE_KEY: 0})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {OSCMODE_KEY: 0}})
+
+            # Test preset mode commands
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_preset_mode("natural")
+                mock_send_command.assert_called_once_with(pydreo_fan, {WIND_MODE_KEY: 2})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: 2}})
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_preset_mode("sleep")
+                mock_send_command.assert_called_once_with(pydreo_fan, {WIND_MODE_KEY: 3})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: 3}})
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_preset_mode("auto")
+                mock_send_command.assert_called_once_with(pydreo_fan, {WIND_MODE_KEY: 4})
+            pydreo_fan.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: 4}})
+
+            # Check switches
+            switches = switch.get_entries([pydreo_fan])
+            self.verify_expected_entities(switches, ["Horizontally Oscillating", "Panel Sound", "Vertically Oscillating"])
+
     def test_HPF007S(self):  # pylint: disable=invalid-name
         """Test test_HPF007S fan."""
         with patch(PATCH_SCHEDULE_UPDATE_HA_STATE) as mock_update_ha_state:

--- a/tests/pydreo/api_responses/get_device_state_HAF008S_1.json
+++ b/tests/pydreo/api_responses/get_device_state_HAF008S_1.json
@@ -1,0 +1,115 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "mixed": {
+      "wifi_rssi": {
+        "state": -58,
+        "timestamp": 1779308283
+      },
+      "poweron": {
+        "state": false,
+        "timestamp": 1779310641
+      },
+      "scheid": {
+        "state": 0,
+        "timestamp": 1779308283
+      },
+      "timeron": {
+        "state": {
+          "du": 0,
+          "ts": 1779308282
+        },
+        "timestamp": null
+      },
+      "scheon": {
+        "state": false,
+        "timestamp": 1779308283
+      },
+      "mode": {
+        "state": 1,
+        "timestamp": 1779308554
+      },
+      "mcuon": {
+        "state": true,
+        "timestamp": 1779308283
+      },
+      "network_latency": {
+        "state": 12,
+        "timestamp": 1779308284
+      },
+      "module_hardware_model": {
+        "state": "HeFi",
+        "timestamp": 1779308283
+      },
+      "mcu_firmware_version": {
+        "state": "0.3.8",
+        "timestamp": 1779308283
+      },
+      "oscmode": {
+        "state": 0,
+        "timestamp": 1779310898
+      },
+      "customconf": {
+        "state": "temp:23333334444446666668888889",
+        "timestamp": 1779308542
+      },
+      "temperature": {
+        "state": 69,
+        "timestamp": 1779310497
+      },
+      "module_hardware_mac": "**REDACTED**",
+      "muteon": {
+        "state": true,
+        "timestamp": 1779308283
+      },
+      "wifi_ssid": "**REDACTED**",
+      "mcu_hardware_model": {
+        "state": "SC95F8613B/US",
+        "timestamp": 1779308283
+      },
+      "windlevel": {
+        "state": 3,
+        "timestamp": 1779308556
+      },
+      "wrong": {
+        "state": 0,
+        "timestamp": 1779308283
+      },
+      "module_firmware_version": {
+        "state": "3.7.11",
+        "timestamp": 1779308283
+      },
+      "connected": {
+        "state": true,
+        "timestamp": 1779308283
+      },
+      "timeroff": {
+        "state": {
+          "du": 0,
+          "ts": 1779308282
+        },
+        "timestamp": null
+      },
+      "_ota": {
+        "state": 0,
+        "timestamp": 1779308283
+      },
+      "ledkepton": {
+        "state": false,
+        "timestamp": 1779308283
+      },
+      "childlockon": {
+        "state": false,
+        "timestamp": 1779308283
+      },
+      "tempoffset": {
+        "state": 0,
+        "timestamp": 1779308283
+      }
+    },
+    "sn": "HAF008S_1",
+    "productId": "1899715254844731393",
+    "region": "eu-central-1/emq"
+  }
+}

--- a/tests/pydreo/api_responses/get_devices_HAF008S.json
+++ b/tests/pydreo/api_responses/get_devices_HAF008S.json
@@ -1,0 +1,43 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "currentPage": 1,
+    "pageSize": 100,
+    "totalNum": 1,
+    "totalPage": 1,
+    "familyRooms": null,
+    "list": [
+      {
+        "deviceId": "2057194130473824257",
+        "sn": "HAF008S_1",
+        "brand": "Dreo",
+        "model": "DR-HAF008S",
+        "productId": "1899715254844731393",
+        "productName": "Air Circulator",
+        "deviceName": "Air Circulator - DR-HAF008S",
+        "shared": false,
+        "series": null,
+        "seriesName": "565S",
+        "type": 0,
+        "owner": true,
+        "familyId": null,
+        "familyName": null,
+        "roomId": null,
+        "roomName": null,
+        "roomNameI18Key": "",
+        "color": "b",
+        "controlsConf": {},
+        "mainConf": {
+          "isSmart": true,
+          "isWifi": true,
+          "isBluetooth": true,
+          "isVoiceControl": true
+        },
+        "resourcesConf": {},
+        "servicesConf": [],
+        "userManuals": []
+      }
+    ]
+  }
+}

--- a/tests/pydreo/test_pydreoaircirculator.py
+++ b/tests/pydreo/test_pydreoaircirculator.py
@@ -246,6 +246,84 @@ class TestPyDreoAirCirculator(TestBase):
             with pytest.raises(ValueError):
                 fan.preset_mode = "invalid_mode_xyz"
 
+    def test_HAF008S(self):  # pylint: disable=invalid-name
+        """Test HAF008S air circulator (565S series, empty controlsConf)."""
+        self.get_devices_file_name = "get_devices_HAF008S.json"
+        self.pydreo_manager.load_devices()
+
+        assert len(self.pydreo_manager.devices) == 1
+
+        fan: PyDreoAirCirculator = self.pydreo_manager.devices[0]
+
+        # Test initial state values
+        assert fan.speed_range == (1, 9)
+        assert fan.preset_modes == ["normal", "natural", "sleep", "auto"]
+        assert fan.preset_mode == "normal"  # Initial mode is 1
+        assert fan.model == "DR-HAF008S"
+        assert fan.device_name is not None
+        assert fan.serial_number is not None
+        assert fan.is_on is False
+        assert fan.fan_speed == 3
+
+        # Test power commands
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.is_on = True
+            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: True})
+        fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: True}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.is_on = False
+            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: False})
+        fan.handle_server_update({REPORTED_KEY: {POWERON_KEY: False}})
+
+        # Test fan speed commands within range
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.fan_speed = 1
+            mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 1})
+        fan.handle_server_update({REPORTED_KEY: {WINDLEVEL_KEY: 1}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.fan_speed = 9
+            mock_send_command.assert_called_once_with(fan, {WINDLEVEL_KEY: 9})
+        fan.handle_server_update({REPORTED_KEY: {WINDLEVEL_KEY: 9}})
+
+        # Test speed out of range
+        with pytest.raises(ValueError):
+            fan.fan_speed = 0
+
+        with pytest.raises(ValueError):
+            fan.fan_speed = 10
+
+        # Test preset mode commands
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "natural"
+            mock_send_command.assert_called_once_with(fan, {WIND_MODE_KEY: 2})
+        fan.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: 2}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "sleep"
+            mock_send_command.assert_called_once_with(fan, {WIND_MODE_KEY: 3})
+        fan.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: 3}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.preset_mode = "auto"
+            mock_send_command.assert_called_once_with(fan, {WIND_MODE_KEY: 4})
+        fan.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: 4}})
+
+        with pytest.raises(ValueError):
+            fan.preset_mode = "not_a_mode"
+
+        # Test oscillation commands (oscmode-based)
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.oscillating = True
+            mock_send_command.assert_called_once_with(fan, {OSCMODE_KEY: 1})
+        fan.handle_server_update({REPORTED_KEY: {OSCMODE_KEY: 1}})
+
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.oscillating = False
+            mock_send_command.assert_called_once_with(fan, {OSCMODE_KEY: 0})
+        fan.handle_server_update({REPORTED_KEY: {OSCMODE_KEY: 0}})
+
     def test_HPF002S(self):  # pylint: disable=invalid-name
         """Test HPF002S fan."""
         self.get_devices_file_name = "get_devices_HPF002S.json"


### PR DESCRIPTION
## Summary

Adds support for the **DR-HAF008S** air circulator (565S series), fixing the entity unavailable crash reported in #678.

## Problem

The DR-HAF008S has an empty \controlsConf\ from the API, so \speed_range\ cannot be auto-detected and remains \None\. This causes a \TypeError\ crash in \anged_value_to_percentage\ when Home Assistant tries to read the fan entity's state, making the entity permanently unavailable.

## Changes

- **\models.py\**: Added explicit \SUPPORTED_DEVICES\ entry for \DR-HAF008S\ with:
  - Speed range: (1, 9)
  - Preset modes: normal, natural, sleep, auto
- **Test fixtures**: Added \get_devices_HAF008S.json\ and \get_device_state_HAF008S_1.json\ based on diagnostics from #678
- **PyDreo unit test**: Verifies speed range, preset modes, power, speed, oscillation (oscmode-based)
- **Integration test**: Verifies HA fan entity creation, percentage calculation, speed/oscillation/preset mode commands, and switch entities

Fixes #678