### PR TITLE
Grant Puppets provider job permissions

### DIFF
--- a/.github/workflows/puppets.yml
+++ b/.github/workflows/puppets.yml
@@ -19,11 +19,9 @@ concurrency:
 permissions:
   # The reusable workflow cannot elevate beyond these caller-granted permissions.
   actions: write
-  # Read is enough while every profile uses the default `copilot` provider. Change to
-  # `write` only if a workflow profile sets `implementation.provider: claude` or `codex` —
-  # the `implement` job needs it to push branches and open pull requests for those
-  # providers, and a reusable workflow can never be granted more than the caller allows here.
-  contents: read
+  # GitHub validates the reusable workflow's provider job before evaluating whether it will
+  # run, so every caller must grant its declared maximum even when using Copilot only.
+  contents: write
   # Lets the reusable workflow identify its exact GitHub-resolved commit.
   id-token: write
   issues: write
@@ -41,9 +39,7 @@ jobs:
       # GITHUB_TOKEN, cannot assign coding agents; use a repository-scoped user token.
       token: ${{ secrets.PUPPETS_TOKEN }}
       # Optional: only required if a workflow profile sets implementation.provider to
-      # `claude` or `codex`. Uncomment the secrets for whichever provider(s) you use, and
-      # remember to also set `permissions.contents: write` above. See docs/configuration.md
-      # and docs/getting-started.md for setup and dry-run testing steps.
+      # `claude` or `codex`. Uncomment the secrets for whichever provider(s) you use.
       # anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
       # claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       # openai_api_key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
GitHub validates every nested reusable-workflow job before evaluating its condition. Grant the caller's declared contents permission so the Copilot-only dry run can start; the skipped provider job does not use the permission.