### PR TITLE
Request Copilot review on fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/request-copilot-review.yaml
+++ b/.github/workflows/request-copilot-review.yaml
@@ -1,7 +1,7 @@
 name: Request Copilot Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, ready_for_review]
 
 permissions:


### PR DESCRIPTION
The `Request Copilot Review` workflow used the `pull_request` trigger, which downgrades `GITHUB_TOKEN` to read-only for PRs from forks. This caused `requestReviewers` to fail with `403 Resource not accessible by integration` on external contributor PRs (e.g. #800).

Switching to `pull_request_target` runs the workflow in the base repo context with a writable token, so Copilot review is requested for external contributors too. No PR code is checked out or executed, so this avoids the usual `pull_request_target` security risk.

Note: takes effect for future PRs once merged to `main` (`pull_request_target` always runs the base-branch version).