### PR TITLE
Fix swapped auto/natural preset modes for DR-HPF015S

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -306,7 +306,7 @@ SUPPORTED_DEVICES = {
     ),
     "DR-HPF015S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,
-        preset_modes=[("normal", 1), ("auto", 2), ("sleep", 3), ("natural", 4), ("turbo", 5), ("custom", 6)],
+        preset_modes=[("normal", 1), ("natural", 2), ("sleep", 3), ("auto", 4), ("turbo", 5), ("custom", 6)],
         device_ranges={SPEED_RANGE: (1, 12), HORIZONTAL_ANGLE_RANGE: (-75, 75)},
     ),
     "DR-HPF017S": DreoDeviceDetails(

--- a/tests/dreo/integrationtests/test_dreoaircirculator.py
+++ b/tests/dreo/integrationtests/test_dreoaircirculator.py
@@ -393,8 +393,8 @@ class TestDreoAirCirculator(IntegrationTestBase):
             assert pydreo_fan.horizontal_angle_range == (-75, 75)
             assert ha_fan.speed_count == 12
             assert ha_fan.percentage == 50
-            assert ha_fan.preset_modes == ["normal", "auto", "sleep", "natural", "turbo", "custom"]
-            assert ha_fan.preset_mode == "natural"
+            assert ha_fan.preset_modes == ["normal", "natural", "sleep", "auto", "turbo", "custom"]
+            assert ha_fan.preset_mode == "auto"
 
             with patch(PATCH_SEND_COMMAND) as mock_send_command:
                 ha_fan.turn_on()

--- a/tests/pydreo/test_pydreoaircirculator.py
+++ b/tests/pydreo/test_pydreoaircirculator.py
@@ -761,8 +761,8 @@ class TestPyDreoAirCirculator(TestBase):
         assert fan.model == "DR-HPF015S"
         assert fan.speed_range == (1, 12)
         assert fan.horizontal_angle_range == (-75, 75)
-        assert fan.preset_modes == ["normal", "auto", "sleep", "natural", "turbo", "custom"]
-        assert fan.preset_mode == "natural"
+        assert fan.preset_modes == ["normal", "natural", "sleep", "auto", "turbo", "custom"]
+        assert fan.preset_mode == "auto"
         assert fan.fan_speed == 6
         assert fan.is_on is False
         assert fan.oscillating is True


### PR DESCRIPTION
Same issue as #786 (DR-HPF007S), now observed on a DR-HPF015S: the static `preset_modes` table in `pydreo/models.py` maps `auto` to mode 2 and `natural` to mode 4, but the device firmware uses `natural` = 2 and `auto` = 4 (matching the sibling models DR-HPF004S/005S/022S and the now-fixed DR-HPF007S).

As a result, selecting **Natural** in Home Assistant puts the fan in Auto mode and vice versa.

Verified on a real DR-HPF015S: after swapping the two values, the preset selected in HA matches the mode shown on the device/Dreo app.

Note: DR-HPF017S has the same `("auto", 2), ("natural", 4)` mapping and may be affected too, but I don't own that model so I left it untouched.