### PR TITLE
Configure Puppets automation

### DIFF
--- a/.github/workflows/puppets.yml
+++ b/.github/workflows/puppets.yml
@@ -1,0 +1,49 @@
+name: Puppets
+
+on:
+  # Stagger the minute across repositories to spread API and model traffic.
+  schedule:
+    - cron: "0 16 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Report intended mutations without applying them
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: puppets-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  # The reusable workflow cannot elevate beyond these caller-granted permissions.
+  actions: write
+  # Read is enough while every profile uses the default `copilot` provider. Change to
+  # `write` only if a workflow profile sets `implementation.provider: claude` or `codex` —
+  # the `implement` job needs it to push branches and open pull requests for those
+  # providers, and a reusable workflow can never be granted more than the caller allows here.
+  contents: read
+  # Lets the reusable workflow identify its exact GitHub-resolved commit.
+  id-token: write
+  issues: write
+  pull-requests: write
+  copilot-requests: write
+
+jobs:
+  reconcile:
+    uses: JeffSteinbok/puppets/.github/workflows/reconcile.yml@v1
+    with:
+      dry_run: ${{ inputs.dry_run || false }}
+      caller_workflow: puppets.yml
+    secrets:
+      # Required when a profile uses Copilot. GitHub App installation tokens, including
+      # GITHUB_TOKEN, cannot assign coding agents; use a repository-scoped user token.
+      token: ${{ secrets.PUPPETS_TOKEN }}
+      # Optional: only required if a workflow profile sets implementation.provider to
+      # `claude` or `codex`. Uncomment the secrets for whichever provider(s) you use, and
+      # remember to also set `permissions.contents: write` above. See docs/configuration.md
+      # and docs/getting-started.md for setup and dry-run testing steps.
+      # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+      # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      # openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.puppets/config.json
+++ b/.puppets/config.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "approvalActors": [
+    "JeffSteinbok"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the repository-local Puppets caller workflow
- add the minimal trusted policy with JeffSteinbok as the approval actor
- use the default Copilot implementation provider through Puppets v1

## Rollout
After merge, run the workflow once with dry_run=true before approving any issue.

Generated with the Puppets npm installer.