### PR TITLE
Fix Chefmaker cook_time_remaining on DR-KCM001S (derive from wkbegin) (#863)

### DIFF
--- a/DEVICE_OWNERS.md
+++ b/DEVICE_OWNERS.md
@@ -131,7 +131,7 @@ Sourced from GitHub issues, PRs, and contributed test data.
 
 | Model | GitHub User(s) | Evidence |
 |---|---|---|
-| DR-KCM001S | [@holstein13](https://github.com/holstein13), [@iRonin](https://github.com/iRonin), [@Ken7382](https://github.com/Ken7382), [@mattgphoto](https://github.com/mattgphoto) | [#169](https://github.com/JeffSteinbok/hass-dreo/issues/169), [#113](https://github.com/JeffSteinbok/hass-dreo/issues/113), [#329](https://github.com/JeffSteinbok/hass-dreo/issues/329), [#564](https://github.com/JeffSteinbok/hass-dreo/issues/564) |
+| DR-KCM001S | [@holstein13](https://github.com/holstein13), [@iRonin](https://github.com/iRonin), [@Ken7382](https://github.com/Ken7382), [@mattgphoto](https://github.com/mattgphoto) | [#169](https://github.com/JeffSteinbok/hass-dreo/issues/169), [#113](https://github.com/JeffSteinbok/hass-dreo/issues/113), [#329](https://github.com/JeffSteinbok/hass-dreo/issues/329), [#564](https://github.com/JeffSteinbok/hass-dreo/issues/564), [#863](https://github.com/JeffSteinbok/hass-dreo/issues/863) |
 
 ---
 

--- a/custom_components/dreo/pydreo/pydreochefmaker.py
+++ b/custom_components/dreo/pydreo/pydreochefmaker.py
@@ -15,7 +15,11 @@ if TYPE_CHECKING:
 
 LIGHT_KEY = "ledpotkepton"
 MODE_KEY = "mode"
-COOK_TIME_REMAINING_KEY = "wkcountdown"
+# The device does not report a live "remaining" value.  "wkcountdown" is a static configured
+# value (typically 300) that never changes during a cook, so remaining time is derived instead
+# from the estimated total duration minus the elapsed duration (see cook_time_remaining).
+COOK_TIME_ESTIMATED_KEY = "wkestdu"  # Estimated total cook duration in seconds.
+COOK_TIME_PASSED_KEY = "wkpdu"  # Elapsed cook duration in seconds.
 MODE_STANDBY = "standby"
 MODE_COOKING = "cooking"
 MODE_PAUSED = "ckpause"
@@ -39,7 +43,23 @@ class PyDreoChefMaker(PyDreoBaseDevice):
         self._is_on = False
         self._ledpotkepton = 0
         self.mode = None
-        self.cook_time_remaining = None  # Remaining cook time in seconds from wkcountdown.
+        # Remaining cook time is derived from these two fields (see cook_time_remaining property).
+        self._cook_time_estimated = None  # wkestdu: estimated total cook duration in seconds.
+        self._cook_time_passed = None  # wkpdu: elapsed cook duration in seconds.
+
+    @property
+    def cook_time_remaining(self):
+        """Return the remaining cook time in seconds.
+
+        The device does not expose a live "remaining" field; "wkcountdown" is a static
+        configured value that never counts down.  Remaining time is therefore computed as
+        the estimated total duration (wkestdu) minus the elapsed duration (wkpdu), clamped
+        to a minimum of 0.  Returns None when the device has not reported these fields
+        (e.g. firmware that does not expose them), which keeps the sensor hidden.
+        """
+        if not isinstance(self._cook_time_estimated, int) or not isinstance(self._cook_time_passed, int):
+            return None
+        return max(0, self._cook_time_estimated - self._cook_time_passed)
 
     @property
     def is_on(self) -> bool:
@@ -93,7 +113,8 @@ class PyDreoChefMaker(PyDreoBaseDevice):
         self._is_on = self.get_state_update_value(state, POWERON_KEY)
         self.set_mode_from_is_on()
         self._ledpotkepton = self.get_state_update_value(state, LIGHT_KEY)
-        self.cook_time_remaining = self.get_state_update_value(state, COOK_TIME_REMAINING_KEY)
+        self._cook_time_estimated = self.get_state_update_value(state, COOK_TIME_ESTIMATED_KEY)
+        self._cook_time_passed = self.get_state_update_value(state, COOK_TIME_PASSED_KEY)
 
         if self.is_on:
             self.mode = self.get_state_update_value(state, MODE_KEY)
@@ -130,11 +151,18 @@ class PyDreoChefMaker(PyDreoBaseDevice):
             )
             self.mode = val_mode
 
-        val_cook_time_remaining = self.get_server_update_key_value(message, COOK_TIME_REMAINING_KEY)
-        if isinstance(val_cook_time_remaining, int):
+        val_cook_time_estimated = self.get_server_update_key_value(message, COOK_TIME_ESTIMATED_KEY)
+        if isinstance(val_cook_time_estimated, int):
+            self._cook_time_estimated = val_cook_time_estimated
+
+        val_cook_time_passed = self.get_server_update_key_value(message, COOK_TIME_PASSED_KEY)
+        if isinstance(val_cook_time_passed, int):
+            self._cook_time_passed = val_cook_time_passed
+
+        if isinstance(val_cook_time_estimated, int) or isinstance(val_cook_time_passed, int):
             _LOGGER.debug(
-                "handle_server_update: cook_time_remaining: %s --> %s",
+                "handle_server_update: cook_time_remaining: estimated=%s passed=%s --> %s",
+                self._cook_time_estimated,
+                self._cook_time_passed,
                 self.cook_time_remaining,
-                val_cook_time_remaining,
             )
-            self.cook_time_remaining = val_cook_time_remaining

--- a/custom_components/dreo/pydreo/pydreochefmaker.py
+++ b/custom_components/dreo/pydreo/pydreochefmaker.py
@@ -1,6 +1,7 @@
 """Support for Dreo ChefMaker devices."""
 
 import logging
+import time
 from typing import Dict, TYPE_CHECKING
 
 from .constant import (
@@ -15,11 +16,13 @@ if TYPE_CHECKING:
 
 LIGHT_KEY = "ledpotkepton"
 MODE_KEY = "mode"
-# The device does not report a live "remaining" value.  "wkcountdown" is a static configured
-# value (typically 300) that never changes during a cook, so remaining time is derived instead
-# from the estimated total duration minus the elapsed duration (see cook_time_remaining).
+# The device does not report a live "remaining" value, and on the DR-KCM001S it never pushes an
+# elapsed-duration field ("wkpdu" stays 0 for the whole cook - see #863).  "wkcountdown" is a
+# static configured value (typically 300) that never changes either.  Remaining time is therefore
+# derived from the estimated total duration and the epoch timestamp at which the cook began
+# (see cook_time_remaining).
 COOK_TIME_ESTIMATED_KEY = "wkestdu"  # Estimated total cook duration in seconds.
-COOK_TIME_PASSED_KEY = "wkpdu"  # Elapsed cook duration in seconds.
+COOK_TIME_BEGIN_KEY = "wkbegin"  # Epoch (seconds) at which the current cook began.
 MODE_STANDBY = "standby"
 MODE_COOKING = "cooking"
 MODE_PAUSED = "ckpause"
@@ -45,21 +48,24 @@ class PyDreoChefMaker(PyDreoBaseDevice):
         self.mode = None
         # Remaining cook time is derived from these two fields (see cook_time_remaining property).
         self._cook_time_estimated = None  # wkestdu: estimated total cook duration in seconds.
-        self._cook_time_passed = None  # wkpdu: elapsed cook duration in seconds.
+        self._cook_time_begin = None  # wkbegin: epoch (seconds) at which the current cook began.
 
     @property
     def cook_time_remaining(self):
         """Return the remaining cook time in seconds.
 
-        The device does not expose a live "remaining" field; "wkcountdown" is a static
-        configured value that never counts down.  Remaining time is therefore computed as
-        the estimated total duration (wkestdu) minus the elapsed duration (wkpdu), clamped
-        to a minimum of 0.  Returns None when the device has not reported these fields
-        (e.g. firmware that does not expose them), which keeps the sensor hidden.
+        The device does not expose a live "remaining" field.  On the DR-KCM001S it also never
+        pushes an elapsed-duration field during a cook ("wkpdu" stays 0 the whole time - see
+        #863), and "wkcountdown" is a static configured value.  It does, however, report the
+        estimated total duration ("wkestdu") and the epoch timestamp at which the cook began
+        ("wkbegin"), so remaining time is derived as wkestdu - (now - wkbegin), clamped to a
+        minimum of 0.  Returns None when the device has not reported these fields (e.g. firmware
+        that does not expose them), which keeps the sensor hidden.
         """
-        if not isinstance(self._cook_time_estimated, int) or not isinstance(self._cook_time_passed, int):
+        if not isinstance(self._cook_time_estimated, int) or not isinstance(self._cook_time_begin, int):
             return None
-        return max(0, self._cook_time_estimated - self._cook_time_passed)
+        elapsed = int(time.time()) - self._cook_time_begin
+        return max(0, self._cook_time_estimated - elapsed)
 
     @property
     def is_on(self) -> bool:
@@ -114,7 +120,7 @@ class PyDreoChefMaker(PyDreoBaseDevice):
         self.set_mode_from_is_on()
         self._ledpotkepton = self.get_state_update_value(state, LIGHT_KEY)
         self._cook_time_estimated = self.get_state_update_value(state, COOK_TIME_ESTIMATED_KEY)
-        self._cook_time_passed = self.get_state_update_value(state, COOK_TIME_PASSED_KEY)
+        self._cook_time_begin = self.get_state_update_value(state, COOK_TIME_BEGIN_KEY)
 
         if self.is_on:
             self.mode = self.get_state_update_value(state, MODE_KEY)
@@ -155,14 +161,14 @@ class PyDreoChefMaker(PyDreoBaseDevice):
         if isinstance(val_cook_time_estimated, int):
             self._cook_time_estimated = val_cook_time_estimated
 
-        val_cook_time_passed = self.get_server_update_key_value(message, COOK_TIME_PASSED_KEY)
-        if isinstance(val_cook_time_passed, int):
-            self._cook_time_passed = val_cook_time_passed
+        val_cook_time_begin = self.get_server_update_key_value(message, COOK_TIME_BEGIN_KEY)
+        if isinstance(val_cook_time_begin, int):
+            self._cook_time_begin = val_cook_time_begin
 
-        if isinstance(val_cook_time_estimated, int) or isinstance(val_cook_time_passed, int):
+        if isinstance(val_cook_time_estimated, int) or isinstance(val_cook_time_begin, int):
             _LOGGER.debug(
-                "handle_server_update: cook_time_remaining: estimated=%s passed=%s --> %s",
+                "handle_server_update: cook_time_remaining: estimated=%s begin=%s --> %s",
                 self._cook_time_estimated,
-                self._cook_time_passed,
+                self._cook_time_begin,
                 self.cook_time_remaining,
             )

--- a/custom_components/dreo/pydreo/pydreochefmaker.py
+++ b/custom_components/dreo/pydreo/pydreochefmaker.py
@@ -51,20 +51,22 @@ class PyDreoChefMaker(PyDreoBaseDevice):
         self._cook_time_begin = None  # wkbegin: epoch (seconds) at which the current cook began.
 
     @property
-    def cook_time_remaining(self):
+    def cook_time_remaining(self) -> "int | None":
         """Return the remaining cook time in seconds.
 
         The device does not expose a live "remaining" field.  On the DR-KCM001S it also never
         pushes an elapsed-duration field during a cook ("wkpdu" stays 0 the whole time - see
         #863), and "wkcountdown" is a static configured value.  It does, however, report the
         estimated total duration ("wkestdu") and the epoch timestamp at which the cook began
-        ("wkbegin"), so remaining time is derived as wkestdu - (now - wkbegin), clamped to a
-        minimum of 0.  Returns None when the device has not reported these fields (e.g. firmware
-        that does not expose them), which keeps the sensor hidden.
+        ("wkbegin"), so remaining time is derived as wkestdu - (now - wkbegin), clamped to the
+        range 0..wkestdu.  Returns None when the device has not reported these fields (e.g.
+        firmware that does not expose them), which keeps the sensor hidden.
         """
         if not isinstance(self._cook_time_estimated, int) or not isinstance(self._cook_time_begin, int):
             return None
-        elapsed = int(time.time()) - self._cook_time_begin
+        # Clamp elapsed to >= 0 so clock skew (wkbegin slightly ahead of local time) can never
+        # produce a remaining time greater than the estimated duration.
+        elapsed = max(0, int(time.time()) - self._cook_time_begin)
         return max(0, self._cook_time_estimated - elapsed)
 
     @property

--- a/tests/pydreo/test_pydreochefmaker.py
+++ b/tests/pydreo/test_pydreochefmaker.py
@@ -229,6 +229,33 @@ class TestPyDreoChefMaker(TestBase):
         with patch(PATCH_TIME, return_value=wkbegin + 400):
             assert cm.cook_time_remaining == 0
 
+    def test_cook_time_remaining_stale_wkbegin_not_used_as_positive(self):
+        """A stale wkbegin from a previous cook must not yield a misleading remaining time.
+
+        The REST fixture (get_device_state_KCM001S_1.json) seeds wkbegin from a prior session
+        while wkestdu is 0.  When a new cook reports wkestdu before pushing a fresh wkbegin (as
+        seen in #863), the stale timestamp is far in the past, so elapsed is large and remaining
+        clamps to 0 rather than reporting a bogus value.
+        """
+        cm = self._load_chefmaker()
+        stale_begin = 1000
+        cm._cook_time_begin = stale_begin  # pylint: disable=protected-access
+
+        # New cook configured: wkestdu arrives, but wkbegin is still the stale value.
+        cm.handle_server_update({REPORTED_KEY: {CM_MODE_KEY: "ckcfm", COOK_TIME_ESTIMATED_KEY: 300}})
+
+        # "now" is long after the stale begin -> elapsed huge -> clamped to 0 (not 300).
+        with patch(PATCH_TIME, return_value=stale_begin + 100000):
+            assert cm.cook_time_remaining == 0
+
+    def test_cook_time_remaining_clamped_when_wkbegin_ahead_of_clock(self):
+        """Clock skew (wkbegin ahead of local time) never exceeds the estimated duration."""
+        cm = self._load_chefmaker()
+        cm.handle_server_update({REPORTED_KEY: {COOK_TIME_ESTIMATED_KEY: 300, COOK_TIME_BEGIN_KEY: 2000}})
+        # Local clock is 50s behind the device's wkbegin -> elapsed clamped to 0 -> remaining == estimate.
+        with patch(PATCH_TIME, return_value=1950):
+            assert cm.cook_time_remaining == 300
+
     def test_handle_server_update_mode(self):
         """Test handle_server_update processes mode."""
         cm = self._load_chefmaker()

--- a/tests/pydreo/test_pydreochefmaker.py
+++ b/tests/pydreo/test_pydreochefmaker.py
@@ -12,7 +12,10 @@ logger.setLevel(logging.DEBUG)
 LIGHT_KEY = "ledpotkepton"
 CM_MODE_KEY = "mode"
 COOK_TIME_ESTIMATED_KEY = "wkestdu"
-COOK_TIME_PASSED_KEY = "wkpdu"
+COOK_TIME_BEGIN_KEY = "wkbegin"
+
+# Patch target for time.time() inside the chefmaker module so cook-time math is deterministic.
+PATCH_TIME = "custom_components.dreo.pydreo.pydreochefmaker.time.time"
 
 
 class TestPyDreoChefMaker(TestBase):
@@ -43,29 +46,33 @@ class TestPyDreoChefMaker(TestBase):
         assert cm.cook_time_remaining is not None
 
     def test_update_state_cook_time_remaining(self):
-        """Remaining cook time is derived from estimated (wkestdu) minus elapsed (wkpdu)."""
+        """Remaining cook time is derived from estimated (wkestdu) minus elapsed time since wkbegin."""
         cm = self._load_chefmaker()
         state = {
             COOK_TIME_ESTIMATED_KEY: {"state": 600},
-            COOK_TIME_PASSED_KEY: {"state": 120},
+            COOK_TIME_BEGIN_KEY: {"state": 1000},
         }
         cm.update_state(state)
-        assert cm.cook_time_remaining == 480
+        # 120 seconds have elapsed since the cook began: 600 - 120 = 480 remaining.
+        with patch(PATCH_TIME, return_value=1120):
+            assert cm.cook_time_remaining == 480
 
     def test_cook_time_remaining_clamped_to_zero(self):
-        """Remaining cook time never goes negative when elapsed exceeds estimated."""
+        """Remaining cook time never goes negative when the cook has run past its estimate."""
         cm = self._load_chefmaker()
         cm.update_state({
             COOK_TIME_ESTIMATED_KEY: {"state": 300},
-            COOK_TIME_PASSED_KEY: {"state": 360},
+            COOK_TIME_BEGIN_KEY: {"state": 1000},
         })
-        assert cm.cook_time_remaining == 0
+        # 360 seconds elapsed against a 300 second estimate -> clamped to 0.
+        with patch(PATCH_TIME, return_value=1360):
+            assert cm.cook_time_remaining == 0
 
     def test_cook_time_remaining_none_when_fields_absent(self):
         """Remaining cook time is None when the device does not report the duration fields."""
         cm = self._load_chefmaker()
         cm._cook_time_estimated = None  # pylint: disable=protected-access
-        cm._cook_time_passed = None  # pylint: disable=protected-access
+        cm._cook_time_begin = None  # pylint: disable=protected-access
         assert cm.cook_time_remaining is None
 
     def test_update_state_led(self):
@@ -82,12 +89,14 @@ class TestPyDreoChefMaker(TestBase):
             LIGHT_KEY: {"state": 1},
             CM_MODE_KEY: {"state": "cooking"},
             COOK_TIME_ESTIMATED_KEY: {"state": 1500},
-            COOK_TIME_PASSED_KEY: {"state": 300},
+            COOK_TIME_BEGIN_KEY: {"state": 1000},
         }
         cm.update_state(state)
         assert cm.is_on is True
         assert cm.mode == "cooking"
-        assert cm.cook_time_remaining == 1200
+        # 300 seconds elapsed since the cook began: 1500 - 300 = 1200 remaining.
+        with patch(PATCH_TIME, return_value=1300):
+            assert cm.cook_time_remaining == 1200
 
     def test_update_state_mode_when_off(self):
         """Test update_state sets mode from power state when device is off."""
@@ -168,19 +177,57 @@ class TestPyDreoChefMaker(TestBase):
         assert cm.ledpotkepton is False
 
     def test_handle_server_update_cook_time_remaining_785(self):
-        """Regression for #785: live diagnostics (wkestdu=360, wkpdu=0) yield remaining=360.
+        """Regression for #785: remaining time counts down instead of showing a static value.
 
         The device reports a static wkcountdown (300) that never counts down; remaining must be
-        derived from wkestdu minus wkpdu instead.  These values come from the real cooking-state
-        diagnostics attached to issue #329/#785.
+        derived from the estimated total duration (wkestdu) and the cook start timestamp (wkbegin)
+        instead.
         """
         cm = self._load_chefmaker()
-        cm.handle_server_update({REPORTED_KEY: {CM_MODE_KEY: "cooking", COOK_TIME_ESTIMATED_KEY: 360, COOK_TIME_PASSED_KEY: 0}})
-        assert cm.cook_time_remaining == 360
+        cm.handle_server_update({REPORTED_KEY: {CM_MODE_KEY: "cooking", COOK_TIME_ESTIMATED_KEY: 360, COOK_TIME_BEGIN_KEY: 1000}})
+        # Just after the cook begins the full estimate remains.
+        with patch(PATCH_TIME, return_value=1000):
+            assert cm.cook_time_remaining == 360
 
-        # A later update reporting more elapsed time must lower the remaining value.
-        cm.handle_server_update({REPORTED_KEY: {COOK_TIME_PASSED_KEY: 90}})
-        assert cm.cook_time_remaining == 270
+        # As real time advances the remaining value must decrease.
+        with patch(PATCH_TIME, return_value=1090):
+            assert cm.cook_time_remaining == 270
+
+    def test_handle_server_update_cook_time_remaining_863(self):
+        """Regression for #863: DR-KCM001S never pushes wkpdu during a cook.
+
+        Captured from the debug log attached to issue #863 for a real 300 second cook:
+          - wkestdu = 300 is reported when the cook is configured.
+          - wkbegin = 1785039118 (epoch seconds) is reported ~21s later at cook start.
+          - No wkpdu / wkcountdown is ever pushed during the cook.
+        With the old wkestdu - wkpdu logic the sensor stayed pinned at 300; deriving from wkbegin
+        makes it count down and reach 0 by completion (device hit ckcomplete ~298.6s later).
+        """
+        cm = self._load_chefmaker()
+        wkbegin = 1785039118
+
+        # Cook configured: estimate reported before wkbegin arrives.
+        cm.handle_server_update({REPORTED_KEY: {CM_MODE_KEY: "ckcfm", COOK_TIME_ESTIMATED_KEY: 300}})
+        # Cook starts: wkbegin arrives, then mode -> cooking.
+        cm.handle_server_update({REPORTED_KEY: {COOK_TIME_BEGIN_KEY: wkbegin}})
+        cm.handle_server_update({REPORTED_KEY: {CM_MODE_KEY: "cooking"}})
+
+        # At cook start the full duration remains.
+        with patch(PATCH_TIME, return_value=wkbegin):
+            assert cm.cook_time_remaining == 300
+
+        # Midway through the cook it has counted down.
+        with patch(PATCH_TIME, return_value=wkbegin + 120):
+            assert cm.cook_time_remaining == 180
+
+        # By the time the device reports ckcomplete (~300s later) it has reached 0.
+        with patch(PATCH_TIME, return_value=wkbegin + 300):
+            assert cm.cook_time_remaining == 0
+
+        # On power-off the device reports wkestdu: 0, which also yields 0.
+        cm.handle_server_update({REPORTED_KEY: {COOK_TIME_ESTIMATED_KEY: 0}})
+        with patch(PATCH_TIME, return_value=wkbegin + 400):
+            assert cm.cook_time_remaining == 0
 
     def test_handle_server_update_mode(self):
         """Test handle_server_update processes mode."""
@@ -194,8 +241,10 @@ class TestPyDreoChefMaker(TestBase):
     def test_handle_server_update_combined(self):
         """Test handle_server_update processes multiple keys."""
         cm = self._load_chefmaker()
-        cm.handle_server_update({REPORTED_KEY: {POWERON_KEY: True, LIGHT_KEY: 1, CM_MODE_KEY: "cooking", COOK_TIME_ESTIMATED_KEY: 1000, COOK_TIME_PASSED_KEY: 100}})
+        cm.handle_server_update({REPORTED_KEY: {POWERON_KEY: True, LIGHT_KEY: 1, CM_MODE_KEY: "cooking", COOK_TIME_ESTIMATED_KEY: 1000, COOK_TIME_BEGIN_KEY: 1000}})
         assert cm.is_on is True
         assert cm.ledpotkepton is True
         assert cm.mode == "cooking"
-        assert cm.cook_time_remaining == 900
+        # 100 seconds elapsed since the cook began: 1000 - 100 = 900 remaining.
+        with patch(PATCH_TIME, return_value=1100):
+            assert cm.cook_time_remaining == 900

--- a/tests/pydreo/test_pydreochefmaker.py
+++ b/tests/pydreo/test_pydreochefmaker.py
@@ -11,7 +11,8 @@ logger.setLevel(logging.DEBUG)
 
 LIGHT_KEY = "ledpotkepton"
 CM_MODE_KEY = "mode"
-COOK_TIME_REMAINING_KEY = "wkcountdown"
+COOK_TIME_ESTIMATED_KEY = "wkestdu"
+COOK_TIME_PASSED_KEY = "wkpdu"
 
 
 class TestPyDreoChefMaker(TestBase):
@@ -42,13 +43,30 @@ class TestPyDreoChefMaker(TestBase):
         assert cm.cook_time_remaining is not None
 
     def test_update_state_cook_time_remaining(self):
-        """Test update_state reads cook time remaining from state."""
+        """Remaining cook time is derived from estimated (wkestdu) minus elapsed (wkpdu)."""
         cm = self._load_chefmaker()
         state = {
-            COOK_TIME_REMAINING_KEY: {"state": 300},
+            COOK_TIME_ESTIMATED_KEY: {"state": 600},
+            COOK_TIME_PASSED_KEY: {"state": 120},
         }
         cm.update_state(state)
-        assert cm.cook_time_remaining == 300
+        assert cm.cook_time_remaining == 480
+
+    def test_cook_time_remaining_clamped_to_zero(self):
+        """Remaining cook time never goes negative when elapsed exceeds estimated."""
+        cm = self._load_chefmaker()
+        cm.update_state({
+            COOK_TIME_ESTIMATED_KEY: {"state": 300},
+            COOK_TIME_PASSED_KEY: {"state": 360},
+        })
+        assert cm.cook_time_remaining == 0
+
+    def test_cook_time_remaining_none_when_fields_absent(self):
+        """Remaining cook time is None when the device does not report the duration fields."""
+        cm = self._load_chefmaker()
+        cm._cook_time_estimated = None  # pylint: disable=protected-access
+        cm._cook_time_passed = None  # pylint: disable=protected-access
+        assert cm.cook_time_remaining is None
 
     def test_update_state_led(self):
         """Test update_state processes LED state from REST."""
@@ -63,7 +81,8 @@ class TestPyDreoChefMaker(TestBase):
             POWERON_KEY: {"state": True},
             LIGHT_KEY: {"state": 1},
             CM_MODE_KEY: {"state": "cooking"},
-            COOK_TIME_REMAINING_KEY: {"state": 1200},
+            COOK_TIME_ESTIMATED_KEY: {"state": 1500},
+            COOK_TIME_PASSED_KEY: {"state": 300},
         }
         cm.update_state(state)
         assert cm.is_on is True
@@ -148,6 +167,21 @@ class TestPyDreoChefMaker(TestBase):
         cm.handle_server_update({REPORTED_KEY: {LIGHT_KEY: 0}})
         assert cm.ledpotkepton is False
 
+    def test_handle_server_update_cook_time_remaining_785(self):
+        """Regression for #785: live diagnostics (wkestdu=360, wkpdu=0) yield remaining=360.
+
+        The device reports a static wkcountdown (300) that never counts down; remaining must be
+        derived from wkestdu minus wkpdu instead.  These values come from the real cooking-state
+        diagnostics attached to issue #329/#785.
+        """
+        cm = self._load_chefmaker()
+        cm.handle_server_update({REPORTED_KEY: {CM_MODE_KEY: "cooking", COOK_TIME_ESTIMATED_KEY: 360, COOK_TIME_PASSED_KEY: 0}})
+        assert cm.cook_time_remaining == 360
+
+        # A later update reporting more elapsed time must lower the remaining value.
+        cm.handle_server_update({REPORTED_KEY: {COOK_TIME_PASSED_KEY: 90}})
+        assert cm.cook_time_remaining == 270
+
     def test_handle_server_update_mode(self):
         """Test handle_server_update processes mode."""
         cm = self._load_chefmaker()
@@ -160,7 +194,7 @@ class TestPyDreoChefMaker(TestBase):
     def test_handle_server_update_combined(self):
         """Test handle_server_update processes multiple keys."""
         cm = self._load_chefmaker()
-        cm.handle_server_update({REPORTED_KEY: {POWERON_KEY: True, LIGHT_KEY: 1, CM_MODE_KEY: "cooking", COOK_TIME_REMAINING_KEY: 900}})
+        cm.handle_server_update({REPORTED_KEY: {POWERON_KEY: True, LIGHT_KEY: 1, CM_MODE_KEY: "cooking", COOK_TIME_ESTIMATED_KEY: 1000, COOK_TIME_PASSED_KEY: 100}})
         assert cm.is_on is True
         assert cm.ledpotkepton is True
         assert cm.mode == "cooking"


### PR DESCRIPTION
## Summary
On the Chefmaker **DR-KCM001S**, `cook_time_remaining` stayed pinned at the full cook duration for the entire cook and never counted down (#863).

## Root cause
PR #862 derived remaining time as `wkestdu - wkpdu`, but this model **never pushes `wkpdu`** during a cook — it stays `0` the whole time. The full debug log in #863 confirms only `wkestdu`, `wkckid`, `wkbegin`, `wkstgbegin`, `wksetwndlv`, `wksetpwrlv` are reported. So `max(0, 300 - 0)` = 300 for the whole cook, and the None-guard never fired.

Notably, there was never captured evidence that `wkpdu` ever incremented, so the original approach is removed rather than kept as a fallback.

## Fix
- `cook_time_remaining` is now derived from the device's own cook-start timestamp: `max(0, wkestdu - (now - wkbegin))`.
- Returns `None` (sensor hidden) when `wkestdu`/`wkbegin` aren't reported.
- The dead `wkpdu` path is removed; `wkbegin` is now tracked in `update_state`/`handle_server_update`.

## Tests
- Reworked cook-time tests to mock `time.time()` for deterministic math.
- Added `test_handle_server_update_cook_time_remaining_863`, built from the reporter's real captured debug log (`wkestdu=300`, `wkbegin=1785039118`, no `wkpdu`): counts down mid-cook, reaches 0 by ~300s, and stays 0 after power-off reports `wkestdu:0`.
- Full suite: **871 passed**, ruff clean.

## Note
`wkbegin` is the device's own clock compared against `now`, so only HA/device clock skew matters (typically small) — an acceptable tradeoff since it's the only elapsed-time signal this model emits.

Fixes #863
