### PR TITLE
Add definition for the horizontal angle range of Turbocool Misting Fan 516S

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -158,7 +158,7 @@ class DreoHeaterDeviceDetails(DreoDeviceDetails):
 
 # Supported prefixes.
 # These prefixes will be listed along with the models in the below collections.
-SUPPORTED_MODEL_PREFIXES = {"DR-HTF", "DR-HAF", "DR-HAP", "DR-HPF", "DR-HCF", "WH", "DR-HAC", "DR-HHM", "DR-HEC"}
+SUPPORTED_MODEL_PREFIXES = {"DR-HTF", "DR-HAF", "DR-HAP", "DR-HPF", "DR-HCF", "WH", "DR-HAC", "DR-HHM", "DR-"}
 
 # MCU hardware model strings used to identify specific hardware revisions.
 _MCU_HAF004S_OLD_REV = "SC95F8613B"
@@ -496,7 +496,7 @@ SUPPORTED_DEVICES = {
     "DR-HEC006S": DreoDeviceDetails(
         device_type=DreoDeviceType.EVAPORATIVE_COOLER,
         preset_modes=[("Normal", 1), ("Turbo", 2)],
-        device_ranges={SPEED_RANGE: (1, 6)},
+        device_ranges={SPEED_RANGE: (1, 6), HORIZONTAL_ANGLE_RANGE: (-75,75)},
     ),
     # DR-HEC005S is the TurboCool Misting Fan 765S.
     # It has 12 fan speeds and can expose an empty controlsConf.

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -493,10 +493,11 @@ SUPPORTED_DEVICES = {
     ),
     # DR-HEC006S is the TurboCool Misting Fan 516S.
     # controlsConf is empty so speed range and preset modes must be hardcoded.
+    # DR-HEC006S has +/-75° oscillation range and the turbo-mode is 4
     "DR-HEC006S": DreoDeviceDetails(
         device_type=DreoDeviceType.EVAPORATIVE_COOLER,
         preset_modes=[("Normal", 1), ("Turbo", 4)],
-        device_ranges={SPEED_RANGE: (1, 6), HORIZONTAL_ANGLE_RANGE: (-75,75)},
+        device_ranges={SPEED_RANGE: (1, 6), HORIZONTAL_ANGLE_RANGE: (-75, 75)},
     ),
     # DR-HEC005S is the TurboCool Misting Fan 765S.
     # It has 12 fan speeds and can expose an empty controlsConf.

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -158,7 +158,7 @@ class DreoHeaterDeviceDetails(DreoDeviceDetails):
 
 # Supported prefixes.
 # These prefixes will be listed along with the models in the below collections.
-SUPPORTED_MODEL_PREFIXES = {"DR-HTF", "DR-HAF", "DR-HAP", "DR-HPF", "DR-HCF", "WH", "DR-HAC", "DR-HHM", "DR-"}
+SUPPORTED_MODEL_PREFIXES = {"DR-HTF", "DR-HAF", "DR-HAP", "DR-HPF", "DR-HCF", "WH", "DR-HAC", "DR-HHM", "DR-HEC"}
 
 # MCU hardware model strings used to identify specific hardware revisions.
 _MCU_HAF004S_OLD_REV = "SC95F8613B"

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -495,7 +495,7 @@ SUPPORTED_DEVICES = {
     # controlsConf is empty so speed range and preset modes must be hardcoded.
     "DR-HEC006S": DreoDeviceDetails(
         device_type=DreoDeviceType.EVAPORATIVE_COOLER,
-        preset_modes=[("Normal", 1), ("Turbo", 2)],
+        preset_modes=[("Normal", 1), ("Turbo", 4)],
         device_ranges={SPEED_RANGE: (1, 6), HORIZONTAL_ANGLE_RANGE: (-75,75)},
     ),
     # DR-HEC005S is the TurboCool Misting Fan 765S.

--- a/custom_components/dreo/pydreo/pydreoevaporativecooler.py
+++ b/custom_components/dreo/pydreo/pydreoevaporativecooler.py
@@ -10,6 +10,7 @@ from .constant import (
     HORIZONTAL_OSCILLATION_KEY,
     HORIZONTAL_OSCILLATION_ANGLE_KEY,
     HORIZONTAL_ANGLE_ADJ_KEY,
+    HORIZONTAL_ANGLE_RANGE,
     HUMIDITY_KEY,
     LIGHTON_KEY,
     MODE_KEY,
@@ -326,7 +327,7 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
     @property
     def horizontal_angle_range(self) -> tuple[int, int] | None:
         """Return the supported horizontal angle range."""
-        range_from_definition = self._device_definition.device_ranges.get("horizontal_angle_range" ) if self._device_definition.device_ranges else None
+        range_from_definition = self._device_definition.device_ranges.get(HORIZONTAL_ANGLE_RANGE) if self._device_definition.device_ranges else None
         if range_from_definition is not None:
             return range_from_definition
         return self._horizontal_angle_range

--- a/custom_components/dreo/pydreo/pydreoevaporativecooler.py
+++ b/custom_components/dreo/pydreo/pydreoevaporativecooler.py
@@ -326,6 +326,9 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
     @property
     def horizontal_angle_range(self) -> tuple[int, int] | None:
         """Return the supported horizontal angle range."""
+        range_from_definition = self._device_definition.device_ranges.get("horizontal_angle_range" ) if self._device_definition.device_ranges else None
+        if range_from_definition is not None:
+            return range_from_definition
         return self._horizontal_angle_range
 
     @staticmethod

--- a/tests/pydreo/test_pydreoevaporativecooler.py
+++ b/tests/pydreo/test_pydreoevaporativecooler.py
@@ -283,7 +283,7 @@ class TestPyDreoEvaporativeCooler(TestBase):
         assert ec_fan.rgbmode == 0
         assert ec_fan.rgbcolor == 30719
         assert ec_fan.horizontal_angle == 5
-        assert ec_fan.horizontal_angle_range == (-15, 15)
+        assert ec_fan.horizontal_angle_range == (-75, 75)
 
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             ec_fan.is_on = False
@@ -335,11 +335,11 @@ class TestPyDreoEvaporativeCooler(TestBase):
         self.pydreo_manager.load_devices()
         ec_fan: PyDreoEvaporativeCooler = self.pydreo_manager.devices[0]
 
-        # "Turbo" -> mode value 2
+        # "Turbo" -> mode value 4
         ec_fan._wind_mode = 1  # set to Normal first
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             ec_fan.preset_mode = "Turbo"
-            mock_send_command.assert_called_once_with(ec_fan, {MODE_KEY: 2})
+            mock_send_command.assert_called_once_with(ec_fan, {MODE_KEY: 4})
 
         # "Normal" -> mode value 1
         ec_fan._wind_mode = 2
@@ -384,8 +384,8 @@ class TestPyDreoEvaporativeCooler(TestBase):
         assert ec_fan.childlockon is True
 
         # mode: HEC006S uses "mode" key via base class; WebSocket sends 1-based int
-        ec_fan.handle_server_update({REPORTED_KEY: {MODE_KEY: 2}})
-        assert ec_fan._wind_mode == 2
+        ec_fan.handle_server_update({REPORTED_KEY: {MODE_KEY: 4}})
+        assert ec_fan._wind_mode == 4
         assert ec_fan.preset_mode == "Turbo"
 
         # work_time


### PR DESCRIPTION
The 516S has a horizontal angle range of 150° (+/-75°). It can also oscillate asymmetrically, which is not yet included in this PR.

Additional change: Turbo-Mode on 516S is number 4 (tested on my Turbocool device) 
 
<img width="561" height="520" alt="image" src="https://github.com/user-attachments/assets/ad913ba7-bf9f-452c-8863-93fc40668248" />
