### PR TITLE
Localize entity names/states + add German translations (finishes #814)

### DIFF
--- a/custom_components/dreo/binary_sensor.py
+++ b/custom_components/dreo/binary_sensor.py
@@ -102,7 +102,10 @@ class DreoBinarySensorHA(DreoBaseDeviceHA, BinarySensorEntity):
         super().__init__(device)
         self.device = device
         self.entity_description = description
-        self._attr_name = super().name + " Water Empty"
+        # Use has_entity_name + translation_key so the entity name and its
+        # on/off state text are localized from the translations/*.json files.
+        self._attr_has_entity_name = True
+        del self._attr_name
         self._attr_unique_id = f"{super().unique_id}-water-empty"
 
     @property

--- a/custom_components/dreo/dreoairconditioner.py
+++ b/custom_components/dreo/dreoairconditioner.py
@@ -96,7 +96,6 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
     _attr_current_temperature = None
     _attr_fan_mode = None
     _attr_fan_modes = [FAN_LOW, FAN_MEDIUM, FAN_HIGH, FAN_AUTO]
-    _attr_name = None
     _attr_has_entity_name = True
     _attr_hvac_mode = HVACMode.OFF
     _attr_hvac_modes = None
@@ -116,7 +115,12 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
             pyDreoDevice.fan_mode,
         )
 
-        self._attr_name = "Air Conditioner"
+        # Use has_entity_name (set on the class) + translation_key so the entity
+        # name is localized from the translations/*.json files. The base class
+        # sets _attr_name to the device name; delete it so the translation_key
+        # is used instead.
+        del self._attr_name
+        self._attr_translation_key = "air_conditioner"
         self._attr_unique_id = f"{super().unique_id}-{self.device.device_id}"
         self._attr_target_temperature = self.device.target_temperature
         self._attr_current_temperature = self.device.temperature
@@ -150,7 +154,7 @@ class DreoAirConditionerHA(DreoBaseDeviceHA, ClimateEntity):
 
         _LOGGER.info(
             "new DreoAirConditionerHA instance(%s), unique ID %s, HVAC mode %s, target temp %s, current temp %s, swing mode %s, swing modes [%s], oscon %s, fan_mode %s",
-            self._attr_name,
+            self._attr_translation_key,
             self._attr_unique_id,
             self._attr_hvac_mode,
             self._attr_target_temperature,

--- a/custom_components/dreo/sensor.py
+++ b/custom_components/dreo/sensor.py
@@ -216,14 +216,19 @@ class DreoSensorHA(DreoBaseDeviceHA, SensorEntity):
 
         # Note this is a "magic" HA property.  Don't rename
         self.entity_description = description
-        self._attr_name = super().name + " " + description.key
+        # Use has_entity_name + translation_key so the entity name (and, where
+        # provided, state values) are localized from the translations/*.json files.
+        # The base class sets _attr_name to the device name; delete it so the
+        # translation_key on the entity description is used instead.
+        self._attr_has_entity_name = True
+        del self._attr_name
         self._attr_unique_id = f"{super().unique_id}-{description.key}"
         if description.native_unit_of_measurement_fn is not None:
             self._attr_native_unit_of_measurement = description.native_unit_of_measurement_fn(self.device)
         if description.options is not None:
             self._attr_options = description.options
 
-        _LOGGER.info("new DreoSensorHA instance(%s), unique ID %s", self._attr_name, self._attr_unique_id)
+        _LOGGER.info("new DreoSensorHA instance(%s), unique ID %s", description.translation_key, self._attr_unique_id)
 
     def __repr__(self):
         # Representation string of object.

--- a/custom_components/dreo/translations/de.json
+++ b/custom_components/dreo/translations/de.json
@@ -32,13 +32,17 @@
   },
   "entity": {
     "binary_sensor": {
-      "water_empty": { "name": "Wasser leer" }
+      "water_empty": { "name": "Wasserstand", "state": { "off": "OK", "on": "Leer" } }
+    },
+    "climate": {
+      "air_conditioner": { "name": "Klimaanlage" }
     },
     "switch": {
       "horizontally_oscillating": { "name": "Horizontale Oszillation" },
       "vertically_oscillating":   { "name": "Vertikale Oszillation" },
       "display_auto_off":         { "name": "Display automatisch aus" },
       "panel_sound":              { "name": "Bedienfeld-Ton" },
+      "mist":                     { "name": "Vernebler" },
       "adaptive_brightness":      { "name": "Adaptive Helligkeit" },
       "mute_on":                  { "name": "Bedienfeld stumm" },
       "oscon":                    { "name": "Oszillation" },
@@ -55,14 +59,14 @@
       "temperature":             { "name": "Temperatur" },
       "humidity":                { "name": "Luftfeuchtigkeit" },
       "use_hours":               { "name": "Nutzung seit Reinigung" },
-      "reach_target_temp":       { "name": "Zieltemperatur erreicht" },
-      "status":                  { "name": "Status" },
-      "pm25":                    { "name": "PM2.5" },
-      "water":                   { "name": "Wasserstand" },
+      "reach_target_temp":       { "name": "Zieltemperatur erreicht", "state": { "Yes": "Ja", "No": "Nein" } },
+      "status":                  { "name": "Status", "state": { "standby": "Bereitschaft", "cooking": "Kochen", "off": "Aus", "ckpause": "Pause", "ckcomplete": "Fertig" } },
+      "pm25":                    { "name": "Feinstaub" },
+      "water":                   { "name": "Wasserstand", "state": { "Ok": "OK", "Empty": "Leer" } },
       "use_hours_hm":            { "name": "Nutzung seit Reinigung" },
       "filter_life":             { "name": "Filterlebensdauer" },
-      "filter_active":           { "name": "Filter aktiv" },
-      "target_humidity_reached": { "name": "Ziel-Luftfeuchtigkeit erreicht" } 
+      "filter_active":           { "name": "Filter aktiv", "state": { "Active": "aktiv", "Inactive": "inaktiv" } },
+      "target_humidity_reached": { "name": "Ziel-Luftfeuchtigkeit erreicht", "state": { "Yes": "Ja", "No": "Nein" } }
     },
     "number": {
       "horizontal_angle":             { "name": "Horizontaler Winkel" },
@@ -75,6 +79,8 @@
       "horizontal_oscillation_angle": { "name": "Horizontaler Oszillationswinkel" },
       "vertical_oscillation_angle":   { "name": "Vertikaler Oszillationswinkel" },
       "target_humidity":              { "name": "Ziel-Luftfeuchtigkeit" },
+      "fog_level":                    { "name": "Nebelstufe" },
+      "sleep_target_humidity":        { "name": "Ziel-Luftfeuchtigkeit (Schlafmodus)" },
       "ambient_light_threshold_low":  { "name": "Umgebungslicht Feuchtigkeitsschwelle niedrig" },
       "ambient_light_threshold_high": { "name": "Umgebungslicht Feuchtigkeitsschwelle hoch" },
       "ambient_light_level":          { "name": "Umgebungslicht-Stufe" }

--- a/custom_components/dreo/translations/en.json
+++ b/custom_components/dreo/translations/en.json
@@ -34,6 +34,9 @@
       "binary_sensor": {
         "water_empty": { "name": "Water Empty" }
       },
+      "climate": {
+        "air_conditioner": { "name": "Air Conditioner" }
+      },
       "switch": {
         "horizontally_oscillating": { "name": "Horizontal Oscillation" },
         "vertically_oscillating":   { "name": "Vertical Oscillation" },

--- a/tests/dreo/integrationtests/test_regression_property_coverage.py
+++ b/tests/dreo/integrationtests/test_regression_property_coverage.py
@@ -97,7 +97,11 @@ class TestRegressionPropertyCoverage(IntegrationTestBase):
         _ = ac.current_humidity
         _ = ac.target_humidity
         _ = ac.unique_id
-        _ = ac.name
+        # The AC entity name is derived from translation_key + has_entity_name, so
+        # reading .name requires an entity platform (unavailable in this unit test).
+        # Exercise the naming attributes that drive it instead.
+        _ = ac.translation_key
+        _ = ac.has_entity_name
 
         if ac.fan_modes:
             target_mode = next((mode for mode in ac.fan_modes if mode != ac.fan_mode), None)

--- a/tests/dreo/test_airconditioner.py
+++ b/tests/dreo/test_airconditioner.py
@@ -94,7 +94,9 @@ class TestDreoAirConditionerHA(TestDeviceBase):
             device = self._create_ac_device()
             ac = DreoAirConditionerHA(device)
 
-            assert ac.name == "Air Conditioner"
+            assert ac.translation_key == "air_conditioner"
+            assert ac.has_entity_name is True
+            assert not hasattr(ac, "_attr_name")
             assert ac.unique_id is not None
             assert ac.is_on is True
             assert ac.current_temperature == 72

--- a/tests/dreo/test_sensor.py
+++ b/tests/dreo/test_sensor.py
@@ -66,7 +66,11 @@ class TestDreoSensorHA(TestDeviceBase):
 
             entities = sensor.get_entries([device])
             temp_sensor = next(e for e in entities if e.entity_description.key == "Temperature")
-            assert temp_sensor.name == "Test Humidifier Temperature"
+            # Name is now derived from the translation_key + has_entity_name rather
+            # than a hardcoded _attr_name (which requires the entity platform to resolve).
+            assert temp_sensor.has_entity_name is True
+            assert temp_sensor.translation_key == "temperature"
+            assert not hasattr(temp_sensor, "_attr_name")
             assert temp_sensor.unique_id == "HUM001-Temperature"
 
     def test_sensor_native_value(self):


### PR DESCRIPTION
## Summary

Finishes the work started in #814 by @harrymayr — gets the German translation strings in and properly wires up the translation plumbing so they actually render.

### Translation plumbing
Home Assistant only localizes an entity's name/state when it uses `has_entity_name = True` + a `translation_key` (the descriptions already defined `translation_key`, but hardcoded `_attr_name` overrides were suppressing it). This PR:
- **Sensor** & **binary sensor**: drop the hardcoded `_attr_name`, set `has_entity_name = True` so names resolve from `translations/*.json`.
- **Air conditioner**: use `translation_key = "air_conditioner"` instead of a hardcoded English name, and remove the class-level `_attr_name = None` that was bypassing translation. Adds `climate.air_conditioner` to `en.json` (required English fallback) and `de.json`.

### German strings (from #814)
- State translations: `water_empty`, `reach_target_temp`, `status`, `water`, `filter_active`, `target_humidity_reached`
- New keys: `switch.mist`, `number.fog_level`, `number.sleep_target_humidity`
- Renames: `water_empty` (Wasser leer → Wasserstand), `pm25` (PM2.5 → Feinstaub)
- Fixed a state-key typo from the original (`filter_active` mapped `Aktive` → corrected to the actual option value `Active`).

### Tests
- Updated `test_ac_basic_properties` and `test_sensor_entity_properties` to assert `translation_key`/`has_entity_name` (translated entities can't resolve `.name` without an entity platform).
- Updated the AC branch of the property-coverage regression test for the same reason.
- Full suite: **807 passed**; `ruff check .` clean.

Supersedes #814.

Co-authored-by: harrymayr <harrymayr@users.noreply.github.com>