### PR TITLE
Enable the setting of asymmetric horizontal oscillation values

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -494,10 +494,16 @@ SUPPORTED_DEVICES = {
     # DR-HEC006S is the TurboCool Misting Fan 516S.
     # controlsConf is empty so speed range and preset modes must be hardcoded.
     # DR-HEC006S has +/-75° oscillation range and the turbo-mode is 4
+    # Asymmetric horizontal oscillation is also supported with left/right angles
     "DR-HEC006S": DreoDeviceDetails(
         device_type=DreoDeviceType.EVAPORATIVE_COOLER,
         preset_modes=[("Normal", 1), ("Turbo", 4)],
-        device_ranges={SPEED_RANGE: (1, 6), HORIZONTAL_ANGLE_RANGE: (-75, 75)},
+        device_ranges={
+            SPEED_RANGE: (1, 6),
+            HORIZONTAL_ANGLE_RANGE: (-75, 75),
+            "horizontal_osc_angle_left_range": (-75, 75),
+            "horizontal_osc_angle_right_range": (-75, 75),
+        },
     ),
     # DR-HEC005S is the TurboCool Misting Fan 765S.
     # It has 12 fan speeds and can expose an empty controlsConf.

--- a/custom_components/dreo/pydreo/pydreoevaporativecooler.py
+++ b/custom_components/dreo/pydreo/pydreoevaporativecooler.py
@@ -333,6 +333,76 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
             return range_from_definition
         return self._horizontal_angle_range
 
+    @property
+    def horizontal_osc_angle_left(self) -> int | None:
+        """Return the configured left horizontal oscillation angle (derived from horizontal_angle_range)."""
+        if self._horizontal_angle_range is not None:
+            return self._horizontal_angle_range[0]
+        return None
+
+    @horizontal_osc_angle_left.setter
+    def horizontal_osc_angle_left(self, value: int) -> None:
+        """Set the left horizontal oscillation angle."""
+        _LOGGER.debug("horizontal_osc_angle_left: setting to %s", value)
+        angle = int(value)
+        current_left = self.horizontal_osc_angle_left
+        current_right = self.horizontal_osc_angle_right
+        if current_left == angle:
+            _LOGGER.debug("horizontal_osc_angle_left: value already %s, skipping command", angle)
+            return
+        # Validate that left < right
+        if current_right is not None and angle >= current_right:
+            raise ValueError(f"Left angle {angle} must be less than right angle {current_right}")
+        # Send as "left,right" via hoscangle key
+        if current_right is not None:
+            self._send_command(HORIZONTAL_OSCILLATION_ANGLE_KEY, f"{angle},{current_right}")
+
+    @property
+    def horizontal_osc_angle_left_range(self) -> tuple[int, int] | None:
+        """Return the supported left horizontal oscillation angle range."""
+        range_from_definition = self._device_definition.device_ranges.get("horizontal_osc_angle_left_range") if self._device_definition.device_ranges else None
+        if range_from_definition is not None:
+            return range_from_definition
+        # Fall back to horizontal angle range if available
+        if self._horizontal_angle_range is not None:
+            return (self._horizontal_angle_range[0], self._horizontal_angle_range[1])
+        return None
+
+    @property
+    def horizontal_osc_angle_right(self) -> int | None:
+        """Return the configured right horizontal oscillation angle (derived from horizontal_angle_range)."""
+        if self._horizontal_angle_range is not None:
+            return self._horizontal_angle_range[1]
+        return None
+
+    @horizontal_osc_angle_right.setter
+    def horizontal_osc_angle_right(self, value: int) -> None:
+        """Set the right horizontal oscillation angle."""
+        _LOGGER.debug("horizontal_osc_angle_right: setting to %s", value)
+        angle = int(value)
+        current_left = self.horizontal_osc_angle_left
+        current_right = self.horizontal_osc_angle_right
+        if current_right == angle:
+            _LOGGER.debug("horizontal_osc_angle_right: value already %s, skipping command", angle)
+            return
+        # Validate that left < right
+        if current_left is not None and angle <= current_left:
+            raise ValueError(f"Right angle {angle} must be greater than left angle {current_left}")
+        # Send as "left,right" via hoscangle key
+        if current_left is not None:
+            self._send_command(HORIZONTAL_OSCILLATION_ANGLE_KEY, f"{current_left},{angle}")
+
+    @property
+    def horizontal_osc_angle_right_range(self) -> tuple[int, int] | None:
+        """Return the supported right horizontal oscillation angle range."""
+        range_from_definition = self._device_definition.device_ranges.get("horizontal_osc_angle_right_range") if self._device_definition.device_ranges else None
+        if range_from_definition is not None:
+            return range_from_definition
+        # Fall back to horizontal angle range if available
+        if self._horizontal_angle_range is not None:
+            return (self._horizontal_angle_range[0], self._horizontal_angle_range[1])
+        return None
+
     @staticmethod
     def _parse_angle_range(value: str) -> tuple[int, int] | None:
         """Parse a Dreo angle range string like '-15,15'."""

--- a/tests/dreo/integrationtests/test_dreoevaporativecooler.py
+++ b/tests/dreo/integrationtests/test_dreoevaporativecooler.py
@@ -91,7 +91,10 @@ class TestDreoEvaporativeCoolers(IntegrationTestBase):
             assert len(pydreo_ec.preset_modes) == 2
 
             numbers = number.get_entries([pydreo_ec])
-            self.verify_expected_entities(numbers, ["Fog Level", "Horizontal Angle", "Target Humidity"])
+            self.verify_expected_entities(
+                numbers,
+                ["Fog Level", "Horizontal Angle", "Horizontal Oscillation Angle Left", "Horizontal Oscillation Angle Right", "Target Humidity"],
+            )
 
             sensors = sensor.get_entries([pydreo_ec])
             self.verify_expected_entities(sensors, ["Temperature", "Humidity", "Use since cleaning"])


### PR DESCRIPTION
DR-HEC006s allow asymmetric oscillation

<img width="1080" height="2340" alt="Screenshot_20260705_114304_DREO" src="https://github.com/user-attachments/assets/a289da16-0227-4d1a-8718-ef820fdd568d" />

Review requested for PR #809.