### PR TITLE
Fix RGBIC preset light support for HCF007S ceiling fans

### DIFF
--- a/custom_components/dreo/haimports.py
+++ b/custom_components/dreo/haimports.py
@@ -68,7 +68,7 @@ from homeassistant.components.number import NumberDeviceClass, NumberEntity, Num
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 
-from homeassistant.components.light import LightEntity, LightEntityFeature, ColorMode, ATTR_COLOR_TEMP_KELVIN, ATTR_BRIGHTNESS, ATTR_RGB_COLOR
+from homeassistant.components.light import LightEntity, LightEntityFeature, ColorMode, ATTR_COLOR_TEMP_KELVIN, ATTR_BRIGHTNESS, ATTR_RGB_COLOR, ATTR_EFFECT
 
 from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorEntityDescription, BinarySensorDeviceClass
 

--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -43,8 +43,12 @@ def get_entries(pydreo_devices: list[PyDreoBaseDevice]) -> list[DreoLightHA]:
             _LOGGER.debug("get_entries: Adding Light for %s", pydreo_device.name)
             light_ha_collection.append(DreoLightHA(pydreo_device))
 
-        # Check if device has an RGB atmosphere light (ceiling fans)
-        if pydreo_device.is_feature_supported("atm_light"):
+        # Check if device has an RGBIC preset-based atmosphere light (e.g., HCF007S)
+        if pydreo_device.is_feature_supported("rgb_preset"):
+            _LOGGER.debug("get_entries: Adding RGBIC Preset Light for %s", pydreo_device.name)
+            light_ha_collection.append(DreoRGBICLightHA(pydreo_device))
+        # Check if device has an RGB atmosphere light with direct color control (ceiling fans)
+        elif pydreo_device.is_feature_supported("atm_color_rgb"):
             _LOGGER.debug("get_entries: Adding RGB Light for %s", pydreo_device.name)
             light_ha_collection.append(DreoRGBLightHA(pydreo_device))
 
@@ -279,6 +283,81 @@ class DreoRGBLightHA(DreoLightHA):
             rgb = kwargs[ATTR_RGB_COLOR]
             _LOGGER.debug("turn_on: Setting RGB color to %s", rgb)
             setattr(self.pydreo_device, "atm_color_rgb", rgb)
+
+
+class DreoRGBICLightHA(DreoLightHA):
+    """RGBIC preset-based atmosphere light for Dreo ceiling fans (e.g., HCF007S).
+
+    Some ceiling fans use an RGBIC (addressable LED) ring that operates via preset
+    effects rather than direct RGB color control. This class exposes preset selection
+    through Home Assistant's light effect system.
+
+    - On/off: atmon (atmosphere light power)
+    - Brightness: atmbri (1-5 scale)
+    - Effects: rgbpresetsel (0-based preset index)
+    """
+
+    # Effect names for RGBIC presets (generic names since API doesn't provide them)
+    EFFECT_NAMES = ["Preset 1", "Preset 2", "Preset 3", "Preset 4"]
+
+    def __init__(self, pyDreoDevice: PyDreoBaseDevice) -> None:
+        """Initialize the RGBIC preset-based atmosphere light."""
+        # Pass RGBIC-specific configuration to parent
+        super().__init__(
+            pyDreoDevice, light_on_attr="atm_light_on", brightness_attr="atm_brightness", brightness_scale=(1, 5)
+        )
+
+        # Override attributes for RGBIC light
+        self.entity_description = EntityDescription("RGBIC Light")
+        self._attr_name = self.pydreo_device.name + " RGB Light"
+        self._attr_unique_id = f"{self.pydreo_device.serial_number}-rgb-light"
+        self._attr_icon = "mdi:led-strip-variant"
+
+        # Use ONOFF mode with effects (not RGB color mode)
+        self._color_mode = ColorMode.ONOFF
+
+        _LOGGER.info("new DreoRGBICLightHA instance(%s), unique ID %s", self._attr_name, self._attr_unique_id)
+
+    @property
+    def supported_features(self) -> LightEntityFeature:
+        """Return the supported features for this light."""
+        return LightEntityFeature.EFFECT
+
+    @property
+    def effect_list(self) -> list[str]:
+        """Return the list of available effects (presets)."""
+        # Use number of presets from device state if available
+        num_presets = getattr(self.pydreo_device, "rgb_preset_num", None)
+        if num_presets is not None and num_presets > 0:
+            return [f"Preset {i + 1}" for i in range(num_presets)]
+        # Fallback to default 4 presets
+        return self.EFFECT_NAMES
+
+    @property
+    def effect(self) -> str | None:
+        """Return the current active effect (preset)."""
+        preset_sel = getattr(self.pydreo_device, "rgb_preset_sel", None)
+        if preset_sel is None:
+            return None
+        # Convert 0-based index to "Preset N" name
+        return f"Preset {preset_sel + 1}"
+
+    def turn_on(self, **kwargs: Any) -> None:
+        """Turn the RGBIC light on, optionally setting effect (preset)."""
+        # Call parent to handle basic light on and brightness
+        super().turn_on(**kwargs)
+
+        # Handle effect/preset selection
+        if ATTR_EFFECT in kwargs:
+            effect = kwargs[ATTR_EFFECT]
+            _LOGGER.debug("turn_on: Setting RGBIC effect to %s", effect)
+            # Parse "Preset N" to get 0-based index
+            if effect.startswith("Preset "):
+                try:
+                    preset_idx = int(effect.split(" ")[1]) - 1
+                    self.pydreo_device.rgb_preset_sel = preset_idx
+                except (ValueError, IndexError):
+                    _LOGGER.warning("turn_on: Invalid effect name %s", effect)
 
 
 class DreoHumidifierLightHA(DreoBaseDeviceHA, LightEntity):  # pylint: disable=abstract-method

--- a/custom_components/dreo/pydreo/constant.py
+++ b/custom_components/dreo/pydreo/constant.py
@@ -77,6 +77,8 @@ SHAKEHORIZONANGLE_KEY = "shakehorizonangle"
 
 # Ceiling Fan
 FANON_KEY = "fanon"
+RGBPRESETSEL_KEY = "rgbpresetsel"
+RGBPRESETNUM_KEY = "rgbpresetnum"
 
 
 DREO_API_URL_FORMAT = "https://app-api-{0}.dreo-tech.com"  # {0} is the 2 letter region code

--- a/custom_components/dreo/pydreo/pydreoceilingfan.py
+++ b/custom_components/dreo/pydreo/pydreoceilingfan.py
@@ -15,6 +15,8 @@ from .constant import (
     ATMCOLOR_KEY,
     ATMBRI_KEY,
     ATMMODE_KEY,
+    RGBPRESETSEL_KEY,
+    RGBPRESETNUM_KEY,
 )
 
 from .pydreofanbase import PyDreoFanBase
@@ -72,6 +74,10 @@ class PyDreoCeilingFan(PyDreoFanBase):
         self._atm_brightness: int = None
         self._atm_color: int = None
         self._atm_mode: int = None
+
+        # RGBIC preset system (used by HCF007S and similar)
+        self._rgb_preset_sel: int = None
+        self._rgb_preset_num: int = None
 
         self._wind_type = None
         self._wind_mode = None
@@ -235,6 +241,28 @@ class PyDreoCeilingFan(PyDreoFanBase):
         """Returns the atmosphere mode (1=Constant, 2=Circle, 3=Breath), or None if not supported."""
         return self._atm_mode
 
+    @property
+    def rgb_preset_sel(self) -> int | None:
+        """Returns the currently selected RGBIC preset (0-based index), or None if not supported."""
+        return self._rgb_preset_sel
+
+    @rgb_preset_sel.setter
+    def rgb_preset_sel(self, value: int):
+        """Set the RGBIC preset selection (0-based index)."""
+        _LOGGER.debug("rgb_preset_sel: rgb_preset_sel.setter - %s", value)
+        if self._rgb_preset_sel is None:
+            _LOGGER.error("rgb_preset_sel: RGBIC presets not supported by this fan model.")
+            return
+        if self._rgb_preset_sel == value:
+            _LOGGER.debug("rgb_preset_sel: rgb_preset_sel - value already %s, skipping command", value)
+            return
+        self._send_command(RGBPRESETSEL_KEY, value)
+
+    @property
+    def rgb_preset_num(self) -> int | None:
+        """Returns the number of available RGBIC presets, or None if not supported."""
+        return self._rgb_preset_num
+
     def update_state(self, state: dict):
         """Process the state dictionary from the REST API."""
         _LOGGER.debug("update_state: Processing state")
@@ -265,6 +293,10 @@ class PyDreoCeilingFan(PyDreoFanBase):
         self._atm_brightness = self.get_state_update_value(state, ATMBRI_KEY)
         self._atm_color = self.get_state_update_value(state, ATMCOLOR_KEY)
         self._atm_mode = self.get_state_update_value(state, ATMMODE_KEY)
+
+        # RGBIC preset system
+        self._rgb_preset_sel = self.get_state_update_value(state, RGBPRESETSEL_KEY)
+        self._rgb_preset_num = self.get_state_update_value(state, RGBPRESETNUM_KEY)
 
     def handle_server_update(self, message):
         """Process a websocket update"""
@@ -301,6 +333,15 @@ class PyDreoCeilingFan(PyDreoFanBase):
         if isinstance(val_atm_mode, int):
             self._atm_mode = val_atm_mode
 
+        # RGBIC preset system
+        val_rgb_preset_sel = self.get_server_update_key_value(message, RGBPRESETSEL_KEY)
+        if isinstance(val_rgb_preset_sel, int):
+            self._rgb_preset_sel = val_rgb_preset_sel
+
+        val_rgb_preset_num = self.get_server_update_key_value(message, RGBPRESETNUM_KEY)
+        if isinstance(val_rgb_preset_num, int):
+            self._rgb_preset_num = val_rgb_preset_num
+
     def _handle_power_state_update(self, message):
         """Override power state handling for ceiling fans"""
         val_poweron = self.get_server_update_key_value(message, POWERON_KEY)
@@ -321,11 +362,11 @@ class PyDreoCeilingFan(PyDreoFanBase):
         """Check if this ceiling fan supports a specific feature"""
         if feature == "atm_light":
             return self._atm_light_on is not None
-        # atm_color_rgb is considered supported whenever the atmosphere light itself is
-        # present on the device.  Some device variants (e.g. DR-HCF002S RGBIC) do not
-        # echo "atmcolor" back in their state heartbeat, so _atm_color stays None and the
-        # base implementation (which uses getattr/None-check) would wrongly report the
-        # feature as unsupported.
+        # atm_color_rgb is only supported if the device has atmcolor (not RGBIC preset system)
         if feature == "atm_color_rgb":
-            return self._atm_light_on is not None
+            # Device must have atmosphere light AND direct atmcolor support (not RGBIC presets)
+            return self._atm_light_on is not None and self._atm_color is not None
+        # RGBIC preset system - device has atmon + rgbpresetsel but not atmcolor
+        if feature == "rgb_preset":
+            return self._atm_light_on is not None and self._rgb_preset_sel is not None
         return super().is_feature_supported(feature)

--- a/tests/dreo/integrationtests/test_dreoceilingfan.py
+++ b/tests/dreo/integrationtests/test_dreoceilingfan.py
@@ -182,9 +182,9 @@ class TestDreoCeilingFan(IntegrationTestBase):
             assert ha_fan.speed_count == 12
             assert pydreo_fan.preset_modes == ["normal", "natural", "sleep", "auto"]
 
-            # Both main light and RGB light entities should be created
+            # Both main light and RGBIC light entities should be created
             lights = light.get_entries([pydreo_fan])
-            self.verify_expected_entities(lights, ["Light", "RGB Light"])
+            self.verify_expected_entities(lights, ["Light", "RGBIC Light"])
 
             # ---- Main light (colour temperature) ----
             main_light = self.get_entity_by_key(lights, "Light")
@@ -200,24 +200,27 @@ class TestDreoCeilingFan(IntegrationTestBase):
                 main_light.turn_on(brightness=128)
                 mock_send_command.assert_called_once_with(pydreo_fan, {BRIGHTNESS_KEY: 50})
 
-            # ---- RGB atmosphere light ----
-            rgb_light = self.get_entity_by_key(lights, "RGB Light")
-            assert rgb_light is not None
-            # Device reported atmon=true but no atmcolor, so rgb_color is unknown
-            assert rgb_light.rgb_color is None
-            # atmon=true in initial state, so the RGB light should be "on"
-            assert rgb_light.is_on is True
+            # ---- RGBIC atmosphere light (preset-based, not direct RGB) ----
+            rgbic_light = self.get_entity_by_key(lights, "RGBIC Light")
+            assert rgbic_light is not None
+            # RGBIC preset device - rgb_color is not supported
+            assert rgbic_light.rgb_color is None
+            # atmon=true in initial state, so the RGBIC light should be "on"
+            assert rgbic_light.is_on is True
+            # RGBIC light should have effect list with presets
+            assert rgbic_light.effect_list == ["Preset 1", "Preset 2", "Preset 3", "Preset 4"]
+            # Current preset is 0, so effect should be "Preset 1"
+            assert rgbic_light.effect == "Preset 1"
 
             # atmon is already True, so turn_on() sends no commands
             with patch(PATCH_SEND_COMMAND) as mock_send_command:
-                rgb_light.turn_on()
+                rgbic_light.turn_on()
                 mock_send_command.assert_not_called()
 
-            # Setting an RGB colour must produce an atmcolor command even though
-            # _atm_color was None on load (regression test for the CFRGB variant)
+            # Setting effect must send rgbpresetsel command
             with patch(PATCH_SEND_COMMAND) as mock_send_command:
-                rgb_light.turn_on(rgb_color=(255, 0, 0))  # Red
-                mock_send_command.assert_called_once_with(pydreo_fan, {ATMCOLOR_KEY: 16711680})
+                rgbic_light.turn_on(effect="Preset 3")
+                mock_send_command.assert_called_once_with(pydreo_fan, {RGBPRESETSEL_KEY: 2})
 
     def test_HCF003S(self):  # pylint: disable=invalid-name
         """Load HCF003S fan and test sending commands."""

--- a/tests/pydreo/test_pydreoceilingfan.py
+++ b/tests/pydreo/test_pydreoceilingfan.py
@@ -221,11 +221,10 @@ class TestPyDreoCeilingFan(TestBase):
         fan.handle_server_update({REPORTED_KEY: {ATMCOLOR_KEY: 16711680}})
 
     def test_HCF002S_CFRGB(self):  # pylint: disable=invalid-name
-        """Test DR-HCF002S RGBIC variant that has atmon/atmbri but no atmcolor in state.
+        """Test DR-HCF002S RGBIC variant that uses preset-based RGB instead of direct color.
 
-        Regression test for https://github.com/JeffSteinbok/hass-dreo/issues/XXX:
-        RGB color commands must be accepted even when the device never reported
-        'atmcolor' in its state heartbeat (i.e. _atm_color is None on load).
+        RGBIC ceiling fans have rgbpresetsel/rgbpresetnum instead of atmcolor.
+        They should expose rgb_preset feature, NOT atm_color_rgb.
         """
         self.get_devices_file_name = "get_devices_HCF002S_CFRGB.json"
         self.pydreo_manager.load_devices()
@@ -249,30 +248,34 @@ class TestPyDreoCeilingFan(TestBase):
         assert fan.atm_light_on is True
         assert fan.atm_brightness == 1
 
-        # atmcolor was NOT in the device state, so the current value is unknown
+        # This is an RGBIC preset device - atm_color_rgb is NOT supported
         assert fan.atm_color_rgb is None
+        assert fan.is_feature_supported("atm_color_rgb") is False
 
-        # atm_color_rgb must still be recognised as a settable feature because the
-        # atmosphere light itself is present on the device.
-        assert fan.is_feature_supported("atm_color_rgb") is True
+        # RGBIC preset feature IS supported
+        assert fan.is_feature_supported("rgb_preset") is True
+        assert fan.rgb_preset_sel == 0
+        assert fan.rgb_preset_num == 4
 
-        # Setting RGB colour must send the atmcolor command even though _atm_color is None
+        # Setting preset must send the rgbpresetsel command
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            fan.atm_color_rgb = (255, 0, 0)  # Red
-            mock_send_command.assert_called_once_with(fan, {ATMCOLOR_KEY: 16711680})  # 0xFF0000
-        fan.handle_server_update({REPORTED_KEY: {ATMCOLOR_KEY: 16711680}})
+            fan.rgb_preset_sel = 2
+            mock_send_command.assert_called_once_with(fan, {RGBPRESETSEL_KEY: 2})
+        fan.handle_server_update({REPORTED_KEY: {RGBPRESETSEL_KEY: 2}})
 
-        # After the server echoes the colour back, subsequent identical set should be skipped
-        assert fan.atm_color_rgb == (255, 0, 0)
+        # After update, preset should be tracked
+        assert fan.rgb_preset_sel == 2
+
+        # Setting same preset should skip command
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            fan.atm_color_rgb = (255, 0, 0)  # same colour – should NOT re-send
+            fan.rgb_preset_sel = 2
             mock_send_command.assert_not_called()
 
-        # Setting a different colour after state is known must send the command
+        # Setting different preset must send command
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            fan.atm_color_rgb = (0, 255, 0)  # Green
-            mock_send_command.assert_called_once_with(fan, {ATMCOLOR_KEY: 65280})  # 0x00FF00
-        fan.handle_server_update({REPORTED_KEY: {ATMCOLOR_KEY: 65280}})
+            fan.rgb_preset_sel = 0
+            mock_send_command.assert_called_once_with(fan, {RGBPRESETSEL_KEY: 0})
+        fan.handle_server_update({REPORTED_KEY: {RGBPRESETSEL_KEY: 0}})
 
         # Colour temperature control must also work
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
@@ -366,7 +369,7 @@ class TestPyDreoCeilingFan(TestBase):
             fan.fan_speed = 13
 
     def test_HCF007S(self):  # pylint: disable=invalid-name
-        """Load HCF007S (CF521S RGBIC) and verify fallback model capabilities."""
+        """Load HCF007S (CF521S RGBIC) and verify RGBIC preset capabilities."""
         self.get_devices_file_name = "get_devices_HCF007S.json"
         self.pydreo_manager.load_devices()
         assert len(self.pydreo_manager.devices) == 1
@@ -374,6 +377,13 @@ class TestPyDreoCeilingFan(TestBase):
         assert fan.model == "DR-HCF007S"
         assert fan.speed_range == (1, 12)
         assert fan.preset_modes == ["normal", "natural", "sleep", "reverse"]
+
+        # HCF007S is an RGBIC preset device - atm_color_rgb is NOT supported
+        assert fan.is_feature_supported("atm_light") is True
+        assert fan.is_feature_supported("atm_color_rgb") is False
+        assert fan.is_feature_supported("rgb_preset") is True
+        assert fan.rgb_preset_sel == 0
+        assert fan.rgb_preset_num == 4
 
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             fan.fan_speed = 12
@@ -384,6 +394,13 @@ class TestPyDreoCeilingFan(TestBase):
             fan.preset_mode = "reverse"
             mock_send_command.assert_called_once_with(fan, {MODE_KEY: 4})
         fan.handle_server_update({REPORTED_KEY: {MODE_KEY: 4}})
+
+        # RGBIC preset control
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            fan.rgb_preset_sel = 3
+            mock_send_command.assert_called_once_with(fan, {RGBPRESETSEL_KEY: 3})
+        fan.handle_server_update({REPORTED_KEY: {RGBPRESETSEL_KEY: 3}})
+        assert fan.rgb_preset_sel == 3
 
     @pytest.mark.parametrize("devices_file", CEILING_FAN_EXHAUSTIVE_MODELS)
     def test_all_settable_properties_for_each_model(self, devices_file: str):


### PR DESCRIPTION
## Summary

Fixes #763

DR-HCF007S (CF521S RGBIC) ceiling fans use a **preset-based RGB system** (\gbpresetsel\/\gbpresetnum\) instead of direct color control (\tmcolor\). The integration was incorrectly exposing an RGB color picker that sent \tmcolor\ commands, which the device ignored.

## Changes

- Add \RGBPRESETSEL_KEY\ and \RGBPRESETNUM_KEY\ constants
- Add \gb_preset_sel\/\gb_preset_num\ properties to \PyDreoCeilingFan\
- Create \DreoRGBICLightHA\ class using Home Assistant light **effects** for preset selection
- Update \is_feature_supported()\ to distinguish RGBIC preset devices vs direct RGB devices
- Update \get_entries()\ to create correct light entity type based on device capabilities

## How It Works

RGBIC ceiling fans now show an effect picker instead of RGB color picker:
- **Preset 1**, **Preset 2**, **Preset 3**, **Preset 4** (based on \gbpresetnum\)
- On/off and brightness controls continue to work via \tmon\/\tmbri\

## Testing

- All 783 tests pass
- Added/updated tests for HCF002S_CFRGB and HCF007S RGBIC behavior