### PR TITLE
fix(purifier): add support for 001 MCU revision of DR-HAP003S

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -379,7 +379,7 @@ SUPPORTED_DEVICES = {
     "DR-HAP": DreoDeviceDetails(device_type=DreoDeviceType.AIR_PURIFIER),
     "DR-HAP003S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_PURIFIER,
-        # Newer hardware revision ("midea" MCU, seriesName "Macro Max S/AS") rejects the plain
+        # Newer hardware and firmware revisions ("midea" or "001" MCU, seriesName "Macro Max S/AS") reject the plain
         # "auto" mode command and requires "auto-silent" instead.  The override sets a flag on
         # the device instance so PyDreoAirPurifier._send_command can remap the command value.
         # The original revision ("meidi" MCU, seriesName "Macro Max S") is left untouched.

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -163,7 +163,7 @@ SUPPORTED_MODEL_PREFIXES = {"DR-HTF", "DR-HAF", "DR-HAP", "DR-HPF", "DR-HCF", "W
 # MCU hardware model strings used to identify specific hardware revisions.
 _MCU_HAF004S_OLD_REV = "SC95F8613B"
 _MCU_HTF007S_OLD_REV = ("CMS89F7518", "CMS89F7518/EUR", "CMS89F7518/USA")
-_MCU_HAP003S_AUTO_SILENT_REV = "midea"
+_MCU_HAP003S_AUTO_SILENT_REV = ("midea", "001")
 
 
 def _haf004s_mcu_override(device) -> None:
@@ -210,7 +210,7 @@ def _hap003s_mcu_override(device) -> None:
     mixed = device.raw_state.get("data", {}).get("mixed", {})
     mcu_obj = mixed.get("mcu_hardware_model", {})
     mcu_model = mcu_obj.get("state", "") if isinstance(mcu_obj, dict) else ""
-    if mcu_model == _MCU_HAP003S_AUTO_SILENT_REV:
+    if mcu_model in _MCU_HAP003S_AUTO_SILENT_REV:
         device._auto_mode_uses_auto_silent = True  # pylint: disable=protected-access
 
 

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -199,9 +199,9 @@ def _htf007s_mcu_override(device) -> None:
 
 
 def _hap003s_mcu_override(device) -> None:
-    """Enable auto-silent command remapping for DR-HAP003S units with the "midea" MCU.
+    """Enable auto-silent command remapping for DR-HAP003S units with the "midea" or "001" MCU.
 
-    A newer hardware revision of the Macro Max S/AS uses a "midea" MCU that rejects the
+    Newer hardware and firmware revisions (mcu_hardware_model is "midea" or "001") reject the
     plain "auto" mode command string.  These units require "auto-silent" to be sent instead.
     Units with a different MCU (e.g. "meidi") accept "auto" directly and are left untouched.
     """

--- a/custom_components/dreo/pydreo/pydreoairpurifier.py
+++ b/custom_components/dreo/pydreo/pydreoairpurifier.py
@@ -19,7 +19,7 @@ class PyDreoAirPurifier(PyDreoFanBase):
         """Initialize air devices."""
         _LOGGER.debug("__init__: __init__")
         super().__init__(device_definition, details, dreo)
-        # Set by _hap003s_mcu_override after device state is loaded when the "midea" MCU is
+        # Set by _hap003s_mcu_override after device state is loaded when the "midea" or "001" MCU is
         # detected.  When True, _send_command remaps the "auto" mode value to "auto-silent"
         # before transmission because that hardware revision rejects the plain "auto" string.
         self._auto_mode_uses_auto_silent: bool = False
@@ -79,7 +79,7 @@ class PyDreoAirPurifier(PyDreoFanBase):
     def _send_command(self, command_key: str, value) -> None:
         """Override to remap the 'auto' mode to 'auto-silent' on newer DR-HAP003S hardware.
 
-        Newer revisions of the DR-HAP003S (identified by the "midea" MCU model) reject the
+        Newer revisions of the DR-HAP003S (identified by the "midea" or "001" MCU models) reject the
         plain "auto" mode command string.  When _auto_mode_uses_auto_silent is set by the
         override function, outgoing "auto" mode commands are translated to "auto-silent"
         before transmission. The device reports back "auto-silent" as its state; PyDreoFanBase.preset_mode

--- a/tests/dreo/integrationtests/test_dreoairpurifier.py
+++ b/tests/dreo/integrationtests/test_dreoairpurifier.py
@@ -170,6 +170,61 @@ class TestDreoAirPurifier(IntegrationTestBase):
             sensors = sensor.get_entries([pydreo_ap])
             self.verify_expected_entities(sensors, ["pm25"])
 
+    def test_HAP003S_3(self):  # pylint: disable=invalid-name
+        """Load HAP003S air purifier (Macro Max S/AS) — newer "001" MCU revision."""
+        with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):
+            self.get_devices_file_name = "get_devices_HAP003S_3.json"
+            self.pydreo_manager.load_devices()
+            assert len(self.pydreo_manager.devices) == 1
+
+            pydreo_ap = self.pydreo_manager.devices[0]
+            assert pydreo_ap.type == "Air Purifier"
+            assert pydreo_ap.model == "DR-HAP003S"
+            assert pydreo_ap.series_name == "Macro Max S/AS"
+            assert pydreo_ap.speed_range == (1, 18)
+            assert pydreo_ap.preset_modes == ["auto", "manual", "sleep", "turbo"]
+            # Newer "001" MCU revision must have auto-silent remapping enabled
+            assert pydreo_ap._auto_mode_uses_auto_silent is True  # pylint: disable=protected-access
+
+            ha_fan = fan.DreoFanHA(pydreo_ap)
+            assert ha_fan.speed_count == 18
+            assert ha_fan.unique_id is not None
+            assert ha_fan.name is not None
+            assert ha_fan.preset_modes == ["auto", "manual", "sleep", "turbo"]
+
+            # Test turn on/off
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.turn_on()
+                mock_send_command.assert_called_once_with(pydreo_ap, {POWERON_KEY: True})
+            pydreo_ap.handle_server_update({REPORTED_KEY: {POWERON_KEY: True}})
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.turn_off()
+                mock_send_command.assert_called_once_with(pydreo_ap, {POWERON_KEY: False})
+            pydreo_ap.handle_server_update({REPORTED_KEY: {POWERON_KEY: False}})
+
+            # Restore ON state via state update (no command sent) before testing preset mode
+            pydreo_ap.handle_server_update({REPORTED_KEY: {POWERON_KEY: True}})
+            pydreo_ap.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: "sleep"}})
+
+            # Newer revision must remap "auto" preset command to "auto-silent"
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_preset_mode("auto")
+                mock_send_command.assert_called_once_with(pydreo_ap, {WIND_MODE_KEY: "auto-silent"})
+            pydreo_ap.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: "auto-silent"}})
+
+            # Other modes must pass through unchanged
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_preset_mode("sleep")
+                mock_send_command.assert_called_once_with(pydreo_ap, {WIND_MODE_KEY: "sleep"})
+
+            # Test entity inventory
+            # Newer revision uses lightmode so no Display Auto Off switch is created, and adds a pm25 sensor.
+            switches = switch.get_entries([pydreo_ap])
+            self.verify_expected_entities(switches, ["Child Lock", "Panel Sound"])
+            sensors = sensor.get_entries([pydreo_ap])
+            self.verify_expected_entities(sensors, ["pm25"])
+
     def test_HAP005S(self):  # pylint: disable=invalid-name
         """Load HAP005S air purifier (Macro AP505S) and test HA entity."""
         with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):

--- a/tests/pydreo/api_responses/get_device_state_HAP003S_3.json
+++ b/tests/pydreo/api_responses/get_device_state_HAP003S_3.json
@@ -1,0 +1,106 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "mixed": {
+      "mcu_hardware_model": {
+        "state": "001",
+        "timestamp": 1782640226
+      },
+      "module_hardware_model": {
+        "state": "HeFi",
+        "timestamp": 1782640226
+      },
+      "wifi_ssid": {
+        "state": "**REDACTED**",
+        "timestamp": 1782640226
+      },
+      "wifi_rssi": {
+        "state": -43,
+        "timestamp": 1782640226
+      },
+      "windlevel": {
+        "state": 1,
+        "timestamp": 1782640226
+      },
+      "poweron": {
+        "state": false,
+        "timestamp": 1782640226
+      },
+      "lifetime": {
+        "state": 1,
+        "timestamp": 1782640226
+      },
+      "timeron": {
+        "state": {
+          "ts": 1782510622,
+          "du": 0
+        },
+        "timestamp": null
+      },
+      "module_firmware_version": {
+        "state": "3.4.4",
+        "timestamp": 1782640226
+      },
+      "connected": {
+        "state": true,
+        "timestamp": 1782640226
+      },
+      "mode": {
+        "state": "auto-silent",
+        "timestamp": 1782640226
+      },
+      "aq": {
+        "state": 1,
+        "timestamp": 1782640226
+      },
+      "mcuon": {
+        "state": true,
+        "timestamp": 1782640226
+      },
+      "timeroff": {
+        "state": {
+          "ts": 1782510622,
+          "du": 0
+        },
+        "timestamp": null
+      },
+      "network_latency": {
+        "state": 10,
+        "timestamp": 1782640226
+      },
+      "mcu_firmware_version": {
+        "state": "0.2.9",
+        "timestamp": 1782640226
+      },
+      "module_hardware_mac": {
+        "state": "**REDACTED**",
+        "timestamp": 1782640226
+      },
+      "lightmode": {
+        "state": 2,
+        "timestamp": 1782640226
+      },
+      "childlockon": {
+        "state": false,
+        "timestamp": 1782640226
+      },
+      "muteon": {
+        "state": true,
+        "timestamp": 1782640226
+      },
+      "purifylevel": {
+        "state": 255,
+        "timestamp": 1782640226
+      },
+      "pm25": {
+        "state": 1,
+        "timestamp": 1782640226
+      }
+    },
+    "sn": "HAP003S_3",
+    "productId": "**REDACTED**",
+    "region": "us-east-2",
+    "deviceInfo": null
+  }
+}

--- a/tests/pydreo/api_responses/get_devices_HAP003S_3.json
+++ b/tests/pydreo/api_responses/get_devices_HAP003S_3.json
@@ -1,0 +1,239 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "currentPage": 1,
+    "pageSize": 100,
+    "totalNum": 1,
+    "totalPage": 1,
+    "list": [
+      {
+        "deviceId": "1821290685702082562",
+        "sn": "HAP003S_3",
+        "brand": "Dreo",
+        "model": "DR-HAP003S",
+        "productId": "**REDACTED**",
+        "productName": "Air Purifier",
+        "deviceName": "DEBUGTEST - Air Purifier - DR-HAP003S (Macro Max S/AS - 001 MCU)",
+        "shared": false,
+        "series": null,
+        "seriesName": "Macro Max S/AS",
+        "color": "s",
+        "controlsConf": {
+          "template": "DR-HAP003S",
+          "lottie": {
+            "frames": [
+              {
+                "value": 0,
+                "frame": [
+                  0
+                ]
+              },
+              {
+                "value": 1,
+                "frame": [
+                  2
+                ]
+              },
+              {
+                "value": 2,
+                "frame": [
+                  4
+                ]
+              },
+              {
+                "value": 3,
+                "frame": [
+                  6
+                ]
+              },
+              {
+                "value": 4,
+                "frame": [
+                  8
+                ]
+              }
+            ],
+            "key": "aq"
+          },
+          "cards": [
+            {
+              "type": 1,
+              "title": "PM2.5",
+              "icon": "ic_air_quality",
+              "image": "",
+              "url": "",
+              "show": true
+            },
+            {
+              "type": 3,
+              "title": "",
+              "icon": "",
+              "image": "",
+              "url": "",
+              "show": true
+            },
+            {
+              "type": 6,
+              "title": "device_settings_title",
+              "icon": "ic_setting",
+              "image": "",
+              "url": "dreo://nav/device/setting?deviceSn=${sn}",
+              "show": true,
+              "key": "setting"
+            }
+          ],
+          "urlConfig": [
+            {
+              "key": "filter",
+              "url": "https://www.dreo.com/products/dreo-air-purifiers-replacement-filter-for-macro-max-s?utm_source=app&utm_medium=airFilterLife003&utm_campaign=airFilter003"
+            }
+          ],
+          "preference": [
+            {
+              "id": "200",
+              "type": "Light",
+              "title": "device_control_light",
+              "image": "ic_display",
+              "reverse": false,
+              "cmd": "lightmode"
+            },
+            {
+              "id": "210",
+              "type": "Panel Sound",
+              "title": "device_control_panelsound",
+              "image": "ic_mute",
+              "reverse": true,
+              "cmd": "muteon"
+            },
+            {
+              "id": "220",
+              "type": "Child Lock",
+              "title": "device_control_childlock",
+              "image": "ic_child_lock",
+              "reverse": false,
+              "cmd": "childlockon"
+            },
+            {
+              "id": "250",
+              "type": "Display Info",
+              "title": "device_control_displayinfo",
+              "image": "ic_display_info"
+            },
+            {
+              "id": "230",
+              "type": "Auto Mode Settings",
+              "title": "device_control_mode_auto_settings",
+              "image": "ic_mode_settings"
+            }
+          ],
+          "control": [
+            {
+              "id": "100",
+              "type": "Mode",
+              "title": "device_mode",
+              "items": [
+                {
+                  "text": "device_control_mode_auto",
+                  "textColors": [
+                    "#D5D6D7",
+                    "#333333"
+                  ],
+                  "image": "ic_auto_wind",
+                  "imageColors": [
+                    "#D5D6D7",
+                    "#0A80F5"
+                  ],
+                  "cmd": "mode",
+                  "value": "auto"
+                },
+                {
+                  "text": "device_control_mode_turbo",
+                  "textColors": [
+                    "#D5D6D7",
+                    "#333333"
+                  ],
+                  "image": "ic_turbo_wind",
+                  "imageColors": [
+                    "#D5D6D7",
+                    "#FFAD0A"
+                  ],
+                  "cmd": "mode",
+                  "value": "turbo"
+                },
+                {
+                  "text": "device_control_mode_sleep",
+                  "textColors": [
+                    "#D5D6D7",
+                    "#333333"
+                  ],
+                  "image": "ic_sleep_wind",
+                  "imageColors": [
+                    "#D5D6D7",
+                    "#6249DF"
+                  ],
+                  "cmd": "mode",
+                  "value": "sleep"
+                }
+              ]
+            },
+            {
+              "id": "110",
+              "type": "Manual",
+              "title": "device_control_mode_manual",
+              "cmd": "mode",
+              "value": "manual",
+              "items": [
+                {
+                  "text": "1",
+                  "cmd": "windlevel",
+                  "value": 1
+                },
+                {
+                  "text": "18",
+                  "cmd": "windlevel",
+                  "value": 18
+                }
+              ]
+            }
+          ],
+          "category": "Air Purifier",
+          "setting": [
+            {
+              "text": "Firmware Version",
+              "image": "image.png",
+              "value": "1.0.0",
+              "url": "dreo://control"
+            }
+          ]
+        },
+        "mainConf": {
+          "isSmart": true,
+          "isWifi": true,
+          "isBluetooth": true,
+          "isVoiceControl": true
+        },
+        "resourcesConf": {
+          "imageSmallSrc": "https://resources.dreo-tech.com/app/202212/21049d350c85b4bc6be1251a171761277.png",
+          "imageFullSrc": "https://resources.dreo-tech.com/app/202307/31879efec9eabb47458072a8e3cea2937a.zip",
+          "imageSmallDarkSrc": "",
+          "imageFullDarkSrc": ""
+        },
+        "servicesConf": [
+          {
+            "key": "user_manual",
+            "value": "https://resources.dreo-tech.com/app/202208/1a2e3cd57ab1c45329fc827dabb2f8b48.pdf"
+          }
+        ],
+        "userManuals": [
+          {
+            "url": "https://resources.dreo-tech.com/app/202208/1a2e3cd57ab1c45329fc827dabb2f8b48.pdf",
+            "icon": null,
+            "desc": "DR-HAP003S User Manual",
+            "lang": "en"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/pydreo/api_responses/get_devices_HAP003S_3.json
+++ b/tests/pydreo/api_responses/get_devices_HAP003S_3.json
@@ -8,7 +8,7 @@
     "totalPage": 1,
     "list": [
       {
-        "deviceId": "1821290685702082562",
+        "deviceId": "1821290685702082563",
         "sn": "HAP003S_3",
         "brand": "Dreo",
         "model": "DR-HAP003S",

--- a/tests/pydreo/test_pydreoairpurifier.py
+++ b/tests/pydreo/test_pydreoairpurifier.py
@@ -89,6 +89,45 @@ class TestPyDreoAirPurifier(TestBase):
         air_purifier.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: "auto-silent"}})
         assert air_purifier.preset_mode == "auto"
 
+    def test_HAP003S_3(self):  # pylint: disable=invalid-name
+        """Test DR-HAP003S Air Purifier (Macro Max S/AS) — newer "001" MCU revision.
+
+        This hardware revision (firmware v1.0.51) also rejects the plain "auto" mode command.
+        The device requires "auto-silent" to be sent.  The _auto_mode_uses_auto_silent flag
+        must be set by the MCU override, and preset_mode="auto" must translate to command
+        value "auto-silent". State updates reporting "auto-silent" must still resolve to
+        preset_mode "auto".
+        """
+
+        self.get_devices_file_name = "get_devices_HAP003S_3.json"
+        self.pydreo_manager.load_devices()
+        assert len(self.pydreo_manager.devices) == 1
+        air_purifier = self.pydreo_manager.devices[0]
+        assert air_purifier.model == "DR-HAP003S"
+        assert air_purifier.series_name == "Macro Max S/AS"
+        assert air_purifier.speed_range == (1, 18)
+        assert air_purifier.preset_modes == ["auto", "manual", "sleep", "turbo"]
+        # Newer "001" MCU revision must have the auto-silent remap flag set
+        assert air_purifier._auto_mode_uses_auto_silent is True  # pylint: disable=protected-access
+
+        # Setting auto on the new revision must send "auto-silent"
+        with patch(PATCH_SEND_COMMAND):
+            air_purifier.preset_mode = "sleep"  # move away from current mode first
+        air_purifier.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: "sleep"}})
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            air_purifier.preset_mode = "auto"
+            mock_send_command.assert_called_once_with(air_purifier, {WIND_MODE_KEY: "auto-silent"})
+
+        # Other modes must remain unchanged
+        air_purifier.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: "auto-silent"}})
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            air_purifier.preset_mode = "sleep"
+            mock_send_command.assert_called_once_with(air_purifier, {WIND_MODE_KEY: "sleep"})
+
+        # State updates with "auto-silent" must resolve to preset_mode "auto"
+        air_purifier.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: "auto-silent"}})
+        assert air_purifier.preset_mode == "auto"
+
     def test_HAP005S(self):  # pylint: disable=invalid-name
         """Test DR-HAP005S Air Purifier (Macro AP505S)."""
 


### PR DESCRIPTION
### Problem / Issue
Following the merge of #818 (adding support for the newer DR-HAP003S revision with `"midea"` MCU), we observed that some physical devices running the latest firmware (e.g., `v1.0.51`) still experience Auto mode transitions reverting to previous states (e.g. manual/sleep).

### Root Cause
When inspecting the raw diagnostics JSON from our live hardware running `v1.0.51` firmware, we discovered that it reports:
- `mcu_hardware_model`: `"001"` (instead of `"midea"`)
- `mcu_firmware_version`: `"1.0.51"` (instead of `"0.2.9"`)

Because of this, the existing `_hap003s_mcu_override` did not detect the newer revision (`mcu_model == "midea"` evaluated as `False`), disabling the `auto-silent` command translation for our units and causing the device to reject the blanket `"auto"` mode packet and revert.

### Solution & Implementation
This PR expands the `_MCU_HAP003S_AUTO_SILENT_REV` constant in `custom_components/dreo/pydreo/models.py` to be a tuple `("midea", "001")` and updates `_hap003s_mcu_override` to match using `in`. This dynamically registers and enables the `auto-silent` command translation for both the `"midea"` revision (test variant) and the latest `"001"` revision (production firmware variant).

### Validation & Testing
- **Static Analysis Compliance:** Ran `pytest tests/pydreo/test_no_hardcoded_models.py` locally and verified it passes cleanly (no hardcoded model strings outside `models.py`).
- **Live Verification:** Successfully deployed this update to our live server and verified that:
  1. Transitioning to Sleep mode (`preset_mode: sleep`, percentage 5%) works perfectly.
  2. Transitioning back to Auto mode (`preset_mode: auto`) correctly translates `"auto"` to `"auto-silent"`, is accepted by the physical device instantly, and holds state natively without any reverting!

No other integrations or files are affected.