### PR TITLE
Fix Add DR-HTF007S hardware revision detection (4-speed vs 8-speed) #706

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -162,7 +162,7 @@ SUPPORTED_MODEL_PREFIXES = {"DR-HTF", "DR-HAF", "DR-HAP", "DR-HPF", "DR-HCF", "W
 
 # MCU hardware model strings used to identify specific hardware revisions.
 _MCU_HAF004S_OLD_REV = "SC95F8613B"
-_MCU_HTF007S_OLD_REV = ["CMS89F7518/EUR", "CMS89F7518/USA"]
+_MCU_HTF007S_OLD_REV = ("CMS89F7518/EUR", "CMS89F7518/USA")
 
 
 def _haf004s_mcu_override(device) -> None:
@@ -183,9 +183,9 @@ def _haf004s_mcu_override(device) -> None:
 
 def _htf007s_mcu_override(device) -> None:
     """Restrict speed range to (1, 4) for DR-HTF007S units with CMS89F7518 MCU variants.
-
-    Older hardware revisions of the Nomad One S using CMS89F7518/EUR or CMS89F7518/USA 
-    only support 4 speed steps. Newer revisions report a different chip string and support 
+    
+    Older hardware revisions of the Nomad One S using CMS89F7518/EUR or CMS89F7518/USA
+    only support 4 speed steps. Newer revisions report a different chip string and support
     8 speed steps, so this function intentionally leaves them untouched.
     """
     if device.raw_state is None:

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -162,7 +162,7 @@ SUPPORTED_MODEL_PREFIXES = {"DR-HTF", "DR-HAF", "DR-HAP", "DR-HPF", "DR-HCF", "W
 
 # MCU hardware model strings used to identify specific hardware revisions.
 _MCU_HAF004S_OLD_REV = "SC95F8613B"
-_MCU_HTF007S_OLD_REV = "CMS89F7518/EUR"
+_MCU_HTF007S_OLD_REV = ["CMS89F7518/EUR", "CMS89F7518/USA"]
 
 
 def _haf004s_mcu_override(device) -> None:
@@ -182,18 +182,18 @@ def _haf004s_mcu_override(device) -> None:
 
 
 def _htf007s_mcu_override(device) -> None:
-    """Restrict speed range to (1, 4) for DR-HTF007S units with the CMS89F7518/EUR MCU.
+    """Restrict speed range to (1, 4) for DR-HTF007S units with CMS89F7518 MCU variants.
 
-    Older hardware revisions of the Nomad One S using this chip only support 4 speed
-    steps.  Newer revisions report a different chip string and support 8 speed steps,
-    so this function intentionally leaves them untouched.
+    Older hardware revisions of the Nomad One S using CMS89F7518/EUR or CMS89F7518/USA 
+    only support 4 speed steps. Newer revisions report a different chip string and support 
+    8 speed steps, so this function intentionally leaves them untouched.
     """
     if device.raw_state is None:
         return
     mixed = device.raw_state.get("data", {}).get("mixed", {})
     mcu_obj = mixed.get("mcu_hardware_model", {})
     mcu_model = mcu_obj.get("state", "") if isinstance(mcu_obj, dict) else ""
-    if mcu_model == _MCU_HTF007S_OLD_REV:
+    if mcu_model in _MCU_HTF007S_OLD_REV:
         device._speed_range = (1, 4)  # pylint: disable=protected-access
 
 


### PR DESCRIPTION
Fix CMS89F7518/USA variant that #706 broke