### PR TITLE
Normalize fan preset modes to lowercase + add display translations

### DIFF
--- a/custom_components/dreo/dreofan.py
+++ b/custom_components/dreo/dreofan.py
@@ -33,11 +33,11 @@ class DreoFanHA(DreoBaseDeviceHA, FanEntity):
     def percentage(self) -> int | None:
         """Return the current speed."""
         if self.device.type is DreoDeviceType.DEHUMIDIFIER:
-            if self.device.preset_mode == "Low":
+            if self.device.preset_mode == "low":
                 return 33
-            elif self.device.preset_mode == "Medium":
+            elif self.device.preset_mode == "medium":
                 return 67
-            elif self.device.preset_mode == "High":
+            elif self.device.preset_mode == "high":
                 return 100
             return None
         if self.device.speed_range is None or self.device.fan_speed is None:
@@ -133,11 +133,11 @@ class DreoFanHA(DreoBaseDeviceHA, FanEntity):
 
         if self.device.type is DreoDeviceType.DEHUMIDIFIER:
             if percentage <= 33:
-                self.device.set_preset_mode("Low")
+                self.device.set_preset_mode("low")
             elif percentage <= 67:
-                self.device.set_preset_mode("Medium")
+                self.device.set_preset_mode("medium")
             else:
-                self.device.set_preset_mode("High")
+                self.device.set_preset_mode("high")
         else:
             if self.device.speed_range is None:
                 _LOGGER.error("set_percentage: speed_range not available for %s", self.device.name)

--- a/custom_components/dreo/icons.json
+++ b/custom_components/dreo/icons.json
@@ -11,7 +11,10 @@
               "auto": "mdi:fan-auto",
               "turbo": "mdi:fan-speed-3",
               "reverse": "mdi:swap-horizontal",
-              "custom": "mdi:tune-variant"
+              "custom": "mdi:tune-variant",
+              "low": "mdi:fan-speed-1",
+              "medium": "mdi:fan-speed-2",
+              "high": "mdi:fan-speed-3"
             }
           }
         }

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -522,7 +522,7 @@ SUPPORTED_DEVICES = {
     # Asymmetric horizontal oscillation is also supported with left/right angles
     "DR-HEC006S": DreoDeviceDetails(
         device_type=DreoDeviceType.EVAPORATIVE_COOLER,
-        preset_modes=[("Normal", 1), ("Turbo", 4)],
+        preset_modes=[("normal", 1), ("turbo", 4)],
         device_ranges={
             SPEED_RANGE: (1, 6),
             HORIZONTAL_ANGLE_RANGE: (-75, 75),
@@ -535,7 +535,7 @@ SUPPORTED_DEVICES = {
     # Without an explicit mapping it falls back to generic DR-HEC defaults.
     "DR-HEC005S": DreoDeviceDetails(
         device_type=DreoDeviceType.EVAPORATIVE_COOLER,
-        preset_modes=[("Normal", 1), ("Natural", 4), ("Sleep", 3), ("Auto", 2)],
+        preset_modes=[("normal", 1), ("natural", 4), ("sleep", 3), ("auto", 2)],
         device_ranges={SPEED_RANGE: (1, 12), "fog_level_range": (1, 4)},
     ),
 }

--- a/custom_components/dreo/pydreo/pydreodehumidifier.py
+++ b/custom_components/dreo/pydreo/pydreodehumidifier.py
@@ -181,27 +181,27 @@ class PyDreoDehumidifier(PyDreoBaseDevice):
     @property
     def preset_modes(self):
         """Get the list of fan speed preset modes"""
-        return ["Low", "Medium", "High"]
+        return ["low", "medium", "high"]
 
     @property
     def preset_mode(self):
         """Get the current fan speed preset mode"""
         if self._wind_level == 1:
-            return "Low"
+            return "low"
         elif self._wind_level == 2:
-            return "Medium"
+            return "medium"
         elif self._wind_level == 3:
-            return "High"
+            return "high"
         return None
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set the fan speed preset mode"""
         _LOGGER.debug("set_preset_mode: set_preset_mode(%s) --> %s", self.name, preset_mode)
-        if preset_mode == "Low":
+        if preset_mode == "low":
             self.wind_level = 1
-        elif preset_mode == "Medium":
+        elif preset_mode == "medium":
             self.wind_level = 2
-        elif preset_mode == "High":
+        elif preset_mode == "high":
             self.wind_level = 3
         else:
             raise ValueError(f"Invalid fan preset mode: {preset_mode}")

--- a/custom_components/dreo/pydreo/pydreoevaporativecooler.py
+++ b/custom_components/dreo/pydreo/pydreoevaporativecooler.py
@@ -48,14 +48,14 @@ HUMIDIFY_MODE_MAP = {
 WATER_LEVEL_STATUS_MAP = {0: WATER_LEVEL_OK, 1: WATER_LEVEL_EMPTY, WATER_LEVEL_OK: 0, WATER_LEVEL_EMPTY: 1}
 
 WINDMODES = [
-    "Normal",
-    "Natural",
-    "Sleep",
-    "Auto",
+    "normal",
+    "natural",
+    "sleep",
+    "auto",
 ]
 
 # Windmodes for evaporative cooler (HEC002S legacy path, 0-indexed REST → 1-based internal)
-WINDMODE_MAP = {"Normal": 1, "Auto": 2, "Sleep": 3, "Natural": 4, 1: "Normal", 2: "Auto", 3: "Sleep", 4: "Natural"}
+WINDMODE_MAP = {"normal": 1, "auto": 2, "sleep": 3, "natural": 4, 1: "normal", 2: "auto", 3: "sleep", 4: "natural"}
 
 if TYPE_CHECKING:
     from pydreo import PyDreo

--- a/custom_components/dreo/strings.json
+++ b/custom_components/dreo/strings.json
@@ -34,6 +34,26 @@
       "binary_sensor": {
         "water_empty": { "name": "Water Empty" }
       },
+      "fan": {
+        "fan": {
+          "state_attributes": {
+            "preset_mode": {
+              "state": {
+                "normal": "Normal",
+                "natural": "Natural",
+                "sleep": "Sleep",
+                "auto": "Auto",
+                "turbo": "Turbo",
+                "reverse": "Reverse",
+                "custom": "Custom",
+                "low": "Low",
+                "medium": "Medium",
+                "high": "High"
+              }
+            }
+          }
+        }
+      },
       "switch": {
         "horizontally_oscillating": { "name": "Horizontal Oscillation" },
         "vertically_oscillating":   { "name": "Vertical Oscillation" },

--- a/custom_components/dreo/translations/bg.json
+++ b/custom_components/dreo/translations/bg.json
@@ -34,6 +34,26 @@
       "binary_sensor": {
         "water_empty": { "name": "Водата е изразходвана" }
       },
+      "fan": {
+        "fan": {
+          "state_attributes": {
+            "preset_mode": {
+              "state": {
+                "normal": "Нормален",
+                "natural": "Естествен",
+                "sleep": "Сън",
+                "auto": "Автоматичен",
+                "turbo": "Турбо",
+                "reverse": "Обратен",
+                "custom": "Персонализиран",
+                "low": "Ниско",
+                "medium": "Средно",
+                "high": "Високо"
+              }
+            }
+          }
+        }
+      },
       "switch": {
         "horizontally_oscillating": { "name": "Хоризонтално осцилиращ" },
         "vertically_oscillating":   { "name": "Вертикално осцилиращ" },

--- a/custom_components/dreo/translations/de.json
+++ b/custom_components/dreo/translations/de.json
@@ -34,6 +34,26 @@
     "binary_sensor": {
       "water_empty": { "name": "Wasserstand", "state": { "off": "OK", "on": "Leer" } }
     },
+    "fan": {
+      "fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "normal": "Normal",
+              "natural": "Natürlich",
+              "sleep": "Schlaf",
+              "auto": "Automatik",
+              "turbo": "Turbo",
+              "reverse": "Rückwärts",
+              "custom": "Benutzerdefiniert",
+              "low": "Niedrig",
+              "medium": "Mittel",
+              "high": "Hoch"
+            }
+          }
+        }
+      }
+    },
     "climate": {
       "air_conditioner": { "name": "Klimaanlage" }
     },

--- a/custom_components/dreo/translations/en.json
+++ b/custom_components/dreo/translations/en.json
@@ -34,6 +34,26 @@
       "binary_sensor": {
         "water_empty": { "name": "Water Empty" }
       },
+      "fan": {
+        "fan": {
+          "state_attributes": {
+            "preset_mode": {
+              "state": {
+                "normal": "Normal",
+                "natural": "Natural",
+                "sleep": "Sleep",
+                "auto": "Auto",
+                "turbo": "Turbo",
+                "reverse": "Reverse",
+                "custom": "Custom",
+                "low": "Low",
+                "medium": "Medium",
+                "high": "High"
+              }
+            }
+          }
+        }
+      },
       "climate": {
         "air_conditioner": { "name": "Air Conditioner" }
       },

--- a/custom_components/dreo/translations/es.json
+++ b/custom_components/dreo/translations/es.json
@@ -34,6 +34,26 @@
     "binary_sensor": {
       "water_empty": { "name": "Agua vacía" }
     },
+    "fan": {
+      "fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "normal": "Normal",
+              "natural": "Natural",
+              "sleep": "Reposo",
+              "auto": "Automático",
+              "turbo": "Turbo",
+              "reverse": "Inverso",
+              "custom": "Personalizado",
+              "low": "Bajo",
+              "medium": "Medio",
+              "high": "Alto"
+            }
+          }
+        }
+      }
+    },
     "switch": {
       "horizontally_oscillating": { "name": "Oscilación horizontal" },
       "vertically_oscillating":   { "name": "Oscilación vertical" },

--- a/custom_components/dreo/translations/it.json
+++ b/custom_components/dreo/translations/it.json
@@ -34,6 +34,26 @@
     "binary_sensor": {
       "water_empty": { "name": "Acqua esaurita" }
     },
+    "fan": {
+      "fan": {
+        "state_attributes": {
+          "preset_mode": {
+            "state": {
+              "normal": "Normale",
+              "natural": "Naturale",
+              "sleep": "Sonno",
+              "auto": "Automatico",
+              "turbo": "Turbo",
+              "reverse": "Inverso",
+              "custom": "Personalizzato",
+              "low": "Bassa",
+              "medium": "Media",
+              "high": "Alta"
+            }
+          }
+        }
+      }
+    },
     "switch": {
       "horizontally_oscillating": { "name": "Oscillazione orizzontale" },
       "vertically_oscillating":   { "name": "Oscillazione verticale" },

--- a/tests/dreo/integrationtests/test_dreoevaporativecooler.py
+++ b/tests/dreo/integrationtests/test_dreoevaporativecooler.py
@@ -87,7 +87,7 @@ class TestDreoEvaporativeCoolers(IntegrationTestBase):
             assert ha_fan.percentage >= 0 and ha_fan.percentage <= 100
 
             # Check preset modes
-            assert pydreo_ec.preset_modes == ["Normal", "Turbo"]
+            assert pydreo_ec.preset_modes == ["normal", "turbo"]
             assert len(pydreo_ec.preset_modes) == 2
 
             numbers = number.get_entries([pydreo_ec])

--- a/tests/pydreo/test_pydreodehumidifier.py
+++ b/tests/pydreo/test_pydreodehumidifier.py
@@ -48,9 +48,9 @@ class TestPyDreoDehumidifier(TestBase):
         dehumidifier: PyDreoDehumidifier = self.pydreo_manager.devices[0]
 
         assert dehumidifier.speed_range == (1, 3)
-        assert dehumidifier.preset_modes == ["Low", "Medium", "High"]
-        # wind_level=2 → "Medium"
-        assert dehumidifier.preset_mode == "Medium"
+        assert dehumidifier.preset_modes == ["low", "medium", "high"]
+        # wind_level=2 → "medium"
+        assert dehumidifier.preset_mode == "medium"
 
     def test_HDH005S_is_on_setter(self):  # pylint: disable=invalid-name
         """Test that is_on setter sends the correct command."""
@@ -220,15 +220,15 @@ class TestPyDreoDehumidifier(TestBase):
         dehumidifier: PyDreoDehumidifier = self.pydreo_manager.devices[0]
 
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            dehumidifier.set_preset_mode("Low")
+            dehumidifier.set_preset_mode("low")
             mock_send_command.assert_called_once_with(dehumidifier, {WINDLEVEL_KEY: 1})
 
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            dehumidifier.set_preset_mode("Medium")
+            dehumidifier.set_preset_mode("medium")
             mock_send_command.assert_called_once_with(dehumidifier, {WINDLEVEL_KEY: 2})
 
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            dehumidifier.set_preset_mode("High")
+            dehumidifier.set_preset_mode("high")
             mock_send_command.assert_called_once_with(dehumidifier, {WINDLEVEL_KEY: 3})
 
         with pytest.raises(ValueError):
@@ -241,13 +241,13 @@ class TestPyDreoDehumidifier(TestBase):
         dehumidifier: PyDreoDehumidifier = self.pydreo_manager.devices[0]
 
         dehumidifier._wind_level = 1
-        assert dehumidifier.preset_mode == "Low"
+        assert dehumidifier.preset_mode == "low"
 
         dehumidifier._wind_level = 2
-        assert dehumidifier.preset_mode == "Medium"
+        assert dehumidifier.preset_mode == "medium"
 
         dehumidifier._wind_level = 3
-        assert dehumidifier.preset_mode == "High"
+        assert dehumidifier.preset_mode == "high"
 
         dehumidifier._wind_level = None
         assert dehumidifier.preset_mode is None

--- a/tests/pydreo/test_pydreoevaporativecooler.py
+++ b/tests/pydreo/test_pydreoevaporativecooler.py
@@ -41,10 +41,10 @@ class TestPyDreoEvaporativeCooler(TestBase):
 
         assert ec_fan.humidity == 41
         assert ec_fan.speed_range == (1, 4)
-        assert ec_fan.preset_modes == ["Normal", "Natural", "Sleep", "Auto"]
+        assert ec_fan.preset_modes == ["normal", "natural", "sleep", "auto"]
         assert ec_fan.oscillating is True
         assert ec_fan.childlockon is False
-        assert ec_fan.preset_mode == "Sleep"
+        assert ec_fan.preset_mode == "sleep"
         assert ec_fan.work_time == 19
         assert ec_fan.water_level == "Ok"
 
@@ -138,21 +138,21 @@ class TestPyDreoEvaporativeCooler(TestBase):
         self.pydreo_manager.load_devices()
         ec_fan: PyDreoEvaporativeCooler = self.pydreo_manager.devices[0]
 
-        # "Normal" -> WINDMODE_MAP["Normal"] = 1
+        # "normal" -> WINDMODE_MAP["normal"] = 1
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            ec_fan.preset_mode = "Normal"
+            ec_fan.preset_mode = "normal"
             mock_send_command.assert_called_once_with(ec_fan, {WIND_MODE_KEY: 1})
 
-        # "Auto" -> WINDMODE_MAP["Auto"] = 2
+        # "auto" -> WINDMODE_MAP["auto"] = 2
         ec_fan._wind_mode = 1
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            ec_fan.preset_mode = "Auto"
+            ec_fan.preset_mode = "auto"
             mock_send_command.assert_called_once_with(ec_fan, {WIND_MODE_KEY: 2})
 
         # Duplicate value -- no command sent (current is 3=Sleep, set Sleep again)
         ec_fan._wind_mode = 3
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            ec_fan.preset_mode = "Sleep"
+            ec_fan.preset_mode = "sleep"
             mock_send_command.assert_not_called()
 
     def test_HEC002S_handle_server_update(self):  # pylint: disable=invalid-name
@@ -215,10 +215,10 @@ class TestPyDreoEvaporativeCooler(TestBase):
         ec_fan: PyDreoEvaporativeCooler = self.pydreo_manager.devices[0]
 
         # Valid 0-based REST indices -> internal int values
-        assert ec_fan._map_wind_mode_from_rest(0) == 1  # "Normal" -> 1
-        assert ec_fan._map_wind_mode_from_rest(1) == 4  # "Natural" -> 4
-        assert ec_fan._map_wind_mode_from_rest(2) == 3  # "Sleep" -> 3
-        assert ec_fan._map_wind_mode_from_rest(3) == 2  # "Auto" -> 2
+        assert ec_fan._map_wind_mode_from_rest(0) == 1  # "normal" -> 1
+        assert ec_fan._map_wind_mode_from_rest(1) == 4  # "natural" -> 4
+        assert ec_fan._map_wind_mode_from_rest(2) == 3  # "sleep" -> 3
+        assert ec_fan._map_wind_mode_from_rest(3) == 2  # "auto" -> 2
 
         # Invalid indices return None
         assert ec_fan._map_wind_mode_from_rest(None) is None
@@ -266,10 +266,10 @@ class TestPyDreoEvaporativeCooler(TestBase):
 
         assert ec_fan.humidity == 41
         assert ec_fan.speed_range == (1, 6)
-        assert ec_fan.preset_modes == ["Normal", "Turbo"]
+        assert ec_fan.preset_modes == ["normal", "turbo"]
         assert ec_fan.oscillating is True
         assert ec_fan.childlockon is False
-        assert ec_fan.preset_mode == "Normal"
+        assert ec_fan.preset_mode == "normal"
         assert ec_fan.work_time == 42
         assert ec_fan.water_level == "Ok"
         assert ec_fan.target_humidity == 55
@@ -335,27 +335,27 @@ class TestPyDreoEvaporativeCooler(TestBase):
         self.pydreo_manager.load_devices()
         ec_fan: PyDreoEvaporativeCooler = self.pydreo_manager.devices[0]
 
-        # "Turbo" -> mode value 4
+        # "turbo" -> mode value 4
         ec_fan._wind_mode = 1  # set to Normal first
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            ec_fan.preset_mode = "Turbo"
+            ec_fan.preset_mode = "turbo"
             mock_send_command.assert_called_once_with(ec_fan, {MODE_KEY: 4})
 
-        # "Normal" -> mode value 1
+        # "normal" -> mode value 1
         ec_fan._wind_mode = 2
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            ec_fan.preset_mode = "Normal"
+            ec_fan.preset_mode = "normal"
             mock_send_command.assert_called_once_with(ec_fan, {MODE_KEY: 1})
 
         # Duplicate value -- no command sent
         ec_fan._wind_mode = 1
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            ec_fan.preset_mode = "Normal"
+            ec_fan.preset_mode = "normal"
             mock_send_command.assert_not_called()
 
         # Invalid mode raises ValueError
         with pytest.raises(ValueError):
-            ec_fan.preset_mode = "Sleep"
+            ec_fan.preset_mode = "sleep"
 
     def test_HEC006S_handle_server_update(self):  # pylint: disable=invalid-name
         """Test handle_server_update processes WebSocket fields correctly for HEC006S."""
@@ -386,7 +386,7 @@ class TestPyDreoEvaporativeCooler(TestBase):
         # mode: HEC006S uses "mode" key via base class; WebSocket sends 1-based int
         ec_fan.handle_server_update({REPORTED_KEY: {MODE_KEY: 4}})
         assert ec_fan._wind_mode == 4
-        assert ec_fan.preset_mode == "Turbo"
+        assert ec_fan.preset_mode == "turbo"
 
         # work_time
         ec_fan.handle_server_update({REPORTED_KEY: {WORKTIME_KEY: 50}})
@@ -425,7 +425,7 @@ class TestPyDreoEvaporativeCooler(TestBase):
 
         # After update_state, _wind_mode should be set from the "mode" key (value 1)
         assert ec_fan._wind_mode == 1
-        assert ec_fan.preset_mode == "Normal"
+        assert ec_fan.preset_mode == "normal"
 
     def test_HEC005S_empty_controls_conf_variance(self):  # pylint: disable=invalid-name
         """Test DR-HEC005S model variance with empty controlsConf."""
@@ -434,16 +434,16 @@ class TestPyDreoEvaporativeCooler(TestBase):
         ec_fan: PyDreoEvaporativeCooler = self.pydreo_manager.devices[0]
 
         assert ec_fan.speed_range == (1, 12)
-        assert ec_fan.preset_modes == ["Normal", "Natural", "Sleep", "Auto"]
+        assert ec_fan.preset_modes == ["normal", "natural", "sleep", "auto"]
         assert ec_fan._wind_mode == 1
-        assert ec_fan.preset_mode == "Normal"
+        assert ec_fan.preset_mode == "normal"
         assert ec_fan.fan_speed == 3
         assert ec_fan.fog_level_range == (1, 4)
         assert ec_fan.temperature == 82
         assert ec_fan.humidity == 58
 
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
-            ec_fan.preset_mode = "Auto"
+            ec_fan.preset_mode = "auto"
             mock_send_command.assert_called_once_with(ec_fan, {MODE_KEY: 2})
 
         with patch(PATCH_SEND_COMMAND) as mock_send_command:


### PR DESCRIPTION
> [!WARNING]
> **This is a substantial change with a user-facing breaking change.** It touches the core preset-mode handling for fan entities and changes the `preset_mode` string values reported/accepted by several device types. **Automations, scripts, and scenes that reference the old capitalized preset names on the affected devices below will stop matching and must be updated to lowercase.**

## Summary
Normalizes **all** fan `preset_mode` values to lowercase so they are consistent across every device type, and adds display-name translations so the UI still shows nicely capitalized labels. This makes `icons.json` state-attribute icons apply to every preset (they are case-sensitive), and gives every preset a proper localized name.

## Why
Most fans already exposed lowercase presets (`normal`, `natural`, `auto`, …), but **evaporative coolers** and **dehumidifiers** exposed **capitalized** raw values. Because icon/translation state keys are case-sensitive, those devices did not match the fan preset icons, and behavior was inconsistent across the integration.

## ⚠️ Breaking change — affected devices
The HA-facing `preset_mode` string changed case (the underlying numeric device command is unchanged). If you reference these presets by name in automations/scripts/scenes, update them to lowercase.

**Evaporative coolers** — `Normal` → `normal`, `Natural` → `natural`, `Sleep` → `sleep`, `Auto` → `auto`, `Turbo` → `turbo`:
- `DR-HEC005S`
- `DR-HEC006S`
- Generic `DR-HEC*` fallback models (e.g. `DR-HEC002S`)

**Dehumidifiers** — `Low` → `low`, `Medium` → `medium`, `High` → `high`:
- `DR-HDH001S`
- `DR-HDH002S`
- `DR-HDH003S`
- `DR-HDH005S`

> [!NOTE]
> The dehumidifier operation **mode** (`Auto` / `Continuous`, on the humidifier entity) is **not** changed — only the dehumidifier fan-speed `preset_mode` (Low/Medium/High). Standard tower fans, air circulators, and ceiling fans were already lowercase and are unaffected.

## Changes
- **Lowercased raw preset values**: `models.py` (DR-HEC005S/006S), `pydreoevaporativecooler.py` (`WINDMODES` / `WINDMODE_MAP`), `pydreodehumidifier.py` (`low`/`medium`/`high`), and `dreofan.py` dehumidifier percentage mapping.
- **`icons.json`**: added `low`/`medium`/`high` icons; full coverage for `normal`, `natural`, `sleep`, `auto`, `turbo`, `reverse`, `custom`, `low`, `medium`, `high`.
- **Translations**: added `fan` → `preset_mode` state display names for all presets in `strings.json` and every locale (`en`, `de`, `es`, `it`, `bg`).
- **Tests**: updated dehumidifier and evaporative cooler assertions to lowercase.

## Validation
- `ruff check .` — clean
- `pytest` — 817 passed