### PR TITLE
Fix DR-HPF017S power control: use fanon instead of poweron

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -20,7 +20,6 @@ from .constant import (
     VERTICAL_ANGLE_RANGE,
     DreoACMode,
     DreoACFanMode,
-    FANON_KEY,
     POWERON_KEY,
 )
 
@@ -198,17 +197,6 @@ def _htf007s_mcu_override(device) -> None:
         device._speed_range = (1, 4)  # pylint: disable=protected-access
 
 
-def _hpf017s_power_override(device) -> None:
-    """Use poweron commands for DR-HPF017S even though REST state reports fanon.
-
-    This device sends fanon in both REST state and websocket updates, but must
-    be commanded via poweron.  Set _power_on_key for commands and
-    _power_state_key so websocket state updates are read from fanon.
-    """
-    device._power_on_key = POWERON_KEY  # pylint: disable=protected-access
-    device._power_state_key = FANON_KEY  # pylint: disable=protected-access
-
-
 SUPPORTED_DEVICES = {
     # Tower Fans
     "DR-HTF": DreoDeviceDetails(device_type=DreoDeviceType.TOWER_FAN),
@@ -306,7 +294,6 @@ SUPPORTED_DEVICES = {
     "DR-HPF017S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,
         device_ranges={SPEED_RANGE: (1, 12)},
-        override_fn=_hpf017s_power_override,
     ),
     "DR-HPF007S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,

--- a/tests/pydreo/test_pydreoaircirculator.py
+++ b/tests/pydreo/test_pydreoaircirculator.py
@@ -731,7 +731,7 @@ class TestPyDreoAirCirculator(TestBase):
             fan.fan_speed = 13
 
     def test_HPF017S(self):  # pylint: disable=invalid-name
-        """Test HPF017S uses poweron commands despite reporting fanon in REST state."""
+        """Test HPF017S uses fanon for both commands and state (no poweron key)."""
         self.get_devices_file_name = "get_devices_HPF017S.json"
         self.pydreo_manager.load_devices()
 
@@ -742,26 +742,24 @@ class TestPyDreoAirCirculator(TestBase):
         assert fan.model == "DR-HPF017S"
         assert fan.is_on is True
         assert fan.speed_range == (1, 12)
-        assert fan._power_on_key == POWERON_KEY  # pylint: disable=protected-access
-        assert fan._power_state_key == FANON_KEY  # pylint: disable=protected-access
+        assert fan._power_on_key == FANON_KEY  # pylint: disable=protected-access
 
-        # Command must use poweron key
+        # Command must use fanon key (device does not respond to poweron)
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.is_on = False
-            mock_send_command.assert_called_once_with(fan, {POWERON_KEY: False})
+            mock_send_command.assert_called_once_with(fan, {FANON_KEY: False})
 
-        # Websocket updates come in via fanon (not poweron)
+        # Websocket updates also use fanon
         fan.handle_server_update({REPORTED_KEY: {FANON_KEY: False}})
         assert fan.is_on is False
 
         fan.handle_server_update({REPORTED_KEY: {FANON_KEY: True}})
         assert fan.is_on is True
 
-        # Calling update_state again (as happens in set_device_setting) must not
-        # overwrite _power_on_key back to fanon
+        # Calling update_state again (as happens in set_device_setting) must
+        # preserve fanon as the power key
         self.pydreo_manager.load_device_state(fan)
-        assert fan._power_on_key == POWERON_KEY  # pylint: disable=protected-access
-        assert fan._power_state_key == FANON_KEY  # pylint: disable=protected-access
+        assert fan._power_on_key == FANON_KEY  # pylint: disable=protected-access
 
     def test_HPF025S(self):  # pylint: disable=invalid-name
         """Test HPF025S tall air circulator fan."""


### PR DESCRIPTION
The HPF017S device ignores \poweron\ commands — toggling power in HA would revert after a few seconds. The device uses \anon\ for both reading state AND sending power commands.

## Root Cause

The \_hpf017s_power_override\ introduced in v1.9.8 (#718) incorrectly assumed the device accepts \poweron\ commands. In reality, the device only responds to \anon\ for power control. When HA sent \{poweron: true}\, the device ignored it, then the websocket reported the unchanged state via \anon\, causing HA to revert the toggle.

## Fix

- Remove \_hpf017s_power_override\ — let the device naturally use \anon\ (auto-detected from REST state)
- Keep \speed_range=(1, 12)\ which was correctly added in #718
- Update tests to verify \anon\ is used for both commands and state

Confirmed by multiple users in #703 that the device does not respond to \poweron\.

Fixes #703