### PR TITLE
Fix Chefmaker cook time remaining (count down instead of static)

### DIFF
--- a/custom_components/dreo/pydreo/pydreochefmaker.py
+++ b/custom_components/dreo/pydreo/pydreochefmaker.py
@@ -15,7 +15,11 @@ if TYPE_CHECKING:
 
 LIGHT_KEY = "ledpotkepton"
 MODE_KEY = "mode"
-COOK_TIME_REMAINING_KEY = "wkcountdown"
+# The device does not report a live "remaining" value.  "wkcountdown" is a static configured
+# value (typically 300) that never changes during a cook, so remaining time is derived instead
+# from the estimated total duration minus the elapsed duration (see cook_time_remaining).
+COOK_TIME_ESTIMATED_KEY = "wkestdu"  # Estimated total cook duration in seconds.
+COOK_TIME_PASSED_KEY = "wkpdu"  # Elapsed cook duration in seconds.
 MODE_STANDBY = "standby"
 MODE_COOKING = "cooking"
 MODE_PAUSED = "ckpause"
@@ -39,7 +43,23 @@ class PyDreoChefMaker(PyDreoBaseDevice):
         self._is_on = False
         self._ledpotkepton = 0
         self.mode = None
-        self.cook_time_remaining = None  # Remaining cook time in seconds from wkcountdown.
+        # Remaining cook time is derived from these two fields (see cook_time_remaining property).
+        self._cook_time_estimated = None  # wkestdu: estimated total cook duration in seconds.
+        self._cook_time_passed = None  # wkpdu: elapsed cook duration in seconds.
+
+    @property
+    def cook_time_remaining(self):
+        """Return the remaining cook time in seconds.
+
+        The device does not expose a live "remaining" field; "wkcountdown" is a static
+        configured value that never counts down.  Remaining time is therefore computed as
+        the estimated total duration (wkestdu) minus the elapsed duration (wkpdu), clamped
+        to a minimum of 0.  Returns None when the device has not reported these fields
+        (e.g. firmware that does not expose them), which keeps the sensor hidden.
+        """
+        if not isinstance(self._cook_time_estimated, int) or not isinstance(self._cook_time_passed, int):
+            return None
+        return max(0, self._cook_time_estimated - self._cook_time_passed)
 
     @property
     def is_on(self) -> bool:
@@ -93,7 +113,8 @@ class PyDreoChefMaker(PyDreoBaseDevice):
         self._is_on = self.get_state_update_value(state, POWERON_KEY)
         self.set_mode_from_is_on()
         self._ledpotkepton = self.get_state_update_value(state, LIGHT_KEY)
-        self.cook_time_remaining = self.get_state_update_value(state, COOK_TIME_REMAINING_KEY)
+        self._cook_time_estimated = self.get_state_update_value(state, COOK_TIME_ESTIMATED_KEY)
+        self._cook_time_passed = self.get_state_update_value(state, COOK_TIME_PASSED_KEY)
 
         if self.is_on:
             self.mode = self.get_state_update_value(state, MODE_KEY)
@@ -130,11 +151,18 @@ class PyDreoChefMaker(PyDreoBaseDevice):
             )
             self.mode = val_mode
 
-        val_cook_time_remaining = self.get_server_update_key_value(message, COOK_TIME_REMAINING_KEY)
-        if isinstance(val_cook_time_remaining, int):
+        val_cook_time_estimated = self.get_server_update_key_value(message, COOK_TIME_ESTIMATED_KEY)
+        if isinstance(val_cook_time_estimated, int):
+            self._cook_time_estimated = val_cook_time_estimated
+
+        val_cook_time_passed = self.get_server_update_key_value(message, COOK_TIME_PASSED_KEY)
+        if isinstance(val_cook_time_passed, int):
+            self._cook_time_passed = val_cook_time_passed
+
+        if isinstance(val_cook_time_estimated, int) or isinstance(val_cook_time_passed, int):
             _LOGGER.debug(
-                "handle_server_update: cook_time_remaining: %s --> %s",
+                "handle_server_update: cook_time_remaining: estimated=%s passed=%s --> %s",
+                self._cook_time_estimated,
+                self._cook_time_passed,
                 self.cook_time_remaining,
-                val_cook_time_remaining,
             )
-            self.cook_time_remaining = val_cook_time_remaining

--- a/tests/pydreo/test_pydreochefmaker.py
+++ b/tests/pydreo/test_pydreochefmaker.py
@@ -11,7 +11,8 @@ logger.setLevel(logging.DEBUG)
 
 LIGHT_KEY = "ledpotkepton"
 CM_MODE_KEY = "mode"
-COOK_TIME_REMAINING_KEY = "wkcountdown"
+COOK_TIME_ESTIMATED_KEY = "wkestdu"
+COOK_TIME_PASSED_KEY = "wkpdu"
 
 
 class TestPyDreoChefMaker(TestBase):
@@ -42,13 +43,30 @@ class TestPyDreoChefMaker(TestBase):
         assert cm.cook_time_remaining is not None
 
     def test_update_state_cook_time_remaining(self):
-        """Test update_state reads cook time remaining from state."""
+        """Remaining cook time is derived from estimated (wkestdu) minus elapsed (wkpdu)."""
         cm = self._load_chefmaker()
         state = {
-            COOK_TIME_REMAINING_KEY: {"state": 300},
+            COOK_TIME_ESTIMATED_KEY: {"state": 600},
+            COOK_TIME_PASSED_KEY: {"state": 120},
         }
         cm.update_state(state)
-        assert cm.cook_time_remaining == 300
+        assert cm.cook_time_remaining == 480
+
+    def test_cook_time_remaining_clamped_to_zero(self):
+        """Remaining cook time never goes negative when elapsed exceeds estimated."""
+        cm = self._load_chefmaker()
+        cm.update_state({
+            COOK_TIME_ESTIMATED_KEY: {"state": 300},
+            COOK_TIME_PASSED_KEY: {"state": 360},
+        })
+        assert cm.cook_time_remaining == 0
+
+    def test_cook_time_remaining_none_when_fields_absent(self):
+        """Remaining cook time is None when the device does not report the duration fields."""
+        cm = self._load_chefmaker()
+        cm._cook_time_estimated = None  # pylint: disable=protected-access
+        cm._cook_time_passed = None  # pylint: disable=protected-access
+        assert cm.cook_time_remaining is None
 
     def test_update_state_led(self):
         """Test update_state processes LED state from REST."""
@@ -63,7 +81,8 @@ class TestPyDreoChefMaker(TestBase):
             POWERON_KEY: {"state": True},
             LIGHT_KEY: {"state": 1},
             CM_MODE_KEY: {"state": "cooking"},
-            COOK_TIME_REMAINING_KEY: {"state": 1200},
+            COOK_TIME_ESTIMATED_KEY: {"state": 1500},
+            COOK_TIME_PASSED_KEY: {"state": 300},
         }
         cm.update_state(state)
         assert cm.is_on is True
@@ -148,6 +167,21 @@ class TestPyDreoChefMaker(TestBase):
         cm.handle_server_update({REPORTED_KEY: {LIGHT_KEY: 0}})
         assert cm.ledpotkepton is False
 
+    def test_handle_server_update_cook_time_remaining_785(self):
+        """Regression for #785: live diagnostics (wkestdu=360, wkpdu=0) yield remaining=360.
+
+        The device reports a static wkcountdown (300) that never counts down; remaining must be
+        derived from wkestdu minus wkpdu instead.  These values come from the real cooking-state
+        diagnostics attached to issue #329/#785.
+        """
+        cm = self._load_chefmaker()
+        cm.handle_server_update({REPORTED_KEY: {CM_MODE_KEY: "cooking", COOK_TIME_ESTIMATED_KEY: 360, COOK_TIME_PASSED_KEY: 0}})
+        assert cm.cook_time_remaining == 360
+
+        # A later update reporting more elapsed time must lower the remaining value.
+        cm.handle_server_update({REPORTED_KEY: {COOK_TIME_PASSED_KEY: 90}})
+        assert cm.cook_time_remaining == 270
+
     def test_handle_server_update_mode(self):
         """Test handle_server_update processes mode."""
         cm = self._load_chefmaker()
@@ -160,7 +194,7 @@ class TestPyDreoChefMaker(TestBase):
     def test_handle_server_update_combined(self):
         """Test handle_server_update processes multiple keys."""
         cm = self._load_chefmaker()
-        cm.handle_server_update({REPORTED_KEY: {POWERON_KEY: True, LIGHT_KEY: 1, CM_MODE_KEY: "cooking", COOK_TIME_REMAINING_KEY: 900}})
+        cm.handle_server_update({REPORTED_KEY: {POWERON_KEY: True, LIGHT_KEY: 1, CM_MODE_KEY: "cooking", COOK_TIME_ESTIMATED_KEY: 1000, COOK_TIME_PASSED_KEY: 100}})
         assert cm.is_on is True
         assert cm.ledpotkepton is True
         assert cm.mode == "cooking"


### PR DESCRIPTION
## Summary
The Chefmaker "Cook time remaining" sensor was stuck at a static value (~`300 s`) and never counted down, because it read the `wkcountdown` field — a configured constant, not the live remaining time (#785).

## Root cause
From the live-cooking diagnostics in #329/#785 (`mode: cooking`, "~5 min left"):
- `wkcountdown` = 300 (static, never changes)
- `wkestdu` = 360 — estimated total cook duration
- `wkpdu` = 0 — elapsed duration

So remaining time must be **derived**, not read directly.

## Fix
- `cook_time_remaining` is now a computed property: `max(0, wkestdu - wkpdu)`.
- Returns `None` (sensor hidden) when the device doesn't report these fields.
- Clock-independent — no reliance on epoch timestamps or HA/device clock sync.

## Tests
- Updated existing chefmaker tests to the new `wkestdu`/`wkpdu` semantics.
- Added coverage: clamp-to-zero, `None` when fields absent, and a regression test using the real captured values from #785 (360/0 → 360, then elapsed 90 → 270).
- Full suite: 870 passed, ruff clean.

## Note for tester
@Ken7382 should see the sensor count down during an actual cook once `wkestdu` is populated (the estimate appears after preheat, so it may read `0`/unknown during preheating).

Fixes #785
