### PR TITLE
Update vertical angle range in models.py for model DR-HPF015S

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -332,7 +332,7 @@ SUPPORTED_DEVICES = {
     "DR-HPF015S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,
         preset_modes=[("normal", 1), ("natural", 2), ("sleep", 3), ("auto", 4), ("turbo", 5), ("custom", 6)],
-        device_ranges={SPEED_RANGE: (1, 12), HORIZONTAL_ANGLE_RANGE: (-75, 75)}, VERTICAL_ANGLE_RANGE: (-10, 90)},
+        device_ranges={SPEED_RANGE: (1, 12), HORIZONTAL_ANGLE_RANGE: (-75, 75), VERTICAL_ANGLE_RANGE: (-10, 90)},
     ),
     "DR-HPF017S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -332,7 +332,7 @@ SUPPORTED_DEVICES = {
     "DR-HPF015S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,
         preset_modes=[("normal", 1), ("natural", 2), ("sleep", 3), ("auto", 4), ("turbo", 5), ("custom", 6)],
-        device_ranges={SPEED_RANGE: (1, 12), HORIZONTAL_ANGLE_RANGE: (-75, 75)},
+        device_ranges={SPEED_RANGE: (1, 12), HORIZONTAL_ANGLE_RANGE: (-75, 75)}, VERTICAL_ANGLE_RANGE: (-10, 90)},
     ),
     "DR-HPF017S": DreoDeviceDetails(
         device_type=DreoDeviceType.AIR_CIRCULATOR,


### PR DESCRIPTION
Hello! Thank you for creating this integration.

### Issue:
1. HA exposes (0, 90) as min/max vertical angle range for the DR-HPF015S model.
2. Actual vertical angle range of model DR-HPF015S is (-10, 90).
3. Targeting range outside of range in HA results in:
`ERROR (MainThread) [homeassistant.components.websocket_api.http.connection] Value -10.0 for number.living_room_fan_vertical_angle is outside valid range 0 - 90`
4. Can set -10 vertical angle in Dreo official app, which reflects in HA as state -10 but only when changed via Dreo app.

### Proposed:
- Adding missing key and value for vertical angle range to DR-HPF015S in models.py
- Previously falling back (0, 90) due to missing key and value
- Found that this fix relates to issue #803 (same model as mine)

### Tested in:
> Installation method Home Assistant OS
> Core 2026.7.2
> Supervisor 2026.07.3
> Operating System 18.1
> Frontend 20260624.5

Please let me know if you need any further details, logs, etc. And thank you for your time! :)