### PR TITLE
Extend DR-HEC006S: ambient light modes, brightness, thresholds (from #841)

### DIFF
--- a/DEVICE_OWNERS.md
+++ b/DEVICE_OWNERS.md
@@ -116,7 +116,7 @@ Sourced from GitHub issues, PRs, and contributed test data.
 | Model | GitHub User(s) | Evidence |
 |---|---|---|
 | DR-HEC002S | [@antz29](https://github.com/antz29), [@obol2](https://github.com/obol2), [@sbR569](https://github.com/sbR569) | [#285](https://github.com/JeffSteinbok/hass-dreo/issues/285), [#290](https://github.com/JeffSteinbok/hass-dreo/issues/290), [#291](https://github.com/JeffSteinbok/hass-dreo/issues/291) |
-| DR-HEC006S | [@Achronite](https://github.com/Achronite), [@stripedew](https://github.com/stripedew) | [#742](https://github.com/JeffSteinbok/hass-dreo/issues/742), [#701](https://github.com/JeffSteinbok/hass-dreo/issues/701), [filter](https://github.com/JeffSteinbok/hass-dreo/issues?q=DR-HEC006S) |
+| DR-HEC006S | [@Achronite](https://github.com/Achronite), [@stripedew](https://github.com/stripedew), [@harrymayr](https://github.com/harrymayr) | [#742](https://github.com/JeffSteinbok/hass-dreo/issues/742), [#701](https://github.com/JeffSteinbok/hass-dreo/issues/701), [#841](https://github.com/JeffSteinbok/hass-dreo/pull/841), [filter](https://github.com/JeffSteinbok/hass-dreo/issues?q=DR-HEC006S) |
 
 ## Dehumidifiers (DR-HDH)
 

--- a/custom_components/dreo/__init__.py
+++ b/custom_components/dreo/__init__.py
@@ -110,6 +110,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         platforms.add(Platform.NUMBER)
         platforms.add(Platform.BINARY_SENSOR)
         platforms.add(Platform.LIGHT)
+        platforms.add(Platform.SELECT)
 
     pydreo_manager.start_transport()
 

--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -453,14 +453,14 @@ class DreoRGBICLightHA(DreoLightHA):
                         new_id = self._build_effect_id(current_id, effect_idx)
                         if new_id is not None:
                             self.pydreo_device.rgb_effect_id = new_id
-                except ValueError, IndexError:
+                except (ValueError, IndexError):
                     _LOGGER.warning("turn_on: Invalid effect name %s", effect)
             elif effect.startswith("Preset "):
                 # Preset system: send rgbpresetsel index
                 try:
                     preset_idx = int(effect.split(" ")[1]) - 1
                     self.pydreo_device.rgb_preset_sel = preset_idx
-                except ValueError, IndexError:
+                except (ValueError, IndexError):
                     _LOGGER.warning("turn_on: Invalid effect name %s", effect)
 
 

--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -573,8 +573,6 @@ class DreoHumidifierLightHA(DreoBaseDeviceHA, LightEntity):  # pylint: disable=a
             return 0
         # Map: level according to number of levels
         return int(255 / (max(self._levels)) * rgblevel)
-        # Map: 1 (low) -> 128, 2 (full) -> 255
-        # return 128 if int(rgblevel) == 1 else 255
 
     @property
     def rgb_color(self) -> tuple[int, int, int] | None:
@@ -611,8 +609,8 @@ class DreoHumidifierLightHA(DreoBaseDeviceHA, LightEntity):  # pylint: disable=a
             # Older firmware path: use rgblevel and rgb* keys.
             if ATTR_BRIGHTNESS in kwargs and self._has_brightness:
                 brightness = kwargs[ATTR_BRIGHTNESS]
-                # Map HA brightness (1-255) to rgblevel: 1-127 -> 1 (low), 128-255 -> 2 (full)
-                desired_level = round(brightness / 255 * (max(self._levels)))
+                # Map HA brightness (1-255) to number of rgblevels:
+                desired_level = min(max(self._levels), max(1, round(brightness / 255 * (max(self._levels)))))
             else:
                 # Default to full brightness
                 desired_level = max(self._levels)

--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -453,14 +453,14 @@ class DreoRGBICLightHA(DreoLightHA):
                         new_id = self._build_effect_id(current_id, effect_idx)
                         if new_id is not None:
                             self.pydreo_device.rgb_effect_id = new_id
-                except (ValueError, IndexError):
+                except ValueError, IndexError:
                     _LOGGER.warning("turn_on: Invalid effect name %s", effect)
             elif effect.startswith("Preset "):
                 # Preset system: send rgbpresetsel index
                 try:
                     preset_idx = int(effect.split(" ")[1]) - 1
                     self.pydreo_device.rgb_preset_sel = preset_idx
-                except (ValueError, IndexError):
+                except ValueError, IndexError:
                     _LOGGER.warning("turn_on: Invalid effect name %s", effect)
 
 
@@ -571,8 +571,10 @@ class DreoHumidifierLightHA(DreoBaseDeviceHA, LightEntity):  # pylint: disable=a
         rgblevel = getattr(self.device, "rgblevel", None)
         if rgblevel is None or int(rgblevel) == 0:
             return 0
+        # Map: level according to number of levels
+        return int(255 / (max(self._levels)) * rgblevel)
         # Map: 1 (low) -> 128, 2 (full) -> 255
-        return 128 if int(rgblevel) == 1 else 255
+        # return 128 if int(rgblevel) == 1 else 255
 
     @property
     def rgb_color(self) -> tuple[int, int, int] | None:
@@ -610,7 +612,7 @@ class DreoHumidifierLightHA(DreoBaseDeviceHA, LightEntity):  # pylint: disable=a
             if ATTR_BRIGHTNESS in kwargs and self._has_brightness:
                 brightness = kwargs[ATTR_BRIGHTNESS]
                 # Map HA brightness (1-255) to rgblevel: 1-127 -> 1 (low), 128-255 -> 2 (full)
-                desired_level = 1 if brightness < 128 else 2
+                desired_level = round(brightness / 255 * (max(self._levels)))
             else:
                 # Default to full brightness
                 desired_level = max(self._levels)

--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -626,7 +626,7 @@ class DreoHumidifierLightHA(DreoBaseDeviceHA, LightEntity):  # pylint: disable=a
             if ATTR_BRIGHTNESS in kwargs and self._has_brightness:
                 brightness = kwargs[ATTR_BRIGHTNESS]
                 # Map HA brightness (1-255) to number of rgblevels:
-                desired_level = min(max(self._levels), max(1, round(brightness / 255 * (max(self._levels)))))
+                desired_level = min(max(self._levels), max(1, math.ceil(brightness / 255 * (max(self._levels)))))
             else:
                 # Default to full brightness
                 desired_level = max(self._levels)

--- a/custom_components/dreo/number.py
+++ b/custom_components/dreo/number.py
@@ -161,7 +161,13 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         min_value=0,
         max_value=100,
         step=1,
-        exists_fn=lambda device: device.type == DreoDeviceType.HUMIDIFIER and device.is_feature_supported("rgbth"),
+        exists_fn=lambda device: (
+            (
+                device.type
+                in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER}
+            )
+            and device.is_feature_supported("rgbth")
+        ),
     ),
     DreoNumberEntityDescription(
         key="Ambient Light Threshold High",
@@ -171,7 +177,13 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         min_value=0,
         max_value=100,
         step=1,
-        exists_fn=lambda device: device.type == DreoDeviceType.HUMIDIFIER and device.is_feature_supported("rgbth"),
+        exists_fn=lambda device: (
+            (
+                device.type
+                in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER}
+            )
+            and device.is_feature_supported("rgbth")
+        ),
     ),
 )
 

--- a/custom_components/dreo/number.py
+++ b/custom_components/dreo/number.py
@@ -161,13 +161,8 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         min_value=0,
         max_value=100,
         step=1,
-        exists_fn=lambda device: (
-            (
-                device.type
-                in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER}
-            )
-            and device.is_feature_supported("rgbth")
-        ),
+        exists_fn=lambda device: device.type in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER}
+        and device.is_feature_supported("rgbth"),
     ),
     DreoNumberEntityDescription(
         key="Ambient Light Threshold High",
@@ -177,13 +172,8 @@ NUMBERS: tuple[DreoNumberEntityDescription, ...] = (
         min_value=0,
         max_value=100,
         step=1,
-        exists_fn=lambda device: (
-            (
-                device.type
-                in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER}
-            )
-            and device.is_feature_supported("rgbth")
-        ),
+        exists_fn=lambda device: device.type in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER}
+        and device.is_feature_supported("rgbth"),
     ),
 )
 

--- a/custom_components/dreo/pydreo/constant.py
+++ b/custom_components/dreo/pydreo/constant.py
@@ -69,6 +69,7 @@ RGB_LEVEL = "rgblevel"
 RGB_TH = "rgbth"
 RGB_MODE = "rgbmode"
 RGB_COLOR = "rgbcolor"
+RGB_BRI = "rgbbri"
 LED_LEVEL_KEY = "ledlevel"
 SCHEDULE_ENABLE = "scheon"
 
@@ -165,6 +166,7 @@ TEMP_RANGE = "temp_range"
 TARGET_TEMP_RANGE = "target_temp_range"
 TARGET_TEMP_RANGE_ECO = "target_temp_range_eco"
 HUMIDITY_RANGE = "humidity_range"
+RGB_MODE_RANGE = "rgb_mode_range"
 
 
 class TemperatureUnit(Enum):

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -21,6 +21,7 @@ from .constant import (
     DreoACMode,
     DreoACFanMode,
     POWERON_KEY,
+    RGB_MODE_RANGE,
 )
 
 COOKING_MODES = [
@@ -90,6 +91,7 @@ class DreoDeviceDetails:
         cooking_range: dict = None,
         override_fn: Callable | None = None,
         ambient_light_levels: tuple | None = None,
+        rgbmode_options: list[str] = None,
     ):
         if device_type is None:
             raise ValueError("device_type is required")
@@ -106,6 +108,7 @@ class DreoDeviceDetails:
         self.cooking_range = cooking_range
         self.override_fn = override_fn
         self.ambient_light_levels = ambient_light_levels
+        self.rgbmode_options = rgbmode_options
 
 
 @dataclass
@@ -519,6 +522,8 @@ SUPPORTED_DEVICES = {
     # DR-HEC006S is the TurboCool Misting Fan 516S.
     # controlsConf is empty so speed range and preset modes must be hardcoded.
     # DR-HEC006S has +/-75° oscillation range and the turbo-mode is 4
+    # DR-HEC006S supports rgbmode (0=humidity indicator, 1=fixed color, 2=breathing, 3=cycling),
+    # rgbcolor, and rgbth (humidity thresholds).  Brightness is low/mid/high.
     # Asymmetric horizontal oscillation is also supported with left/right angles
     "DR-HEC006S": DreoDeviceDetails(
         device_type=DreoDeviceType.EVAPORATIVE_COOLER,
@@ -528,7 +533,9 @@ SUPPORTED_DEVICES = {
             HORIZONTAL_ANGLE_RANGE: (-75, 75),
             "horizontal_osc_angle_left_range": (-75, 75),
             "horizontal_osc_angle_right_range": (-75, 75),
+            RGB_MODE_RANGE: (0, 3),
         },
+        ambient_light_levels=(0, 1, 2, 3),
     ),
     # DR-HEC005S is the TurboCool Misting Fan 765S.
     # It has 12 fan speeds and can expose an empty controlsConf.

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -91,7 +91,6 @@ class DreoDeviceDetails:
         cooking_range: dict = None,
         override_fn: Callable | None = None,
         ambient_light_levels: tuple | None = None,
-        rgbmode_options: list[str] = None,
     ):
         if device_type is None:
             raise ValueError("device_type is required")
@@ -108,7 +107,6 @@ class DreoDeviceDetails:
         self.cooking_range = cooking_range
         self.override_fn = override_fn
         self.ambient_light_levels = ambient_light_levels
-        self.rgbmode_options = rgbmode_options
 
 
 @dataclass

--- a/custom_components/dreo/pydreo/pydreoevaporativecooler.py
+++ b/custom_components/dreo/pydreo/pydreoevaporativecooler.py
@@ -15,8 +15,12 @@ from .constant import (
     LIGHTON_KEY,
     MODE_KEY,
     MUTEON_KEY,
+    RGB_LEVEL,
+    RGB_TH,
     RGB_COLOR,
     RGB_MODE,
+    RGB_MODE_RANGE,
+    RGB_BRI,
     TEMPOFFSET_KEY,
 )
 from .helpers import Helpers
@@ -87,13 +91,27 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
         self._display_auto_off = None
         self._water_level = None
         self._fog_level = None
+        self._rgblevel = None
+        self._rgbth = None
         self._rgb_light_on = None
         self._rgbmode = None
         self._rgbcolor = None
+        self._rgbbri = None
         self._light_on = None
         self._suspend = None
         self._horizontal_angle = None
         self._horizontal_angle_range = None
+        self._rgb_mode_range = None
+        if device_definition.device_ranges is not None and RGB_MODE_RANGE in device_definition.device_ranges:
+            self._rgb_mode_range = device_definition.device_ranges[RGB_MODE_RANGE]
+        if self._rgb_mode_range is not None:
+            if self._rgb_mode_range[1] == 3:
+                self.rgbmode_options = [
+                    ("humidity"),
+                    ("color"),
+                    ("breath"),
+                    ("cycle"),
+                ]
 
     def parse_preset_modes(self, details: Dict[str, list]) -> tuple[str, int]:
         # Not needed atm
@@ -139,6 +157,8 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
     @target_humidity.setter
     def target_humidity(self, value: int) -> None:
         """Set the target humidity"""
+        # value must be an int if sent to the device, otherwise an error comes up
+        value = int(value)
         _LOGGER.debug("target_humidity: target_humidity.setter(%s) %s --> %s", self, self._target_humidity, value)
         if self._target_humidity == value:
             _LOGGER.debug("target_humidity: target_humidity - value already %s, skipping command", value)
@@ -147,7 +167,8 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
         self._send_command(HUMIDITY_TARGET_KEY, value)
 
     @property
-    def fog_level(self) -> int | None:
+    # use property mist_level to show select-box in UI, but keep fog_level commands
+    def mist_level(self) -> int | None:
         """Return the misting level."""
         return self._fog_level
 
@@ -159,8 +180,9 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
             return range_from_definition
         return (1, 3)
 
-    @fog_level.setter
-    def fog_level(self, value: int) -> None:
+    @mist_level.setter
+    # use property mist_level to show select-box in UI, but keep fog_level commands
+    def mist_level(self, value: int) -> None:
         """Set the misting level."""
         level = int(value)
         min_level, max_level = self.fog_level_range
@@ -261,12 +283,25 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
         """Return a compatibility RGB light level for the ambient light entity."""
         if self._rgb_light_on is None:
             return None
+        # DR-HEC006S uses rgbbri for light intensities
+        if self._rgbbri is not None:
+            return self._rgbbri if self._rgb_light_on else 0
         return 1 if self._rgb_light_on else 0
 
     @rgblevel.setter
     def rgblevel(self, value: int) -> None:
         """Map ambient light on/off requests onto the device's rgbon field."""
         desired_on = int(value) > 0
+        if self._rgbbri is not None:
+            if self._rgbbri == value:
+                _LOGGER.debug(
+                    "rgblevel: rgblevel - value already %s, skipping command",
+                    value,
+                )
+                return
+            self._rgbbri = value
+            self._send_command(RGB_BRI, value)
+            return
         if self._rgb_light_on == desired_on:
             _LOGGER.debug("rgblevel: rgblevel - value already %s, skipping command", desired_on)
             return
@@ -300,6 +335,53 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
             return
         self._rgbcolor = value
         self._send_command(RGB_COLOR, value)
+
+    @property
+    def rgbth(self):
+        """Return raw rgbth string (e.g. '30,65') for ambient light thresholds."""
+        return self._rgbth
+
+    @property
+    def rgbth_low(self) -> int | None:
+        """Return low humidity threshold for ambient light."""
+        if not self._rgbth or not isinstance(self._rgbth, str) or "," not in self._rgbth:
+            return None
+        try:
+            low_str, _ = self._rgbth.split(",", 1)
+            return int(low_str.strip())
+        except (ValueError, AttributeError):
+            return None
+
+    @rgbth_low.setter
+    def rgbth_low(self, value: int) -> None:
+        """Set low humidity threshold for ambient light."""
+        high = self.rgbth_high if self.rgbth_high is not None else 0
+        payload = f"{int(value)},{high}"
+        if self._rgbth == payload:
+            return
+        self._rgbth = payload  # optimistic update
+        self._send_command(RGB_TH, payload)
+
+    @property
+    def rgbth_high(self) -> int | None:
+        """Return high humidity threshold for ambient light."""
+        if not self._rgbth or not isinstance(self._rgbth, str) or "," not in self._rgbth:
+            return None
+        try:
+            _, high_str = self._rgbth.split(",", 1)
+            return int(high_str.strip())
+        except (ValueError, AttributeError):
+            return None
+
+    @rgbth_high.setter
+    def rgbth_high(self, value: int) -> None:
+        """Set high humidity threshold for ambient light."""
+        low = self.rgbth_low if self.rgbth_low is not None else 0
+        payload = f"{low},{int(value)}"
+        if self._rgbth == payload:
+            return
+        self._rgbth = payload  # optimistic update
+        self._send_command(RGB_TH, payload)
 
     @property
     def work_time(self) -> int:
@@ -362,11 +444,14 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
         # Send as "left,right" via hoscangle key
         if current_right is not None:
             self._send_command(HORIZONTAL_OSCILLATION_ANGLE_KEY, f"{angle},{current_right}")
+            self._horizontal_angle_range = (angle, current_right)
 
     @property
     def horizontal_osc_angle_left_range(self) -> tuple[int, int] | None:
         """Return the supported left horizontal oscillation angle range."""
-        range_from_definition = self._device_definition.device_ranges.get("horizontal_osc_angle_left_range") if self._device_definition.device_ranges else None
+        range_from_definition = (
+            self._device_definition.device_ranges.get("horizontal_osc_angle_left_range") if self._device_definition.device_ranges else None
+        )
         if range_from_definition is not None:
             return range_from_definition
         # Fall back to horizontal angle range if available
@@ -397,11 +482,14 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
         # Send as "left,right" via hoscangle key
         if current_left is not None:
             self._send_command(HORIZONTAL_OSCILLATION_ANGLE_KEY, f"{current_left},{angle}")
+            self._horizontal_angle_range = (current_left, angle)
 
     @property
     def horizontal_osc_angle_right_range(self) -> tuple[int, int] | None:
         """Return the supported right horizontal oscillation angle range."""
-        range_from_definition = self._device_definition.device_ranges.get("horizontal_osc_angle_right_range") if self._device_definition.device_ranges else None
+        range_from_definition = (
+            self._device_definition.device_ranges.get("horizontal_osc_angle_right_range") if self._device_definition.device_ranges else None
+        )
         if range_from_definition is not None:
             return range_from_definition
         # Fall back to horizontal angle range if available
@@ -458,9 +546,12 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
         self._work_time = self.get_state_update_value(state, WORKTIME_KEY)
         self._water_level = self.get_state_update_value_mapped(state, WATER_LEVEL_STATUS_KEY, WATER_LEVEL_STATUS_MAP)
         self._fog_level = self.get_state_update_value(state, FOG_LEVEL_KEY)
+        self._rgblevel = self.get_state_update_value(state, RGB_LEVEL)
+        self._rgbth = self.get_state_update_value(state, RGB_TH)
         self._rgb_light_on = self.get_state_update_value(state, RGB_ON_KEY)
         self._rgbmode = self.get_state_update_value(state, RGB_MODE)
         self._rgbcolor = self.get_state_update_value(state, RGB_COLOR)
+        self._rgbbri = self.get_state_update_value(state, RGB_BRI)
         self._light_on = self.get_state_update_value(state, LIGHTON_KEY)
         self._suspend = self.get_state_update_value(state, HUMIDIFY_SUSPEND_KEY)
         self._horizontal_angle = self.get_state_update_value(state, HORIZONTAL_ANGLE_ADJ_KEY)
@@ -521,6 +612,14 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
         if isinstance(val_rgb_light_on, bool):
             self._rgb_light_on = val_rgb_light_on
 
+        val_rgblevel = self.get_server_update_key_value(message, RGB_LEVEL)
+        if isinstance(val_rgblevel, int):
+            self._rgblevel = val_rgblevel
+
+        val_rgbth = self.get_server_update_key_value(message, RGB_TH)
+        if isinstance(val_rgbth, str):
+            self._rgbth = val_rgbth
+
         val_rgbmode = self.get_server_update_key_value(message, RGB_MODE)
         if isinstance(val_rgbmode, int):
             self._rgbmode = val_rgbmode
@@ -528,6 +627,10 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
         val_rgbcolor = self.get_server_update_key_value(message, RGB_COLOR)
         if isinstance(val_rgbcolor, int):
             self._rgbcolor = val_rgbcolor
+
+        val_rgbbri = self.get_server_update_key_value(message, RGB_BRI)
+        if isinstance(val_rgbbri, int):
+            self._rgbbri = val_rgbbri
 
         val_light_on = self.get_server_update_key_value(message, LIGHTON_KEY)
         if isinstance(val_light_on, bool):

--- a/custom_components/dreo/pydreo/pydreoevaporativecooler.py
+++ b/custom_components/dreo/pydreo/pydreoevaporativecooler.py
@@ -293,16 +293,19 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
         """Map ambient light on/off requests onto the device's rgbon field."""
         desired_on = int(value) > 0
         if self._rgbbri is not None:
-            if self._rgbbri == value:
-                _LOGGER.debug(
-                    "rgblevel: rgblevel - value already %s, skipping command",
-                    value,
-                )
+            level = int(value)
+            if self._rgb_light_on != desired_on:
+                self._rgb_light_on = desired_on
+                self._send_command(RGB_ON_KEY, desired_on)
+            if not desired_on:
                 return
-            self._rgbbri = value
-            self._send_command(RGB_BRI, value)
+            if self._rgbbri == level:
+                _LOGGER.debug("rgblevel: rgblevel - value already %s, skipping command", level)
+                return
+            self._rgbbri = level
+            self._send_command(RGB_BRI, level)
             return
-        if self._rgb_light_on == desired_on:
+    if self._rgb_light_on == desired_on:
             _LOGGER.debug("rgblevel: rgblevel - value already %s, skipping command", desired_on)
             return
         self._rgb_light_on = desired_on

--- a/custom_components/dreo/pydreo/pydreoevaporativecooler.py
+++ b/custom_components/dreo/pydreo/pydreoevaporativecooler.py
@@ -106,12 +106,7 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
             self._rgb_mode_range = device_definition.device_ranges[RGB_MODE_RANGE]
         if self._rgb_mode_range is not None:
             if self._rgb_mode_range[1] == 3:
-                self.rgbmode_options = [
-                    ("humidity"),
-                    ("color"),
-                    ("breath"),
-                    ("cycle"),
-                ]
+                self.rgbmode_options = ["humidity", "color", "breath", "cycle"]
 
     def parse_preset_modes(self, details: Dict[str, list]) -> tuple[str, int]:
         # Not needed atm
@@ -167,8 +162,7 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
         self._send_command(HUMIDITY_TARGET_KEY, value)
 
     @property
-    # use property mist_level to show select-box in UI, but keep fog_level commands
-    def mist_level(self) -> int | None:
+    def fog_level(self) -> int | None:
         """Return the misting level."""
         return self._fog_level
 
@@ -180,9 +174,8 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
             return range_from_definition
         return (1, 3)
 
-    @mist_level.setter
-    # use property mist_level to show select-box in UI, but keep fog_level commands
-    def mist_level(self, value: int) -> None:
+    @fog_level.setter
+    def fog_level(self, value: int) -> None:
         """Set the misting level."""
         level = int(value)
         min_level, max_level = self.fog_level_range
@@ -305,7 +298,7 @@ class PyDreoEvaporativeCooler(PyDreoFanBase):
             self._rgbbri = level
             self._send_command(RGB_BRI, level)
             return
-    if self._rgb_light_on == desired_on:
+        if self._rgb_light_on == desired_on:
             _LOGGER.debug("rgblevel: rgblevel - value already %s, skipping command", desired_on)
             return
         self._rgb_light_on = desired_on

--- a/custom_components/dreo/select.py
+++ b/custom_components/dreo/select.py
@@ -40,8 +40,10 @@ SELECTS: tuple[DreoSelectEntityDescription, ...] = (
         icon="mdi:weather-windy",
         options_list=["low", "medium", "high"],
         raw_values=[1, 2, 3],
-        exists_fn=lambda device: device.type in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER} 
-        and device.is_feature_supported("mist_level"),
+        exists_fn=lambda device: (
+            device.type in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER}
+            and device.is_feature_supported("mist_level")
+        ),
     ),
     DreoSelectEntityDescription(
         key="Ambient Light Mode",

--- a/custom_components/dreo/select.py
+++ b/custom_components/dreo/select.py
@@ -40,7 +40,8 @@ SELECTS: tuple[DreoSelectEntityDescription, ...] = (
         icon="mdi:weather-windy",
         options_list=["low", "medium", "high"],
         raw_values=[1, 2, 3],
-        exists_fn=lambda device: device.type == DreoDeviceType.HUMIDIFIER and device.is_feature_supported("mist_level"),
+        exists_fn=lambda device: device.type in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER} 
+        and device.is_feature_supported("mist_level"),
     ),
     DreoSelectEntityDescription(
         key="Ambient Light Mode",
@@ -48,7 +49,7 @@ SELECTS: tuple[DreoSelectEntityDescription, ...] = (
         attr_name="rgbmode",
         icon="mdi:lightbulb-cog",
         options_list=["humidity", "color"],
-        raw_values=[0, 1],
+        raw_values=[0, 1, 2, 3],
         exists_fn=lambda device: device.type in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER}
         and device.is_feature_supported("rgbmode"),
     ),

--- a/custom_components/dreo/select.py
+++ b/custom_components/dreo/select.py
@@ -40,10 +40,7 @@ SELECTS: tuple[DreoSelectEntityDescription, ...] = (
         icon="mdi:weather-windy",
         options_list=["low", "medium", "high"],
         raw_values=[1, 2, 3],
-        exists_fn=lambda device: (
-            device.type in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER}
-            and device.is_feature_supported("mist_level")
-        ),
+        exists_fn=lambda device: device.type == DreoDeviceType.HUMIDIFIER and device.is_feature_supported("mist_level"),
     ),
     DreoSelectEntityDescription(
         key="Ambient Light Mode",
@@ -51,7 +48,7 @@ SELECTS: tuple[DreoSelectEntityDescription, ...] = (
         attr_name="rgbmode",
         icon="mdi:lightbulb-cog",
         options_list=["humidity", "color"],
-        raw_values=[0, 1, 2, 3],
+        raw_values=[0, 1],
         exists_fn=lambda device: device.type in {DreoDeviceType.HUMIDIFIER, DreoDeviceType.EVAPORATIVE_COOLER}
         and device.is_feature_supported("rgbmode"),
     ),
@@ -106,13 +103,23 @@ class DreoSelectHA(DreoBaseDeviceHA, SelectEntity):
         self._attr_unique_id = f"{super().unique_id}-{description.key}"
         self._attr_options = self._get_device_options()
 
-    def _get_device_options(self) -> list[str]:
-        """Return current options list for this select."""
+    def _dynamic_options(self) -> list[str] | None:
+        """Return the device-provided options list, if any.
+
+        When a device exposes a `{attr_name}_options` list, the raw device value is treated
+        as the index into that list.  This lets a single entity description adapt to devices
+        that support a different number of options (e.g. DR-HEC006S exposes four ambient light
+        modes while humidifiers expose two).
+        """
         options_attr_name = f"{self.entity_description.attr_name}_options"
         options = getattr(self.device, options_attr_name, None)
         if isinstance(options, list) and len(options) > 0:
             return options
-        return self.entity_description.options_list
+        return None
+
+    def _get_device_options(self) -> list[str]:
+        """Return current options list for this select."""
+        return self._dynamic_options() or self.entity_description.options_list
 
     @property
     def options(self) -> list[str]:
@@ -126,6 +133,15 @@ class DreoSelectHA(DreoBaseDeviceHA, SelectEntity):
         raw = getattr(self.device, self.entity_description.attr_name)
         if raw is None:
             return None
+        # For int-coded selects (those declaring raw_values), a device-provided options list
+        # means the raw value is the index into that list.  This lets one entity adapt to a
+        # variable number of options (e.g. DR-HEC006S exposes four ambient light modes).
+        dynamic = self._dynamic_options()
+        if dynamic is not None and len(self.entity_description.raw_values) > 0:
+            try:
+                return dynamic[int(raw)]
+            except (ValueError, IndexError):
+                return None
         if len(self.entity_description.raw_values) == 0:
             return str(raw)
         try:
@@ -136,6 +152,14 @@ class DreoSelectHA(DreoBaseDeviceHA, SelectEntity):
 
     def select_option(self, option: str) -> None:
         """Set a new option."""
+        # For int-coded selects with a device-provided options list, the list index is the raw value.
+        dynamic = self._dynamic_options()
+        if dynamic is not None and len(self.entity_description.raw_values) > 0:
+            try:
+                setattr(self.device, self.entity_description.attr_name, dynamic.index(option))
+            except ValueError:
+                return
+            return
         if len(self.entity_description.raw_values) == 0:
             setattr(self.device, self.entity_description.attr_name, option)
             return

--- a/custom_components/dreo/strings.json
+++ b/custom_components/dreo/strings.json
@@ -271,7 +271,9 @@
         "name": "Ambient Light Mode",
         "state": {
           "humidity": "Humidity",
-          "color": "Color"
+          "color": "Color",
+          "breath": "Breath",
+          "cycle": "Cycle"
         }
       },
       "three_d_angle_preset": {

--- a/custom_components/dreo/translations/bg.json
+++ b/custom_components/dreo/translations/bg.json
@@ -260,7 +260,9 @@
         "name": "Режим на ambient осветление",
         "state": {
           "humidity": "Влажност",
-          "color": "Цвят"
+          "color": "Цвят",
+          "breath": "Дишай",
+          "cycle": "циклично"
         }
       },
       "three_d_angle_preset": {

--- a/custom_components/dreo/translations/de.json
+++ b/custom_components/dreo/translations/de.json
@@ -260,7 +260,9 @@
         "name": "Umgebungslicht-Modus",
         "state": {
           "humidity": "Feuchtigkeit",
-          "color": "Farbe"
+          "color": "Farbe",
+          "breath": "Atmen",
+          "cycle": "Zyklus"
         }
       },
       "three_d_angle_preset": {

--- a/custom_components/dreo/translations/en.json
+++ b/custom_components/dreo/translations/en.json
@@ -260,7 +260,9 @@
         "name": "Ambient Light Mode",
         "state": {
           "humidity": "Humidity",
-          "color": "Color"
+          "color": "Color",
+          "breath": "Breath",
+          "cycle": "Cycle"
         }
       },
       "three_d_angle_preset": {

--- a/custom_components/dreo/translations/es.json
+++ b/custom_components/dreo/translations/es.json
@@ -260,7 +260,9 @@
         "name": "Modo de luz ambiental",
         "state": {
           "humidity": "Humedad",
-          "color": "Color"
+          "color": "Color",
+          "breath": "Respirar",
+          "cycle": "cíclicas"
         }
       },
       "three_d_angle_preset": {

--- a/custom_components/dreo/translations/fr.json
+++ b/custom_components/dreo/translations/fr.json
@@ -260,7 +260,9 @@
         "name": "Mode lumière d'ambiance",
         "state": {
           "humidity": "Humidité",
-          "color": "Couleur"
+          "color": "Couleur",
+          "breath": "Respirer",
+          "cycle": "cyclique"
         }
       },
       "three_d_angle_preset": {

--- a/custom_components/dreo/translations/it.json
+++ b/custom_components/dreo/translations/it.json
@@ -260,7 +260,9 @@
         "name": "Modalità luce ambientale",
         "state": {
           "humidity": "Umidità",
-          "color": "Colore"
+          "color": "Colore",
+          "breath": "Respirare",
+          "cycle": "cicliche"
         }
       },
       "three_d_angle_preset": {

--- a/custom_components/dreo/translations/nl.json
+++ b/custom_components/dreo/translations/nl.json
@@ -260,7 +260,9 @@
         "name": "Sfeerverlichtingsmodus",
         "state": {
           "humidity": "Vochtigheid",
-          "color": "Kleur"
+          "color": "Kleur",
+          "breath": "Ademen",
+          "cycle": "cyclisch"
         }
       },
       "three_d_angle_preset": {

--- a/custom_components/dreo/translations/pl.json
+++ b/custom_components/dreo/translations/pl.json
@@ -260,7 +260,9 @@
         "name": "Tryb światła otoczenia",
         "state": {
           "humidity": "Wilgotność",
-          "color": "Kolor"
+          "color": "Kolor",
+          "breath": "Oddychać",
+          "cycle": "cyklicznie"
         }
       },
       "three_d_angle_preset": {

--- a/tests/dreo/integrationtests/test_dreoevaporativecooler.py
+++ b/tests/dreo/integrationtests/test_dreoevaporativecooler.py
@@ -10,7 +10,7 @@ from custom_components.dreo import select
 from custom_components.dreo import sensor
 from custom_components.dreo import switch
 from .imports import *  # pylint: disable=W0401,W0614
-from .integrationtestbase import IntegrationTestBase
+from .integrationtestbase import IntegrationTestBase, PATCH_SEND_COMMAND
 
 PATCH_BASE_PATH = "homeassistant.helpers.entity.Entity"
 PATCH_SCHEDULE_UPDATE_HA_STATE = f"{PATCH_BASE_PATH}.schedule_update_ha_state"
@@ -51,7 +51,7 @@ class TestDreoEvaporativeCoolers(IntegrationTestBase):
                 assert len(pydreo_ec.preset_modes) > 0
 
             numbers = number.get_entries([pydreo_ec])
-            self.verify_expected_entities(numbers, ["Target Humidity"])
+            self.verify_expected_entities(numbers, ["Ambient Light Threshold Low", "Ambient Light Threshold High", "Target Humidity"])
 
             sensors = sensor.get_entries([pydreo_ec])
             self.verify_expected_entities(sensors, ["Temperature", 'Target Humidity Reached', "Humidity", "Use since cleaning"])
@@ -93,7 +93,15 @@ class TestDreoEvaporativeCoolers(IntegrationTestBase):
             numbers = number.get_entries([pydreo_ec])
             self.verify_expected_entities(
                 numbers,
-                ["Fog Level", "Horizontal Angle", "Horizontal Oscillation Angle Left", "Horizontal Oscillation Angle Right", "Target Humidity"],
+                [
+                    "Ambient Light Threshold Low",
+                    "Ambient Light Threshold High",
+                    "Fog Level",
+                    "Horizontal Angle",
+                    "Horizontal Oscillation Angle Left",
+                    "Horizontal Oscillation Angle Right",
+                    "Target Humidity",
+                ],
             )
 
             sensors = sensor.get_entries([pydreo_ec])
@@ -107,6 +115,20 @@ class TestDreoEvaporativeCoolers(IntegrationTestBase):
 
             selects = select.get_entries([pydreo_ec])
             self.verify_expected_entities(selects, ["Ambient Light Mode"])
+
+            # The Ambient Light Mode select exposes all four DR-HEC006S modes and can read/write
+            # each of them (regression: modes 2/3 previously rendered blank and were unselectable).
+            ambient_mode = next(s for s in selects if s.entity_description.key == "Ambient Light Mode")
+            assert ambient_mode.options == ["humidity", "color", "breath", "cycle"]
+            # Fixture reports rgbmode=0 -> "humidity".
+            assert ambient_mode.current_option == "humidity"
+            with patch(PATCH_SEND_COMMAND):
+                ambient_mode.select_option("breath")
+                assert pydreo_ec.rgbmode == 2
+                assert ambient_mode.current_option == "breath"
+                ambient_mode.select_option("cycle")
+                assert pydreo_ec.rgbmode == 3
+                assert ambient_mode.current_option == "cycle"
 
     def test_HEC005S_fog_level_range(self):  # pylint: disable=invalid-name
         """Load HEC005S and verify fog level slider range includes level 4."""

--- a/tests/pydreo/test_pydreoevaporativecooler.py
+++ b/tests/pydreo/test_pydreoevaporativecooler.py
@@ -18,6 +18,8 @@ from custom_components.dreo.pydreo.pydreoevaporativecooler import (
     RGB_ON_KEY,
     RGB_COLOR,
     RGB_MODE,
+    RGB_BRI,
+    RGB_TH,
     WATER_LEVEL_STATUS_KEY,
     WORKTIME_KEY,
 )
@@ -313,9 +315,13 @@ class TestPyDreoEvaporativeCooler(TestBase):
             ec_fan.display_light = False
             mock_send_command.assert_called_once_with(ec_fan, {LIGHTON_KEY: False})
 
+        # DR-HEC006S maps rgblevel onto rgbon + rgbbri: turning the light on at level 1
+        # sends both the power (rgbon) and brightness (rgbbri) commands.
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             ec_fan.rgblevel = 1
-            mock_send_command.assert_called_once_with(ec_fan, {RGB_ON_KEY: True})
+            mock_send_command.assert_any_call(ec_fan, {RGB_ON_KEY: True})
+            mock_send_command.assert_any_call(ec_fan, {RGB_BRI: 1})
+            assert mock_send_command.call_count == 2
 
         with patch(PATCH_SEND_COMMAND) as mock_send_command:
             ec_fan.rgbmode = 1
@@ -406,7 +412,8 @@ class TestPyDreoEvaporativeCooler(TestBase):
         assert ec_fan.display_light is False
 
         ec_fan.handle_server_update({REPORTED_KEY: {RGB_ON_KEY: True}})
-        assert ec_fan.rgblevel == 1
+        # DR-HEC006S reports rgbbri=3 in the fixture, so rgblevel reflects that brightness once on.
+        assert ec_fan.rgblevel == 3
 
         ec_fan.handle_server_update({REPORTED_KEY: {RGB_MODE: 1}})
         assert ec_fan.rgbmode == 1
@@ -452,3 +459,91 @@ class TestPyDreoEvaporativeCooler(TestBase):
 
         with pytest.raises(ValueError):
             ec_fan.fog_level = 5
+
+    def test_HEC006S_rgbbri_brightness(self):  # pylint: disable=invalid-name
+        """DR-HEC006S maps ambient light brightness onto the rgbbri field."""
+        self.get_devices_file_name = "get_devices_HEC006S.json"
+        self.pydreo_manager.load_devices()
+        ec_fan: PyDreoEvaporativeCooler = self.pydreo_manager.devices[0]
+
+        # Fixture: rgbbri=3, rgbon=false -> compatibility level reports 0 while the light is off.
+        assert ec_fan._rgbbri == 3
+        assert ec_fan._rgb_light_on is False
+        assert ec_fan.rgblevel == 0
+
+        # Turning on at a new brightness sends both rgbon and rgbbri.
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            ec_fan.rgblevel = 2
+            mock_send_command.assert_any_call(ec_fan, {RGB_ON_KEY: True})
+            mock_send_command.assert_any_call(ec_fan, {RGB_BRI: 2})
+            assert mock_send_command.call_count == 2
+        assert ec_fan.rgblevel == 2
+
+        # Turning off sends only rgbon False and leaves rgbbri untouched.
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            ec_fan.rgblevel = 0
+            mock_send_command.assert_called_once_with(ec_fan, {RGB_ON_KEY: False})
+        assert ec_fan._rgbbri == 2
+        assert ec_fan.rgblevel == 0
+
+        # Re-enabling at the same brightness only needs to toggle rgbon back on.
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            ec_fan.rgblevel = 2
+            mock_send_command.assert_called_once_with(ec_fan, {RGB_ON_KEY: True})
+
+    def test_HEC006S_rgbth_thresholds(self):  # pylint: disable=invalid-name
+        """DR-HEC006S exposes ambient light humidity thresholds via rgbth ('low,high')."""
+        self.get_devices_file_name = "get_devices_HEC006S.json"
+        self.pydreo_manager.load_devices()
+        ec_fan: PyDreoEvaporativeCooler = self.pydreo_manager.devices[0]
+
+        # Fixture rgbth = "30,70".
+        assert ec_fan.rgbth == "30,70"
+        assert ec_fan.rgbth_low == 30
+        assert ec_fan.rgbth_high == 70
+
+        # Setting the low threshold preserves the high value and sends the combined payload.
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            ec_fan.rgbth_low = 40
+            mock_send_command.assert_called_once_with(ec_fan, {RGB_TH: "40,70"})
+        assert ec_fan.rgbth_low == 40
+
+        # Setting the high threshold preserves the low value.
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            ec_fan.rgbth_high = 80
+            mock_send_command.assert_called_once_with(ec_fan, {RGB_TH: "40,80"})
+        assert ec_fan.rgbth_high == 80
+
+        # rgbth is also updated from WebSocket reports.
+        ec_fan.handle_server_update({REPORTED_KEY: {RGB_TH: "25,65"}})
+        assert ec_fan.rgbth_low == 25
+        assert ec_fan.rgbth_high == 65
+
+    def test_HEC006S_rgbmode_options_and_selection(self):  # pylint: disable=invalid-name
+        """DR-HEC006S advertises four ambient light modes and can select each one."""
+        self.get_devices_file_name = "get_devices_HEC006S.json"
+        self.pydreo_manager.load_devices()
+        ec_fan: PyDreoEvaporativeCooler = self.pydreo_manager.devices[0]
+
+        assert ec_fan.rgbmode_options == ["humidity", "color", "breath", "cycle"]
+
+        # Modes 2 (breath) and 3 (cycle) round-trip through the setter.
+        with patch(PATCH_SEND_COMMAND) as mock_send_command:
+            ec_fan.rgbmode = 2
+            mock_send_command.assert_called_once_with(ec_fan, {RGB_MODE: 2})
+        assert ec_fan.rgbmode == 2
+
+        ec_fan.handle_server_update({REPORTED_KEY: {RGB_MODE: 3}})
+        assert ec_fan.rgbmode == 3
+
+    def test_HEC006S_rgbbri_from_server_update(self):  # pylint: disable=invalid-name
+        """rgbbri brightness is updated from WebSocket reports."""
+        self.get_devices_file_name = "get_devices_HEC006S.json"
+        self.pydreo_manager.load_devices()
+        ec_fan: PyDreoEvaporativeCooler = self.pydreo_manager.devices[0]
+
+        ec_fan.handle_server_update({REPORTED_KEY: {RGB_ON_KEY: True, RGB_BRI: 1}})
+        assert ec_fan.rgblevel == 1
+        ec_fan.handle_server_update({REPORTED_KEY: {RGB_BRI: 3}})
+        assert ec_fan.rgblevel == 3
+


### PR DESCRIPTION
Extends and fixes DR-HEC006S evaporative cooler support. This is a cleaned-up copy of #841 by @harrymayr (their commits are preserved in this branch's history for authorship credit), with all code-review feedback resolved and the missing test coverage added.

## What this adds
- **Ambient Light modes**: full support for all four modes — Humidity, Color, Breath, Cycle — for DR-HEC006S.
- **Ambient Light brightness**: N-level brightness mapping via `rgbbri`.
- **Ambient Light thresholds**: Low/High humidity threshold Number entities for evaporative coolers.
- **Target humidity** `int()` cast fix.

## Review feedback resolved (from #841)
- Fixed an `IndentationError` in the `rgblevel` setter that broke ruff/pytest/hassfest.
- Kept **Fog Level** as a Number entity (reverted the `fog_level`→`mist_level` rename and the Number→Select swap) so variable ranges keep working (e.g. DR-HEC005S `fog_level_range` (1,4)).
- Reworked the Ambient Light Mode select to map read/write through the device's **dynamic `{attr}_options` list** (raw value == list index) for int-coded selects, instead of hardcoded `raw_values`. Humidifiers keep their 2 modes; string-coded selects (3D Angle Preset) are unaffected.
- Simplified the threshold `exists_fn` lambdas.

## Tests
- Updated existing HEC006S unit + integration tests for the new brightness model and threshold entities.
- Added coverage for `rgbbri` brightness, `rgbth` low/high thresholds, the four-mode ambient-light select (read + write of breath/cycle), and `rgbbri`/`rgbth`/`rgbmode` WebSocket updates.

All 878 tests pass; `ruff check .` clean.

Credit: @harrymayr (original PR #841). Supersedes #841.
