### PR TITLE
Fix swapped auto/natural preset modes for DR-HPF007S

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -316,7 +316,7 @@ SUPPORTED_DEVICES = {
     ),
     "DR-HPF007S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,
-        preset_modes=[("normal", 1), ("auto", 2), ("sleep", 3), ("natural", 4), ("turbo", 5), ("custom", 6)],
+        preset_modes=[("normal", 1), ("natural", 2), ("sleep", 3), ("auto", 4), ("turbo", 5), ("custom", 6)],
         device_ranges={SPEED_RANGE: (1, 10), HORIZONTAL_ANGLE_RANGE: (-75, 75), VERTICAL_ANGLE_RANGE: (-30, 90)},
     ),
     "DR-HPF005S": DreoDeviceDetails(


### PR DESCRIPTION
### Bug
On the **DR-HPF007S** air circulator, selecting the `natural` preset mode puts the fan into **Auto**, and selecting `auto` puts it into **Natural** — the two presets are inverted.

### Root cause
In `custom_components/dreo/pydreo/models.py`, the `DR-HPF007S` entry assigns the wrong numeric mode values:

```python
preset_modes=[("normal", 1), ("auto", 2), ("sleep", 3), ("natural", 4), ("turbo", 5), ("custom", 6)],
```

The device firmware uses `natural`=2 and `auto`=4. Since `pydreofanbase` maps name→value via the static `preset_modes` table (`value_from_name`), `natural` sends 4 (Auto on the device) and vice-versa.

The other air-circulator models already use the correct ordering — `DR-HPF004S`, `DR-HPF005S`, `DR-HPF022S` all have `("natural", 2)` / `("auto", 4)`.

### Fix
Swap the two values so they match the firmware (and the sibling models):

```python
preset_modes=[("normal", 1), ("natural", 2), ("sleep", 3), ("auto", 4), ("turbo", 5), ("custom", 6)],
```

### Testing
Verified on real hardware (DR-HPF007S, HA Core 2026.6.4, hass-dreo 1.9.22): after the change, `natural` correctly engages Natural mode and `auto` engages Auto mode.
