### PR TITLE
DR-HPF015S: conservative (0, 90) vertical default, widened to (-30, 90) for SC95F8613B/GL revisions via override_fn

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -164,6 +164,7 @@ SUPPORTED_MODEL_PREFIXES = {"DR-HTF", "DR-HAF", "DR-HAP", "DR-HPF", "DR-HCF", "W
 _MCU_HAF004S_OLD_REV = "SC95F8613B"
 _MCU_HTF007S_OLD_REV = ("CMS89F7518", "CMS89F7518/EUR", "CMS89F7518/USA")
 _MCU_HAP003S_AUTO_SILENT_REV = ("midea", "001")
+_MCU_HPF015S_NEG_TILT_REVS = ("SC95F8613B/GL",)
 
 
 def _haf004s_mcu_override(device) -> None:
@@ -212,6 +213,23 @@ def _hap003s_mcu_override(device) -> None:
     mcu_model = mcu_obj.get("state", "") if isinstance(mcu_obj, dict) else ""
     if mcu_model in _MCU_HAP003S_AUTO_SILENT_REV:
         device._auto_mode_uses_auto_silent = True  # pylint: disable=protected-access
+
+
+def _hpf015s_mcu_override(device) -> None:
+    """Widen vertical angle range to (-30, 90) for DR-HPF015S units with the SC95F8613B/GL MCU.
+
+    Newer Matter-capable hardware revisions using this chip can physically tilt below
+    horizontal (owner-verified), matching the DR-HPF017S sibling.  Other revisions keep
+    the conservative (0, 90) default from the device definition, since chips in the
+    SC95F8613B family have variants that cannot reach negative vertical angles.
+    """
+    if device.raw_state is None:
+        return
+    mixed = device.raw_state.get("data", {}).get("mixed", {})
+    mcu_obj = mixed.get("mcu_hardware_model", {})
+    mcu_model = mcu_obj.get("state", "") if isinstance(mcu_obj, dict) else ""
+    if mcu_model in _MCU_HPF015S_NEG_TILT_REVS:
+        device._vertical_angle_range = (-30, 90)  # pylint: disable=protected-access
 
 
 SUPPORTED_DEVICES = {
@@ -332,7 +350,10 @@ SUPPORTED_DEVICES = {
     "DR-HPF015S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,
         preset_modes=[("normal", 1), ("natural", 2), ("sleep", 3), ("auto", 4), ("turbo", 5), ("custom", 6)],
-        device_ranges={SPEED_RANGE: (1, 12), HORIZONTAL_ANGLE_RANGE: (-75, 75)},
+        # Conservative default: vertical range (0, 90).
+        # Newer revision (_MCU_HPF015S_NEG_TILT_REVS MCU): widened to (-30, 90) by _hpf015s_mcu_override.
+        device_ranges={SPEED_RANGE: (1, 12), HORIZONTAL_ANGLE_RANGE: (-75, 75), VERTICAL_ANGLE_RANGE: (0, 90)},
+        override_fn=_hpf015s_mcu_override,
     ),
     "DR-HPF017S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,

--- a/tests/dreo/integrationtests/test_dreoaircirculator.py
+++ b/tests/dreo/integrationtests/test_dreoaircirculator.py
@@ -447,6 +447,36 @@ class TestDreoAirCirculator(IntegrationTestBase):
                 mock_send_command.assert_called_once_with(pydreo_fan, {WIND_MODE_KEY: 5})
             pydreo_fan.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: 5}})
 
+    def test_HPF015S_old_rev(self):  # pylint: disable=invalid-name
+        """Test HPF015S hardware revision with the bare SC95F8613B MCU.
+
+        The override_fn should not fire; the vertical angle range stays at the
+        conservative (0, 90) default from the device definition.
+        """
+        with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):
+            self.get_devices_file_name = "get_devices_HPF015S_2REVS.json"
+            self.pydreo_manager.load_devices()
+            assert len(self.pydreo_manager.devices) == 2
+
+            pydreo_fan = self.pydreo_manager.devices[0]
+            assert pydreo_fan.model == "DR-HPF015S"
+            assert pydreo_fan.vertical_angle_range == (0, 90)
+
+    def test_HPF015S_new_rev(self):  # pylint: disable=invalid-name
+        """Test HPF015S new hardware revision (SC95F8613B/GL MCU, Matter-capable).
+
+        The override_fn should widen the vertical angle range to (-30, 90) since this
+        revision can physically tilt below horizontal, like the DR-HPF017S sibling.
+        """
+        with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):
+            self.get_devices_file_name = "get_devices_HPF015S_2REVS.json"
+            self.pydreo_manager.load_devices()
+            assert len(self.pydreo_manager.devices) == 2
+
+            pydreo_fan = self.pydreo_manager.devices[1]
+            assert pydreo_fan.model == "DR-HPF015S"
+            assert pydreo_fan.vertical_angle_range == (-30, 90)
+
     def test_HPF017S(self):  # pylint: disable=invalid-name
         """Test HPF017S fan uses fanon for on/off commands."""
         with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):

--- a/tests/pydreo/api_responses/get_device_state_HPF015S_2REVS_NEW_REV.json
+++ b/tests/pydreo/api_responses/get_device_state_HPF015S_2REVS_NEW_REV.json
@@ -1,0 +1,63 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "mixed": {
+      "wifi_rssi": {
+        "state": -31,
+        "timestamp": 1779482566
+      },
+      "poweron": {
+        "state": false,
+        "timestamp": 1779483926
+      },
+      "mode": {
+        "state": 4,
+        "timestamp": 1779482877
+      },
+      "mcuon": {
+        "state": true,
+        "timestamp": 1779482566
+      },
+      "oscmode": {
+        "state": 1,
+        "timestamp": 1779482796
+      },
+      "temperature": {
+        "state": 79,
+        "timestamp": 1779483985
+      },
+      "lighton": {
+        "state": false,
+        "timestamp": 1779482566
+      },
+      "muteon": {
+        "state": false,
+        "timestamp": 1779483512
+      },
+      "windlevel": {
+        "state": 6,
+        "timestamp": 1779482874
+      },
+      "connected": {
+        "state": true,
+        "timestamp": 1779482566
+      },
+      "childlockon": {
+        "state": false,
+        "timestamp": 1779482566
+      },
+      "mcu_hardware_model": {
+        "state": "SC95F8613B/GL",
+        "timestamp": 1779482566
+      },
+      "matter_state": {
+        "state": 4,
+        "timestamp": 1779482566
+      }
+    },
+    "sn": "HPF015S_2REVS_NEW_REV",
+    "productId": "1952968879364452354",
+    "region": "us-east-2/emq"
+  }
+}

--- a/tests/pydreo/api_responses/get_device_state_HPF015S_2REVS_OLD_REV.json
+++ b/tests/pydreo/api_responses/get_device_state_HPF015S_2REVS_OLD_REV.json
@@ -1,0 +1,59 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "mixed": {
+      "wifi_rssi": {
+        "state": -31,
+        "timestamp": 1779482566
+      },
+      "poweron": {
+        "state": false,
+        "timestamp": 1779483926
+      },
+      "mode": {
+        "state": 4,
+        "timestamp": 1779482877
+      },
+      "mcuon": {
+        "state": true,
+        "timestamp": 1779482566
+      },
+      "oscmode": {
+        "state": 1,
+        "timestamp": 1779482796
+      },
+      "temperature": {
+        "state": 79,
+        "timestamp": 1779483985
+      },
+      "lighton": {
+        "state": false,
+        "timestamp": 1779482566
+      },
+      "muteon": {
+        "state": false,
+        "timestamp": 1779483512
+      },
+      "windlevel": {
+        "state": 6,
+        "timestamp": 1779482874
+      },
+      "connected": {
+        "state": true,
+        "timestamp": 1779482566
+      },
+      "childlockon": {
+        "state": false,
+        "timestamp": 1779482566
+      },
+      "mcu_hardware_model": {
+        "state": "SC95F8613B",
+        "timestamp": 1779482566
+      }
+    },
+    "sn": "HPF015S_2REVS_OLD_REV",
+    "productId": "1952968879364452354",
+    "region": "us-east-2/emq"
+  }
+}

--- a/tests/pydreo/api_responses/get_devices_HPF015S_2REVS.json
+++ b/tests/pydreo/api_responses/get_devices_HPF015S_2REVS.json
@@ -1,0 +1,89 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "currentPage": 1,
+    "pageSize": 100,
+    "totalNum": 2,
+    "totalPage": 1,
+    "familyRooms": null,
+    "list": [
+      {
+        "deviceId": "2057925139352317955",
+        "sn": "HPF015S_2REVS_OLD_REV",
+        "brand": "Dreo",
+        "model": "DR-HPF015S",
+        "productId": "1952968879364452354",
+        "productName": "Air Circulator",
+        "deviceName": "DEBUGTEST - Air Circulator - DR-HPF015S - Old Rev",
+        "shared": false,
+        "series": null,
+        "seriesName": "765S",
+        "type": 0,
+        "owner": true,
+        "familyId": null,
+        "familyName": null,
+        "roomId": null,
+        "roomName": null,
+        "roomNameI18Key": "",
+        "color": "b",
+        "widgetOnImage": "https://resources.dreo-tech.com/app/preSigned202603/3189242ccce00340a2986590a9c28a69f6.png",
+        "widgetOffImage": "https://resources.dreo-tech.com/app/preSigned202603/3178caca13255a42309c528ff327393228.png",
+        "widgetAbnormalImage": null,
+        "variantIconMd5": null,
+        "controlsConf": {},
+        "mainConf": {
+          "isSmart": true,
+          "isWifi": true,
+          "isBluetooth": null,
+          "isVoiceControl": true
+        },
+        "resourcesConf": {
+          "imageSmallSrc": "https://resources.dreo-tech.com/app/preSigned202603/31aa02272755304919a8b3fdfa28f89baa.png",
+          "imageFullSrc": "https://resources.dreo-tech.com/app/preSigned202603/3147e15ff82daa4ca5b1cb93e4e7849832.lottie.zip",
+          "imageSmallDarkSrc": null,
+          "imageFullDarkSrc": null
+        },
+        "servicesConf": []
+      },
+      {
+        "deviceId": "2057925139352317956",
+        "sn": "HPF015S_2REVS_NEW_REV",
+        "brand": "Dreo",
+        "model": "DR-HPF015S",
+        "productId": "1952968879364452354",
+        "productName": "Air Circulator",
+        "deviceName": "DEBUGTEST - Air Circulator - DR-HPF015S - New Rev",
+        "shared": false,
+        "series": null,
+        "seriesName": "765S",
+        "type": 0,
+        "owner": true,
+        "familyId": null,
+        "familyName": null,
+        "roomId": null,
+        "roomName": null,
+        "roomNameI18Key": "",
+        "color": "b",
+        "widgetOnImage": "https://resources.dreo-tech.com/app/preSigned202603/3189242ccce00340a2986590a9c28a69f6.png",
+        "widgetOffImage": "https://resources.dreo-tech.com/app/preSigned202603/3178caca13255a42309c528ff327393228.png",
+        "widgetAbnormalImage": null,
+        "variantIconMd5": null,
+        "controlsConf": {},
+        "mainConf": {
+          "isSmart": true,
+          "isWifi": true,
+          "isBluetooth": null,
+          "isVoiceControl": true
+        },
+        "resourcesConf": {
+          "imageSmallSrc": "https://resources.dreo-tech.com/app/preSigned202603/31aa02272755304919a8b3fdfa28f89baa.png",
+          "imageFullSrc": "https://resources.dreo-tech.com/app/preSigned202603/3147e15ff82daa4ca5b1cb93e4e7849832.lottie.zip",
+          "imageSmallDarkSrc": null,
+          "imageFullDarkSrc": null
+        },
+        "servicesConf": []
+      }
+    ]
+  }
+}

--- a/tests/pydreo/test_pydreoaircirculator.py
+++ b/tests/pydreo/test_pydreoaircirculator.py
@@ -778,6 +778,7 @@ class TestPyDreoAirCirculator(TestBase):
         assert fan.model == "DR-HPF015S"
         assert fan.speed_range == (1, 12)
         assert fan.horizontal_angle_range == (-75, 75)
+        assert fan.vertical_angle_range == (0, 90)
         assert fan.preset_modes == ["normal", "natural", "sleep", "auto", "turbo", "custom"]
         assert fan.preset_mode == "auto"
         assert fan.fan_speed == 6


### PR DESCRIPTION
Reworked per maintainer feedback: **conservative approach**.

The device definition for DR-HPF015S now declares an explicit conservative default of `VERTICAL_ANGLE_RANGE: (0, 90)`, and a new `override_fn` (`_hpf015s_mcu_override`, mirroring the existing `_haf004s_mcu_override` pattern) widens it to **(-30, 90)** only when `mcu_hardware_model` is `SC95F8613B/GL` — the newer Matter-capable revision where physical tilt below horizontal is owner-verified (see thread; full diagnostics attached above).

Any other revision of this model keeps the safe 0..90 range, given the `SC95F8613B`-family history on DR-HAF004S.

**Tests**
- New 2-revision fixture `get_devices_HPF015S_2REVS.json` (+ state files): bare `SC95F8613B` stays at `(0, 90)`, `SC95F8613B/GL` widens to `(-30, 90)` — mirroring the HAF004S 2REVS tests.
- Added `vertical_angle_range == (0, 90)` assertion to the existing HPF015S test (no `mcu_hardware_model` in that fixture → conservative default).

Full suite passes: 858 tests, ruff clean. Branch rebased on current `main`.