### PR TITLE
Fix dehumidifier fan entity broken by temperature_units lookup

### DIFF
--- a/custom_components/dreo/pydreo/pydreodehumidifier.py
+++ b/custom_components/dreo/pydreo/pydreodehumidifier.py
@@ -3,7 +3,7 @@
 import logging
 from typing import TYPE_CHECKING, Dict
 
-from .constant import MODE_KEY, MUTEON_KEY, POWERON_KEY, HUMIDITY_KEY, WINDLEVEL_KEY, CHILDLOCKON_KEY, LIGHTON_KEY, SPEED_RANGE, TEMPERATURE_KEY
+from .constant import MODE_KEY, MUTEON_KEY, POWERON_KEY, HUMIDITY_KEY, WINDLEVEL_KEY, CHILDLOCKON_KEY, LIGHTON_KEY, SPEED_RANGE, TEMPERATURE_KEY, TemperatureUnit
 
 from .pydreobasedevice import PyDreoBaseDevice
 from .models import DreoDeviceDetails
@@ -215,6 +215,13 @@ class PyDreoDehumidifier(PyDreoBaseDevice):
     def temperature(self):
         """Get the current temperature"""
         return self._temperature
+
+    @property
+    def temperature_units(self) -> TemperatureUnit:
+        """Auto-detect the temperature unit from the reported value."""
+        if self._temperature is not None and self._temperature > 50:
+            return TemperatureUnit.FAHRENHEIT
+        return TemperatureUnit.CELSIUS
 
     @property
     def wrong(self):


### PR DESCRIPTION
DreoFanHA.extra_state_attributes was updated in #667 to read self.device.temperature_units. That property is defined on PyDreoFanBase, PyDreoHeater, and PyDreoAirConditioner, but PyDreoDehumidifier extends PyDreoBaseDevice directly and never had it. The dehumidifier still goes through DreoFanHA for its fan-speed entity, so every state read raises AttributeError once the device reports a temperature, knocking the fan entity offline (DR-HDH001S, DR-HDH002S, DR-HDH005S).

Add a temperature_units property to PyDreoDehumidifier mirroring the auto-detection in PyDreoFanBase (Fahrenheit when the reported value exceeds 50, Celsius otherwise).

Review requested for PR #535.