### PR TITLE
Credit @nertwork for DR-HAP003S midea variant (#818)

### DIFF
--- a/DEVICE_OWNERS.md
+++ b/DEVICE_OWNERS.md
@@ -99,7 +99,7 @@ Sourced from GitHub issues, PRs, and contributed test data.
 | Model | GitHub User(s) | Evidence |
 |---|---|---|
 | DR-HAP002S | [@cameronbowe](https://github.com/cameronbowe), [@CSSGeek94](https://github.com/CSSGeek94), [@Monsterray](https://github.com/Monsterray) | [#63](https://github.com/JeffSteinbok/hass-dreo/issues/63), [#260](https://github.com/JeffSteinbok/hass-dreo/issues/260), [#76](https://github.com/JeffSteinbok/hass-dreo/issues/76) |
-| DR-HAP003S | [@nertwork](https://github.com/nertwork), [@UberMentch](https://github.com/UberMentch) | [#22](https://github.com/JeffSteinbok/hass-dreo/issues/22), [#149](https://github.com/JeffSteinbok/hass-dreo/issues/149), [#784](https://github.com/JeffSteinbok/hass-dreo/pull/784) |
+| DR-HAP003S | [@nertwork](https://github.com/nertwork), [@UberMentch](https://github.com/UberMentch) | [#22](https://github.com/JeffSteinbok/hass-dreo/issues/22), [#149](https://github.com/JeffSteinbok/hass-dreo/issues/149), [#784](https://github.com/JeffSteinbok/hass-dreo/pull/784), [#818](https://github.com/JeffSteinbok/hass-dreo/pull/818) |
 | DR-HAP005S | [@TheShai1](https://github.com/TheShai1), [@calpay2000-afk](https://github.com/calpay2000-afk) | [#282](https://github.com/JeffSteinbok/hass-dreo/issues/282), [#612](https://github.com/JeffSteinbok/hass-dreo/issues/612) |
 
 ## Floor Fans (DR-HAF)


### PR DESCRIPTION
Adds PR #818 to @nertwork's evidence in DEVICE_OWNERS.md. The midea DR-HAP003S variant fix in #818 was built from their diagnostics (originally in #784).