### PR TITLE
Fix water level

### DIFF
--- a/custom_components/dreo/binary_sensor.py
+++ b/custom_components/dreo/binary_sensor.py
@@ -17,7 +17,7 @@ from .pydreo.pydreobasedevice import PyDreoBaseDevice
 from .pydreo.constant import DreoDeviceType
 from .pydreo.pydreohumidifier import WATER_LEVEL_STATUS_KEY, WATER_LEVEL_EMPTY
 from .pydreo.pydreoevaporativecooler import (
-    WATER_LEVEL_STATUS_KEY as EVAP_WATER_LEVEL_STATUS_KEY,
+    WATER_LEVEL_KEY as EVAP_WATER_LEVEL_KEY,
     WATER_LEVEL_EMPTY as EVAP_WATER_LEVEL_EMPTY,
 )
 from .pydreo.pydreodehumidifier import (
@@ -52,7 +52,7 @@ def _water_empty_exists(device: PyDreoBaseDevice) -> bool:
     if device.type == DreoDeviceType.HUMIDIFIER:
         return device.is_feature_supported(WATER_LEVEL_STATUS_KEY)
     if device.type == DreoDeviceType.EVAPORATIVE_COOLER:
-        return device.is_feature_supported(EVAP_WATER_LEVEL_STATUS_KEY)
+        return device.is_feature_supported(EVAP_WATER_LEVEL_KEY)
     if device.type == DreoDeviceType.DEHUMIDIFIER:
         return device.is_feature_supported(DEHUMIDIFIER_ERROR_CODE_KEY)
     return False

--- a/custom_components/dreo/pydreo/pydreoevaporativecooler.py
+++ b/custom_components/dreo/pydreo/pydreoevaporativecooler.py
@@ -30,6 +30,7 @@ HUMIDIFY_SUSPEND_KEY = "rhsuspend"
 HUMIDITY_TARGET_KEY = "rhtarget"
 WORKTIME_KEY = "worktime"
 WATER_LEVEL_STATUS_KEY = "wrong"
+WATER_LEVEL_KEY = "water_level"
 RGB_ON_KEY = "rgbon"
 
 # Status for water level indicator


### PR DESCRIPTION
Review requested for PR #800.

DR-HEC devices uses property `water_level` instead of `wrong`, so we need to check for this property

With these changes the property is visible:
<img width="321" height="262" alt="image" src="https://github.com/user-attachments/assets/c38e42e1-f117-47af-9075-ee751765937c" />
