### PR TITLE
Add workflow to auto-assign Copilot to triaged issues

### DIFF
--- a/.github/workflows/copilot-autofix.yml
+++ b/.github/workflows/copilot-autofix.yml
@@ -1,0 +1,211 @@
+name: Copilot Auto-Fix Triaged Issues
+
+on:
+  schedule:
+    # Run every day at 8 AM UTC (1 AM PST / 4 AM EST)
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run - only list issues, do not assign Copilot'
+        required: false
+        default: 'false'
+        type: boolean
+      max_issues:
+        description: 'Maximum number of issues to process'
+        required: false
+        default: '5'
+        type: string
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  find-and-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find newly triaged issues and assign to Copilot
+        id: assign
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const maxIssues = parseInt('${{ inputs.max_issues }}' || '5');
+            const dryRun = '${{ inputs.dry_run }}' === 'true';
+            
+            // Calculate 24 hours ago
+            const oneDayAgo = new Date();
+            oneDayAgo.setDate(oneDayAgo.getDate() - 1);
+            
+            console.log(`Looking for issues triaged since ${oneDayAgo.toISOString()}`);
+            console.log(`Max issues to process: ${maxIssues}`);
+            console.log(`Dry run: ${dryRun}`);
+            
+            // Find open issues with "triaged" label
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'triaged',
+              sort: 'updated',
+              direction: 'desc',
+              per_page: 50
+            });
+            
+            let processed = 0;
+            const candidates = [];
+            
+            for (const issue of issues.data) {
+              // Skip pull requests
+              if (issue.pull_request) continue;
+              
+              // Check if issue was recently triaged (look at label events)
+              const events = await github.rest.issues.listEvents({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 50
+              });
+              
+              // Find when "triaged" label was added
+              const triagedEvent = events.data.find(e => 
+                e.event === 'labeled' && 
+                e.label?.name === 'triaged'
+              );
+              
+              if (!triagedEvent) continue;
+              
+              const triagedAt = new Date(triagedEvent.created_at);
+              if (triagedAt < oneDayAgo) {
+                console.log(`#${issue.number}: Triaged ${triagedAt.toISOString()} - too old, skipping`);
+                continue;
+              }
+              
+              // Check if Copilot is already assigned
+              const isCopilotAssigned = issue.assignees?.some(a => 
+                a.login.toLowerCase() === 'copilot' || 
+                a.login.toLowerCase().includes('copilot')
+              );
+              
+              if (isCopilotAssigned) {
+                console.log(`#${issue.number}: Copilot already assigned, skipping`);
+                continue;
+              }
+              
+              // Check if there's already a linked PR (Copilot may have already worked on it)
+              const timeline = await github.rest.issues.listEventsForTimeline({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100
+              });
+              
+              const hasLinkedPR = timeline.data.some(e => 
+                e.event === 'cross-referenced' && 
+                e.source?.issue?.pull_request
+              );
+              
+              if (hasLinkedPR) {
+                console.log(`#${issue.number}: Already has linked PR, skipping`);
+                continue;
+              }
+              
+              // This is a candidate for Copilot
+              candidates.push({
+                number: issue.number,
+                title: issue.title,
+                triagedAt: triagedAt.toISOString(),
+                labels: issue.labels.map(l => l.name)
+              });
+              
+              if (candidates.length >= maxIssues) break;
+            }
+            
+            console.log(`\nFound ${candidates.length} candidate issues:`);
+            for (const c of candidates) {
+              console.log(`  #${c.number}: ${c.title}`);
+              console.log(`    Triaged: ${c.triagedAt}`);
+              console.log(`    Labels: ${c.labels.join(', ')}`);
+            }
+            
+            if (dryRun) {
+              console.log('\nDry run - not assigning Copilot');
+              return;
+            }
+            
+            // Assign Copilot to each candidate issue
+            for (const candidate of candidates) {
+              try {
+                // Add a comment to trigger Copilot
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: candidate.number,
+                  body: `@copilot Please investigate this issue and create a fix if possible. Check the diagnostics data and any related code.`
+                });
+                
+                console.log(`\n✓ Assigned Copilot to #${candidate.number}`);
+                processed++;
+                
+                // Small delay to avoid rate limiting
+                await new Promise(r => setTimeout(r, 2000));
+                
+              } catch (error) {
+                console.error(`✗ Failed to assign #${candidate.number}: ${error.message}`);
+              }
+            }
+            
+            console.log(`\nProcessed ${processed} issues`);
+            
+            // Store results for Discord notification
+            core.setOutput('processed', processed);
+            core.setOutput('candidates', JSON.stringify(candidates));
+
+      - name: Send Discord notification
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+        run: |
+          PROCESSED="${{ steps.assign.outputs.processed }}"
+          CANDIDATES='${{ steps.assign.outputs.candidates }}'
+          DRY_RUN="${{ inputs.dry_run }}"
+          DAY_OF_WEEK=$(date +%u)  # 1=Monday, 7=Sunday
+          
+          # Skip if no webhook configured
+          if [ -z "$DISCORD_WEBHOOK" ]; then
+            echo "No Discord webhook configured, skipping notification"
+            exit 0
+          fi
+          
+          # Decide whether to notify
+          # - Always notify if issues were processed
+          # - Always notify on dry runs
+          # - On Mondays, send weekly summary even if 0 issues
+          if [ "$PROCESSED" == "0" ] && [ "$DRY_RUN" != "true" ] && [ "$DAY_OF_WEEK" != "1" ]; then
+            echo "No issues processed and not Monday - skipping notification"
+            exit 0
+          fi
+          
+          # Build message based on scenario
+          if [ "$DRY_RUN" == "true" ]; then
+            TITLE="🔍 Copilot Auto-Fix (Dry Run)"
+            COLOR=16776960  # Yellow
+          elif [ "$PROCESSED" == "0" ]; then
+            TITLE="📊 Copilot Auto-Fix (Weekly Summary)"
+            COLOR=3447003   # Blue
+          else
+            TITLE="🤖 Copilot Auto-Fix"
+            COLOR=5763719   # Green
+          fi
+          
+          if [ "$PROCESSED" == "0" ]; then
+            DESCRIPTION="No new triaged issues in the last 24 hours.\n\nThe workflow is running normally. ✅"
+          else
+            ISSUE_LIST=$(echo "$CANDIDATES" | jq -r '.[] | "• [#\(.number)](<https://github.com/${{ github.repository }}/issues/\(.number)>) - \(.title)"' | head -10)
+            DESCRIPTION="**Assigned Copilot to $PROCESSED issue(s):**\n\n$ISSUE_LIST"
+          fi
+          
+          # Send to Discord
+          curl -H "Content-Type: application/json" \
+            -d "{\"embeds\": [{\"title\": \"$TITLE\", \"description\": \"$DESCRIPTION\", \"color\": $COLOR}]}" \
+            "$DISCORD_WEBHOOK"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically assigns Copilot to newly triaged issues.

## How it works

1. **Scheduled run**: Every day at 8 AM UTC (1 AM PST)
2. **Finds candidates**: Issues with \	riaged\ label added in the last 24 hours
3. **Filters out**:
   - Issues already assigned to Copilot
   - Issues with existing linked PRs (Copilot may have already worked on them)
4. **Triggers Copilot**: Comments \@copilot\ on each candidate issue

## Manual trigger

Can be triggered manually via \workflow_dispatch\ with options:
- **dry_run**: List issues without assigning (default: false)
- **max_issues**: Limit number of issues to process (default: 5)

## Safety features

- Only processes 5 issues max per run by default
- 2-second delay between assignments to avoid rate limiting
- Skips issues with existing PRs to avoid duplicate work