### PR TITLE
Add DR-HEC005S (TurboCool Misting Fan 765S) with 12 fan speeds

### DIFF
--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -102,6 +102,7 @@ This document lists all Dreo device models that have been tested and confirmed t
 ## Evaporative Coolers (DR-HEC Series)
 
 - DR-HEC002S
+- DR-HEC005S (TurboCool Misting Fan 765S, 12 fan speeds)
 - DR-HEC006S (DR-HEC516S TurboCool Misting Fan 516S)
 
 ---

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -485,4 +485,12 @@ SUPPORTED_DEVICES = {
         preset_modes=[("Normal", 1), ("Turbo", 2)],
         device_ranges={SPEED_RANGE: (1, 6)},
     ),
+    # DR-HEC005S is the TurboCool Misting Fan 765S.
+    # It has 12 fan speeds; without a dedicated entry it falls back to the
+    # generic "DR-HEC" prefix which caps the speed range at (1, 4).
+    # Preset modes (Normal/Natural/Sleep/Auto) are parsed from controlsConf.
+    "DR-HEC005S": DreoDeviceDetails(
+        device_type=DreoDeviceType.EVAPORATIVE_COOLER,
+        device_ranges={SPEED_RANGE: (1, 12)},
+    ),
 }


### PR DESCRIPTION
Fixes #735

## Summary
The 765S (`DR-HEC005S`) has 12 fan speeds but had no dedicated entry in
`SUPPORTED_DEVICES`, so it fell back to the generic `DR-HEC` prefix which caps
`SPEED_RANGE` at `(1, 4)`. The fan entity therefore reported `percentage_step = 25`
and only 4 of the 12 speeds were reachable.

## Change
- `custom_components/dreo/pydreo/models.py`: add an explicit `DR-HEC005S` entry
  (`EVAPORATIVE_COOLER`, `SPEED_RANGE: (1, 12)`).
- `SUPPORTED_MODELS.md`: list the model under the DR-HEC series.

Preset modes (Normal/Natural/Sleep/Auto) are parsed from `controlsConf`, so they
need no hardcoding.

## Testing
Tested on real hardware (`DR-HEC005S`): after the change `percentage_step` is `8.33`
and individual speeds are selectable — e.g. setting ~58% now lands on speed 7/12
(previously snapped to one of 4 steps).