### PR TITLE
Fix DR-HAP009S auto mode (send auto-regular)

### DIFF
--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -215,6 +215,16 @@ def _hap003s_mcu_override(device) -> None:
         device._auto_mode_uses_auto_silent = True  # pylint: disable=protected-access
 
 
+def _hap009s_override(device) -> None:
+    """Remap the "auto" mode command to "auto-regular" for DR-HAP009S air purifiers.
+
+    The DR-HAP009S rejects the plain "auto" mode command ("instruction validate failed",
+    error 500003) and requires "auto-regular" instead (issue #860).  The device reports
+    "auto-regular" back as its state, which PyDreoFanBase.preset_mode normalizes to "auto".
+    """
+    device._auto_mode_command_value = "auto-regular"  # pylint: disable=protected-access
+
+
 def _hpf015s_mcu_override(device) -> None:
     """Widen vertical angle range to (-10, 90) for DR-HPF015S units with the SC95F8613B/GL MCU.
 
@@ -428,6 +438,8 @@ SUPPORTED_DEVICES = {
         device_type=DreoDeviceType.AIR_PURIFIER,
         preset_modes=[("auto", "auto"), ("manual", "manual"), ("sleep", "sleep"), ("turbo", "turbo")],
         device_ranges={SPEED_RANGE: (1, 4)},
+        # The device rejects the plain "auto" mode command and requires "auto-regular" (issue #860).
+        override_fn=_hap009s_override,
     ),
     # Heaters
     "DR-HSH017BS": DreoHeaterDeviceDetails(

--- a/custom_components/dreo/pydreo/pydreoairpurifier.py
+++ b/custom_components/dreo/pydreo/pydreoairpurifier.py
@@ -23,6 +23,10 @@ class PyDreoAirPurifier(PyDreoFanBase):
         # detected.  When True, _send_command remaps the "auto" mode value to "auto-silent"
         # before transmission because that hardware revision rejects the plain "auto" string.
         self._auto_mode_uses_auto_silent: bool = False
+        # Alternate command string to send in place of the plain "auto" mode value for models that
+        # reject "auto" (e.g. DR-HAP009S requires "auto-regular").  None means send "auto" unchanged.
+        # Takes effect only when _auto_mode_uses_auto_silent is not set.
+        self._auto_mode_command_value: str | None = None
 
     def parse_speed_range_from_control_node(self, control_node) -> tuple[int, int]:
         """Parse the speed range from a control node"""
@@ -77,16 +81,21 @@ class PyDreoAirPurifier(PyDreoFanBase):
         super().handle_server_update(message)
 
     def _send_command(self, command_key: str, value) -> None:
-        """Override to remap the 'auto' mode to 'auto-silent' on newer DR-HAP003S hardware.
+        """Override to remap the 'auto' mode command for models that reject the plain "auto" string.
 
-        Newer revisions of the DR-HAP003S (identified by the "midea" or "001" MCU models) reject the
-        plain "auto" mode command string.  When _auto_mode_uses_auto_silent is set by the
-        override function, outgoing "auto" mode commands are translated to "auto-silent"
-        before transmission. The device reports back "auto-silent" as its state; PyDreoFanBase.preset_mode
-        normalizes mode variants by stripping any "-<suffix>" (so "auto-silent" resolves to "auto").
-        This keeps the Home Assistant-facing preset name stable across hardware/firmware variants.
+        Some hardware/firmware revisions reject the plain "auto" mode command and require a
+        variant instead.  Newer DR-HAP003S units ("midea"/"001" MCU) require "auto-silent"
+        (_auto_mode_uses_auto_silent); DR-HAP009S requires "auto-regular"
+        (_auto_mode_command_value).  The device reports the variant back as its state;
+        PyDreoFanBase.preset_mode normalizes mode variants by stripping any "-<suffix>" (so
+        "auto-silent"/"auto-regular" resolve to "auto").  This keeps the Home Assistant-facing
+        preset name stable across hardware/firmware variants.
         """
-        if self._auto_mode_uses_auto_silent and command_key == "mode" and value == "auto":
-            _LOGGER.debug("PyDreoAirPurifier._send_command: remapping 'auto' to 'auto-silent' for %s", self.model)
-            value = "auto-silent"
+        if command_key == "mode" and value == "auto":
+            if self._auto_mode_uses_auto_silent:
+                value = "auto-silent"
+            elif self._auto_mode_command_value is not None:
+                value = self._auto_mode_command_value
+            if value != "auto":
+                _LOGGER.debug("PyDreoAirPurifier._send_command: remapping 'auto' to '%s' for %s", value, self.model)
         super()._send_command(command_key, value)

--- a/tests/dreo/integrationtests/test_dreoairpurifier.py
+++ b/tests/dreo/integrationtests/test_dreoairpurifier.py
@@ -293,3 +293,13 @@ class TestDreoAirPurifier(IntegrationTestBase):
             with patch(PATCH_SEND_COMMAND) as mock_send_command:
                 ha_fan.set_preset_mode("sleep")
                 mock_send_command.assert_called_once_with(pydreo_ap, {WIND_MODE_KEY: "sleep"})
+
+            # Selecting "auto" must send "auto-regular" — the device rejects plain "auto" (issue #860)
+            pydreo_ap.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: "sleep"}})
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_preset_mode("auto")
+                mock_send_command.assert_called_once_with(pydreo_ap, {WIND_MODE_KEY: "auto-regular"})
+
+            # The device reports "auto-regular"; HA must surface it as the "auto" preset
+            pydreo_ap.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: "auto-regular"}})
+            assert ha_fan.preset_mode == "auto"

--- a/tests/pydreo/test_pydreoairpurifier.py
+++ b/tests/pydreo/test_pydreoairpurifier.py
@@ -42,6 +42,8 @@ class TestPyDreoAirPurifier(TestBase):
         assert air_purifier.preset_modes == ["auto", "manual", "sleep", "turbo"]
         # Original revision must NOT have the auto-silent remap flag set
         assert air_purifier._auto_mode_uses_auto_silent is False  # pylint: disable=protected-access
+        # And must not carry the HAP009S auto-regular command override
+        assert air_purifier._auto_mode_command_value is None  # pylint: disable=protected-access
 
         # Setting auto on the original revision must send "auto" unchanged
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
@@ -155,6 +157,33 @@ class TestPyDreoAirPurifier(TestBase):
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             air_purifier.preset_mode = "sleep"
             mock_send_command.assert_called_once_with(air_purifier, {WIND_MODE_KEY: "sleep"})
+
+        # DR-HAP009S rejects plain "auto" and requires "auto-regular" (issue #860)
+        air_purifier.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: "sleep"}})
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            air_purifier.preset_mode = "auto"
+            mock_send_command.assert_called_once_with(air_purifier, {WIND_MODE_KEY: "auto-regular"})
+
+        # State updates reporting "auto-regular" must resolve back to preset_mode "auto"
+        air_purifier.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: "auto-regular"}})
+        assert air_purifier.preset_mode == "auto"
+
+        # Other preset modes must be sent unchanged (no auto remap leakage)
+        air_purifier.handle_server_update({REPORTED_KEY: {WIND_MODE_KEY: "auto-regular"}})
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            air_purifier.preset_mode = "turbo"
+            mock_send_command.assert_called_once_with(air_purifier, {WIND_MODE_KEY: "turbo"})
+
+    def test_HAP009S_auto_regular_override_flag(self):  # pylint: disable=invalid-name
+        """DR-HAP009S must set the auto-regular command override and NOT the auto-silent flag."""
+        self.get_devices_file_name = "get_devices_HAP009S.json"
+        self.pydreo_manager.load_devices()
+        air_purifier = self.pydreo_manager.devices[0]
+        assert air_purifier.model == "DR-HAP009S"
+        # pylint: disable=protected-access
+        assert air_purifier._auto_mode_command_value == "auto-regular"
+        assert air_purifier._auto_mode_uses_auto_silent is False
+        # pylint: enable=protected-access
 
     def test_air_purifier_preset_mode_variant_mapping(self):
         """Mode variants like auto-regular should still map to the base preset mode."""


### PR DESCRIPTION
## Summary
DR-HAP009S rejects the plain `auto` mode command (`instruction validate failed`, error 500003) and requires `auto-regular`. Selecting the "auto" preset previously failed silently.

## Changes
- Generalize `PyDreoAirPurifier._send_command`'s auto-mode remap with a configurable `_auto_mode_command_value` (alongside the existing `_auto_mode_uses_auto_silent` used by HAP003S).
- Add `_hap009s_override` setting `_auto_mode_command_value = "auto-regular"`, wired to `DR-HAP009S` via `override_fn`.
- State reported as `auto-regular` already normalizes back to the `auto` preset (from #845 work).

## Tests
- pydreo: command remap `auto` -> `auto-regular`, state `auto-regular` -> `auto`, override flags set correctly, other modes unaffected, and HAP003S does NOT get the auto-regular override.
- integration: same behavior verified through the HA fan entity.
- Full suite: 868 passed, ruff clean.

Fixes #845
Fixes #860
