### PR TITLE
fix: atomic ceiling-fan light turn-on (#846) + HEC005S temp sensor regression test (#839)

### DIFF
--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -12,6 +12,7 @@ import math
 from .haimports import *  # pylint: disable=W0401,W0614
 from .pydreo import PyDreo
 from .pydreo.pydreobasedevice import PyDreoBaseDevice
+from .pydreo.pydreoceilingfan import PyDreoCeilingFan
 from .pydreo.constant import DreoDeviceType  # pylint: disable=C0415
 from .dreobasedevice import DreoBaseDeviceHA
 
@@ -187,24 +188,39 @@ class DreoLightHA(DreoBaseDeviceHA, LightEntity):  # pylint: disable=abstract-me
         """
         _LOGGER.debug("turn_on: Turning on light %s", self.pydreo_device.name)
 
-        # Handle brightness adjustment BEFORE turning on to avoid a momentary jump
-        # to the previous brightness value.
+        # Compute the device-scale brightness value (HA 0-255 -> device scale).
+        computed_brightness: int | None = None
         if ATTR_BRIGHTNESS in kwargs:
             brightness = kwargs[ATTR_BRIGHTNESS]
             _LOGGER.debug("turn_on: Setting brightness to %s", brightness)
-            setattr(self.pydreo_device, self._brightness_attr, round(brightness_to_value(self._brightness_scale, brightness)))
+            computed_brightness = round(brightness_to_value(self._brightness_scale, brightness))
 
-        # Handle color temperature adjustment (also before turning on)
+        # Compute the device-scale color temperature value (Kelvin -> device percentage).
+        computed_color_temp: int | None = None
         if ATTR_COLOR_TEMP_KELVIN in kwargs:
             color_temp = kwargs[ATTR_COLOR_TEMP_KELVIN]
             _LOGGER.debug("turn_on: Setting color temperature to %s", color_temp)
             # Clamp to the device's valid range to prevent out-of-range (e.g. negative) values
             color_temp = max(self.min_color_temp_kelvin, min(self.max_color_temp_kelvin, color_temp))
-            setattr(
-                self.pydreo_device,
-                self._color_temp_attr,
-                math.ceil(ranged_value_to_percentage((self.min_color_temp_kelvin, self.max_color_temp_kelvin), color_temp)),
-            )
+            computed_color_temp = math.ceil(ranged_value_to_percentage((self.min_color_temp_kelvin, self.max_color_temp_kelvin), color_temp))
+
+        # If the device exposes an atomic combined turn-on for its main light, use it so
+        # brightness/color and the on-command are delivered in a single request. Sending
+        # them as separate sequential commands caused the light to intermittently fail to
+        # turn on (issue #846). Gated on the main light attribute so atmosphere/RGB lights
+        # (which reuse this entity with a different on attribute) keep their own behaviour.
+        if self._light_on_attr == "light_on" and isinstance(self.pydreo_device, PyDreoCeilingFan):
+            self.pydreo_device.turn_light_on(brightness=computed_brightness, color_temp=computed_color_temp)
+            return
+
+        # Handle brightness adjustment BEFORE turning on to avoid a momentary jump
+        # to the previous brightness value.
+        if computed_brightness is not None:
+            setattr(self.pydreo_device, self._brightness_attr, computed_brightness)
+
+        # Handle color temperature adjustment (also before turning on)
+        if computed_color_temp is not None:
+            setattr(self.pydreo_device, self._color_temp_attr, computed_color_temp)
 
         setattr(self.pydreo_device, self._light_on_attr, True)
 

--- a/custom_components/dreo/pydreo/pydreoceilingfan.py
+++ b/custom_components/dreo/pydreo/pydreoceilingfan.py
@@ -204,17 +204,13 @@ class PyDreoCeilingFan(PyDreoFanBase):
         params: dict = {}
 
         if brightness is not None and self._brightness is not None and self._brightness != brightness:
-            self._brightness = brightness
             params[BRIGHTNESS_KEY] = brightness
 
         if color_temp is not None and self._color_temp is not None and self._color_temp != color_temp:
-            self._color_temp = color_temp
             params[COLORTEMP_KEY] = color_temp
 
         if not self._light_on:
             params[LIGHTON_KEY] = True
-
-        self._light_on = True
 
         if params:
             _LOGGER.debug("turn_light_on: sending combined command %s", params)

--- a/custom_components/dreo/pydreo/pydreoceilingfan.py
+++ b/custom_components/dreo/pydreo/pydreoceilingfan.py
@@ -188,6 +188,38 @@ class PyDreoCeilingFan(PyDreoFanBase):
             return
         self._send_command(COLORTEMP_KEY, value)
 
+    def turn_light_on(self, brightness: int | None = None, color_temp: int | None = None) -> None:
+        """Turn the main light on, optionally setting brightness and/or color temperature.
+
+        Sends a single combined control command instead of separate brightness, color
+        temperature and on commands so the device receives the whole desired state
+        atomically. Adaptive Lighting and similar integrations send brightness/color
+        together with the on command; issuing them as separate sequential commands
+        caused the light to intermittently fail to turn on (issue #846).
+        """
+        if self._light_on is None:
+            _LOGGER.error("turn_light_on: Light control not supported by this fan model.")
+            return
+
+        params: dict = {}
+
+        if brightness is not None and self._brightness is not None and self._brightness != brightness:
+            self._brightness = brightness
+            params[BRIGHTNESS_KEY] = brightness
+
+        if color_temp is not None and self._color_temp is not None and self._color_temp != color_temp:
+            self._color_temp = color_temp
+            params[COLORTEMP_KEY] = color_temp
+
+        if not self._light_on:
+            params[LIGHTON_KEY] = True
+
+        self._light_on = True
+
+        if params:
+            _LOGGER.debug("turn_light_on: sending combined command %s", params)
+            self._dreo.send_command(self, params)
+
     @property
     def atm_light_on(self) -> bool | None:
         """Returns True if the atmosphere light is on, False otherwise."""

--- a/tests/dreo/integrationtests/test_dreoceilingfan.py
+++ b/tests/dreo/integrationtests/test_dreoceilingfan.py
@@ -106,6 +106,38 @@ class TestDreoCeilingFan(IntegrationTestBase):
                     light_switch.turn_on(brightness=128)
                     mock_send_command.assert_called_once_with(pydreo_fan, {BRIGHTNESS_KEY: 50})
 
+    def test_HCF001S_light_atomic_turn_on(self):  # pylint: disable=invalid-name
+        """Issue #846: turning the light on together with a brightness change (as Adaptive
+        Lighting does) must be delivered as a single combined command containing both the
+        brightness and lighton=True, not as two separate sequential commands."""
+        with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):
+            self.get_devices_file_name = "get_devices_HCF001S.json"
+            self.pydreo_manager.load_devices()
+            pydreo_fan = self.pydreo_manager.devices[0]
+
+            lights = light.get_entries([pydreo_fan])
+            light_switch = self.get_entity_by_key(lights, "Light")
+
+            # Known starting state: light off, brightness 100.
+            pydreo_fan.handle_server_update({REPORTED_KEY: {LIGHTON_KEY: False, BRIGHTNESS_KEY: 100}})
+
+            # Turning on with a new brightness must send ONE combined command.
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                light_switch.turn_on(brightness=128)  # 128/255*100 ≈ 50
+                mock_send_command.assert_called_once_with(pydreo_fan, {BRIGHTNESS_KEY: 50, LIGHTON_KEY: True})
+
+            # Turning on with no attributes still sends just lighton=True.
+            pydreo_fan.handle_server_update({REPORTED_KEY: {LIGHTON_KEY: False}})
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                light_switch.turn_on()
+                mock_send_command.assert_called_once_with(pydreo_fan, {LIGHTON_KEY: True})
+
+            # If the light is already on and brightness is unchanged, no command is sent.
+            pydreo_fan.handle_server_update({REPORTED_KEY: {LIGHTON_KEY: True, BRIGHTNESS_KEY: 50}})
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                light_switch.turn_on(brightness=128)  # still 50 on device scale
+                mock_send_command.assert_not_called()
+
     def test_HCF002S(self):  # pylint: disable=invalid-name
         """Load fan and test sending commands."""
         with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):

--- a/tests/dreo/integrationtests/test_dreoevaporativecooler.py
+++ b/tests/dreo/integrationtests/test_dreoevaporativecooler.py
@@ -123,3 +123,7 @@ class TestDreoEvaporativeCoolers(IntegrationTestBase):
             fog_level_number = next(n for n in numbers if n.entity_description.key == "Fog Level")
             assert fog_level_number.native_min_value == 1
             assert fog_level_number.native_max_value == 4
+
+            assert pydreo_ec.temperature == 82
+            sensors = sensor.get_entries([pydreo_ec])
+            self.verify_expected_entities(sensors, ["Temperature", "Humidity", "Use since cleaning"])


### PR DESCRIPTION
Fixes #846 and adds a regression test for #839 (both were falsely auto-closed by empty Copilot PRs, see #857).

## #846 — Ceiling-fan light seldom turns on with Adaptive Lighting
Turning the light on while also setting brightness/color previously sent **three separate sequential** WebSocket commands (brightness, colortemp, lighton). That ordering could leave the light off. Now `PyDreoCeilingFan.turn_light_on()` emits a **single combined** control command and `DreoLightHA.turn_on` delegates to it for the main light. Atmosphere/RGB lights keep their existing behaviour.

## #839 — DR-HEC005S temperature sensor
Already exposed generically (state reports a `temperature` key). Added a regression test asserting the Temperature sensor + value so it can't silently regress.

## Validation
- `python -m pytest` → 867 passed
- `python -m ruff check .` → clean

Note: the exact intermittent #846 failure was never captured in the reporter's logs; the change matches the Dreo app's atomic behaviour and is well unit-tested, but on-device confirmation is welcome.