### PR TITLE
Fix issue triage validation for diagnostics

### DIFF
--- a/.github/workflows/issue-template-check.yml
+++ b/.github/workflows/issue-template-check.yml
@@ -74,7 +74,7 @@ jobs:
   check-logs:
     runs-on: ubuntu-latest
     steps:
-      - name: Validate bug report content
+      - name: Validate issue content
         uses: actions/github-script@v7
         with:
           script: |
@@ -82,9 +82,12 @@ jobs:
             const author = context.payload.issue.user.login;
             const issueNumber = context.issue.number;
 
-            // Only check bug reports
-            if (!body.includes('### Describe the bug')) {
-              core.info('Not a bug report. Skipping.');
+            // Check if this is a bug report or feature request that needs validation
+            const isBugReport = body.includes('### Describe the bug');
+            const isFeatureRequest = body.includes('### Problem description');
+            
+            if (!isBugReport && !isFeatureRequest) {
+              core.info('Not a bug report or feature request. Skipping.');
               return;
             }
 
@@ -118,15 +121,31 @@ jobs:
                 .replace(/\s+/g, ' ')
                 .trim()
                 .toLowerCase();
-              if (stripped.length < 5) return true;
-              const placeholders = ['n/a', 'na', 'none', 'no', 'tbd', 'todo', 'will add later', '_no response_'];
+              if (stripped.length < 10) return true;
+              const placeholders = ['n/a', 'na', 'none', 'no', 'tbd', 'todo', 'will add later', '_no response_', 'not available', 'not applicable'];
               return placeholders.includes(stripped);
             }
 
-            const diagnostics = getSectionContent('Diagnostics');
-            const logs = getSectionContent('Debug Logs');
+            function isDiagnosticsValid(content) {
+              if (isMissing(content)) return false;
+              // Try to extract and parse JSON from the content
+              // Diagnostics may be wrapped in code blocks or have surrounding text
+              const jsonMatch = content.match(/\{[\s\S]*"home_assistant"[\s\S]*\}/);
+              if (!jsonMatch) return false;
+              try {
+                const parsed = JSON.parse(jsonMatch[0]);
+                // Must have both home_assistant and integration_manifest keys
+                return parsed.home_assistant && parsed.integration_manifest;
+              } catch (e) {
+                return false;
+              }
+            }
 
-            const missingDiagnostics = isMissing(diagnostics);
+            const diagnostics = getSectionContent('Diagnostics');
+            // Bug reports use "Debug Logs", feature requests use "Log Files"
+            const logs = getSectionContent('Debug Logs') || getSectionContent('Log Files');
+
+            const missingDiagnostics = !isDiagnosticsValid(diagnostics);
             const missingLogs = isMissing(logs);
 
             if (!missingDiagnostics && !missingLogs) {
@@ -185,8 +204,6 @@ jobs:
                 '',
                 'It looks like the following information is missing:',
                 ...missing.map(item => `- ${item}`),
-                '',
-                'I only personally own 2 Dreo devices, so logs and diagnostics are **essential** for me to debug issues with devices I don\'t own.',
                 '',
                 'Please update your issue with the missing information. See the [debugging instructions](https://github.com/JeffSteinbok/hass-dreo?tab=readme-ov-file#debugging) for help collecting this data.',
                 '',


### PR DESCRIPTION
## Problem

The issue triage workflow was incorrectly marking issues as 'triaged' when:
1. **Bug reports** had placeholder text like \---------\ instead of actual diagnostics (#745)
2. **Feature requests** were not validated at all - they skipped the check entirely (#766)

## Changes

- Add \isDiagnosticsValid()\ function to verify diagnostics contain actual JSON with required keys (\home_assistant\ and \integration_manifest\)
- **Extend validation to feature requests** (\### Problem description\), not just bug reports (\### Describe the bug\)
- Support both \Debug Logs\ and \Log Files\ section names (different templates use different names)
- Increase minimum content length from 5 to 10 characters
- Add more placeholder strings to \isMissing()\ check ('not available', 'not applicable')
- Remove personal comment about device ownership from the needs-info message

## Validation

| Issue | Diagnostics | Old Result | New Result |
|-------|-------------|------------|------------|
| #745 (bug) | \---------\ | ✅ Triaged | ❌ needs-info |
| #766 (feature) | \_No response_\ | ✅ Triaged (skipped) | ❌ needs-info |