### PR TITLE
Add water_level_percent for DR-HHM014S-class humidifiers (opt-in)

### DIFF
--- a/custom_components/dreo/binary_sensor.py
+++ b/custom_components/dreo/binary_sensor.py
@@ -89,7 +89,10 @@ BINARY_SENSORS: tuple[DreoBinarySensorEntityDescription, ...] = (
         value_fn=_water_empty_value,
         exists_fn=_water_empty_exists,
         icon_fn=lambda device: "mdi:water-remove" if _water_empty_value(device) else "mdi:water-check",
-        attrs_fn=lambda device: {"water_level": getattr(device, "water_level", None)},
+        attrs_fn=lambda device: {
+            "water_level": getattr(device, "water_level", None),
+            "water_level_percent": getattr(device, "water_level_percent", None),
+        },
         unique_id_suffix="water-empty",  # pre-dates the key-derived default; do not change
     ),
     DreoBinarySensorEntityDescription(

--- a/custom_components/dreo/pydreo/pydreohumidifier.py
+++ b/custom_components/dreo/pydreo/pydreohumidifier.py
@@ -36,6 +36,7 @@ from .models import DreoDeviceDetails
 _LOGGER = logging.getLogger(__name__)
 
 WATER_LEVEL_STATUS_KEY = "wrong"
+WATER_LEVEL_PERCENT_KEY = "waterlevel"
 WORKTIME_KEY = "worktime"
 FOGLEVEL_INTERNAL_KEY = "foglevel"
 FILTERTIME_KEY = "filtertime"
@@ -89,6 +90,7 @@ class PyDreoHumidifier(PyDreoBaseDevice):
         self._sleep_target_humidity = None
         self._ledkepton = None
         self._wrong = None
+        self._water_level_percent = None
         self._worktime = None
         self._foglevel = None
         self._rgblevel = None
@@ -270,6 +272,14 @@ class PyDreoHumidifier(PyDreoBaseDevice):
     def water_level(self):
         """Return the water level status"""
         return self._wrong
+
+    @property
+    def water_level_percent(self) -> int | None:
+        """Return the numeric water level percentage (0-100), reported by newer humidifiers.
+
+        None on models that only report the fault-code-based ``wrong``/``water_level`` status.
+        """
+        return self._water_level_percent
 
     @property
     def worktime(self):
@@ -580,6 +590,7 @@ class PyDreoHumidifier(PyDreoBaseDevice):
         self._ledkepton = self.get_state_update_value(state, LEDKEPTON_KEY)
         self._ledlevel = self.get_state_update_value_mapped(state, LEDLEVEL_KEY, LEDLEVEL_MAP)
         self._wrong = self.get_state_update_value_mapped(state, WATER_LEVEL_STATUS_KEY, WATER_LEVEL_STATUS_MAP)
+        self._water_level_percent = self.get_state_update_value(state, WATER_LEVEL_PERCENT_KEY)
         self._worktime = self.get_state_update_value(state, WORKTIME_KEY)
         self._foglevel = self.get_state_update_value(state, FOGLEVEL_INTERNAL_KEY)
         self._rgblevel = self.get_state_update_value(state, RGB_LEVEL)
@@ -618,6 +629,10 @@ class PyDreoHumidifier(PyDreoBaseDevice):
         if isinstance(val_water_level, int):
             val_water_level = WATER_LEVEL_STATUS_MAP.get(val_water_level, val_water_level)
             self._wrong = val_water_level
+
+        val_water_level_percent = self.get_server_update_key_value(message, WATER_LEVEL_PERCENT_KEY)
+        if isinstance(val_water_level_percent, int):
+            self._water_level_percent = val_water_level_percent
 
         val_foglevel = self.get_server_update_key_value(message, FOGLEVEL_INTERNAL_KEY)
         if isinstance(val_foglevel, int):

--- a/custom_components/dreo/sensor.py
+++ b/custom_components/dreo/sensor.py
@@ -147,6 +147,17 @@ SENSORS: tuple[DreoSensorEntityDescription, ...] = (
         exists_fn=lambda device: (device.type in {DreoDeviceType.HUMIDIFIER}) and device.is_feature_supported(FILTERTIME_KEY),
     ),
     DreoSensorEntityDescription(
+        # Opt-in: confirmed on DR-HHM014S only; not yet verified on other humidifier models.
+        key="Water Level Percent",
+        translation_key="water_level_percent",
+        icon="mdi:water-percent",
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement_fn=lambda device: "%",
+        value_fn=lambda device: device.water_level_percent,
+        exists_fn=lambda device: (device.type in {DreoDeviceType.HUMIDIFIER}) and device.is_feature_supported("water_level_percent"),
+    ),
+    DreoSensorEntityDescription(
         key="Filter Active",
         translation_key="filter_active",
         icon="mdi:filter-check",

--- a/custom_components/dreo/strings.json
+++ b/custom_components/dreo/strings.json
@@ -207,6 +207,9 @@
       "filter_life": {
         "name": "Filter Life"
       },
+      "water_level_percent": {
+        "name": "Water Level Percent"
+      },
       "filter_active": {
         "name": "Filter Active",
         "state": {

--- a/custom_components/dreo/translations/bg.json
+++ b/custom_components/dreo/translations/bg.json
@@ -196,6 +196,9 @@
       "filter_life": {
         "name": "Живот на филтъра"
       },
+      "water_level_percent": {
+        "name": "Ниво на водата в проценти"
+      },
       "filter_active": {
         "name": "Активен филтър",
         "state": {

--- a/custom_components/dreo/translations/de.json
+++ b/custom_components/dreo/translations/de.json
@@ -196,6 +196,9 @@
       "filter_life": {
         "name": "Filterlebensdauer"
       },
+      "water_level_percent": {
+        "name": "Wasserstand in Prozent"
+      },
       "filter_active": {
         "name": "Filter aktiv",
         "state": {

--- a/custom_components/dreo/translations/en.json
+++ b/custom_components/dreo/translations/en.json
@@ -196,6 +196,9 @@
       "filter_life": {
         "name": "Filter Life"
       },
+      "water_level_percent": {
+        "name": "Water Level Percent"
+      },
       "filter_active": {
         "name": "Filter Active",
         "state": {

--- a/custom_components/dreo/translations/es.json
+++ b/custom_components/dreo/translations/es.json
@@ -196,6 +196,9 @@
       "filter_life": {
         "name": "Vida del filtro"
       },
+      "water_level_percent": {
+        "name": "Nivel de agua en porcentaje"
+      },
       "filter_active": {
         "name": "Filtro activo",
         "state": {

--- a/custom_components/dreo/translations/fr.json
+++ b/custom_components/dreo/translations/fr.json
@@ -196,6 +196,9 @@
       "filter_life": {
         "name": "Durée de vie du filtre"
       },
+      "water_level_percent": {
+        "name": "Niveau d'eau en pourcentage"
+      },
       "filter_active": {
         "name": "Filtre actif",
         "state": {

--- a/custom_components/dreo/translations/it.json
+++ b/custom_components/dreo/translations/it.json
@@ -196,6 +196,9 @@
       "filter_life": {
         "name": "Durata filtro"
       },
+      "water_level_percent": {
+        "name": "Livello acqua in percentuale"
+      },
       "filter_active": {
         "name": "Filtro attivo",
         "state": {

--- a/custom_components/dreo/translations/nl.json
+++ b/custom_components/dreo/translations/nl.json
@@ -196,6 +196,9 @@
       "filter_life": {
         "name": "Filterlevensduur"
       },
+      "water_level_percent": {
+        "name": "Waterniveau in procenten"
+      },
       "filter_active": {
         "name": "Filter actief",
         "state": {

--- a/custom_components/dreo/translations/pl.json
+++ b/custom_components/dreo/translations/pl.json
@@ -196,6 +196,9 @@
       "filter_life": {
         "name": "Żywotność filtra"
       },
+      "water_level_percent": {
+        "name": "Poziom wody w procentach"
+      },
       "filter_active": {
         "name": "Filtr aktywny",
         "state": {

--- a/tests/dreo/integrationtests/test_dreohumidifier.py
+++ b/tests/dreo/integrationtests/test_dreohumidifier.py
@@ -128,6 +128,24 @@ class TestDreoHumidifier(IntegrationTestBase):
             binary_sensors = binary_sensor.get_entries([pydreo_humidifier])
             assert len(binary_sensors) == 1
 
+    def test_HHM014S_water_level_percent_attribute(self):  # pylint: disable=invalid-name
+        """Test that a DR-HHM014S reporting waterlevel surfaces it as a water_empty attribute and sensor."""
+        with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):
+            self.get_devices_file_name = "get_devices_HHM014S_2.json"
+            self.pydreo_manager.load_devices()
+            assert len(self.pydreo_manager.devices) == 1
+
+            pydreo_humidifier: PyDreoHumidifier = self.pydreo_manager.devices[0]
+
+            binary_sensors = binary_sensor.get_entries([pydreo_humidifier])
+            assert len(binary_sensors) == 1
+            assert binary_sensors[0].extra_state_attributes.get("water_level_percent") == 42
+
+            sensors = sensor.get_entries([pydreo_humidifier])
+            water_level_percent_sensor = next(s for s in sensors if s.entity_description.key == "Water Level Percent")
+            assert water_level_percent_sensor.native_value == 42
+            assert water_level_percent_sensor.entity_description.entity_registry_enabled_default is False
+
     def test_HHM003S(self):# pylint: disable=invalid-name
         """Load HHM003S (HM713S/813S) humidifier and test all features including humidity sensors."""
         with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):

--- a/tests/dreo/test_sensor.py
+++ b/tests/dreo/test_sensor.py
@@ -186,6 +186,48 @@ class TestDreoSensorHA(TestDeviceBase):
         assert filter_life.native_value == 75
         assert filter_life._attr_native_unit_of_measurement == "%"
 
+    def test_sensor_get_entries_water_level_percent(self):
+        """Test Water Level Percent sensor creation for humidifiers that support it."""
+        device = self.create_mock_device(
+            name="Test Humidifier", serial_number="HUM001", type="Humidifier", features={"water_level_percent": 42}
+        )
+
+        entities = sensor.get_entries([device])
+        keys = [e.entity_description.key for e in entities]
+        assert "Water Level Percent" in keys
+
+    def test_sensor_get_entries_water_level_percent_absent_when_unsupported(self):
+        """Test Water Level Percent sensor is absent for devices that don't support it."""
+        device = self.create_mock_device(name="Test Humidifier", serial_number="HUM001", type="Humidifier", features={"humidity": 55})
+
+        entities = sensor.get_entries([device])
+        keys = [e.entity_description.key for e in entities]
+        assert "Water Level Percent" not in keys
+
+    def test_sensor_get_entries_water_level_percent_excluded_for_non_humidifier(self):
+        """Test Water Level Percent sensor is not created for a non-humidifier device type."""
+        device = self.create_mock_device(
+            name="Test Cooler", serial_number="COOL001", type="Evaporative Cooler", features={"water_level_percent": 42}
+        )
+
+        entities = sensor.get_entries([device])
+        keys = [e.entity_description.key for e in entities]
+        assert "Water Level Percent" not in keys
+
+    def test_sensor_water_level_percent_native_value(self):
+        """Test the native_value property for the Water Level Percent sensor."""
+        with patch(PATCH_UPDATE_HA_STATE):
+            device = self.create_mock_device(
+                name="Test Humidifier", serial_number="HUM001", type="Humidifier", features={"water_level_percent": 42}
+            )
+
+            entities = sensor.get_entries([device])
+            water_level_percent_sensor = next(e for e in entities if e.entity_description.key == "Water Level Percent")
+            assert water_level_percent_sensor.native_value == 42
+            assert water_level_percent_sensor._attr_native_unit_of_measurement == "%"
+
+            device.water_level_percent = 18
+            assert water_level_percent_sensor.native_value == 18
 
     def test_sensor_filter_active(self):
         """Test Filter Active sensor creation for humidifiers."""

--- a/tests/pydreo/api_responses/get_device_state_HHM014S_2.json
+++ b/tests/pydreo/api_responses/get_device_state_HHM014S_2.json
@@ -1,0 +1,51 @@
+{
+    "code": 0,
+    "msg": "OK",
+    "data": {
+        "mixed": {
+            "poweron": {
+                "state": true,
+                "timestamp": 1735000000
+            },
+            "mode": {
+                "state": 1,
+                "timestamp": 1735000000
+            },
+            "rh": {
+                "state": 52,
+                "timestamp": 1735000000
+            },
+            "rhautolevel": {
+                "state": 55,
+                "timestamp": 1735000000
+            },
+            "worktime": {
+                "state": 1220,
+                "timestamp": 1735000000
+            },
+            "muteon": {
+                "state": true,
+                "timestamp": 1735000000
+            },
+            "wrong": {
+                "state": 0,
+                "timestamp": 1735000000
+            },
+            "waterlevel": {
+                "state": 42,
+                "timestamp": 1735000000
+            },
+            "rgblevel": {
+                "state": 2,
+                "timestamp": 1735000000
+            },
+            "scheon": {
+                "state": false,
+                "timestamp": 1735000000
+            }
+        },
+        "sn": "HHM014S_2",
+        "productId": "1903038208387133441",
+        "region": "us-east-1/emq"
+    }
+}

--- a/tests/pydreo/api_responses/get_devices_HHM014S_2.json
+++ b/tests/pydreo/api_responses/get_devices_HHM014S_2.json
@@ -1,0 +1,90 @@
+{
+  "code": 0,
+  "msg": "OK",
+  "data": {
+    "currentPage": 1,
+    "pageSize": 100,
+    "totalNum": 1,
+    "totalPage": 1,
+    "list": [
+      {
+        "deviceId": "1974920854696423427",
+        "sn": "HHM014S_2",
+        "brand": "Dreo",
+        "model": "DR-HHM014S",
+        "productId": "**REDACTED**",
+        "productName": "Humidifier",
+        "deviceName": "DEBUGTEST - Humidifier - DR-HHM014S",
+        "shared": false,
+        "series": null,
+        "seriesName": "HM774S",
+        "type": 0,
+        "owner": true,
+        "familyId": null,
+        "familyName": null,
+        "roomId": null,
+        "roomName": null,
+        "roomNameI18Key": "",
+        "color": "w",
+        "widgetOnImage": "https://resources.dreo-tech.com/app/preSigned202507/3bf64f82b3ae2411c96e713f2eec52334.png",
+        "widgetOffImage": "https://resources.dreo-tech.com/app/preSigned202507/3e66b7a1b39c6465980fbdc1b1a8d0e1f.png",
+        "widgetAbnormalImage": null,
+        "variantIconMd5": null,
+        "controlsConf": {
+          "schedule": {
+            "modes": [
+              {
+                "icon": "ic_sch_item_manual",
+                "title": "device_control_mode_manual",
+                "cmd": "mode",
+                "value": 0,
+                "valueType": 1
+              },
+              {
+                "icon": "ic_sch_item_auto",
+                "title": "device_control_mode_auto",
+                "cmd": "mode",
+                "value": 1,
+                "valueType": 1
+              },
+              {
+                "icon": "ic_sch_item_sleep",
+                "title": "device_control_mode_sleep",
+                "cmd": "mode",
+                "value": 2,
+                "valueType": 1
+              }
+            ]
+          }
+        },
+        "mainConf": {
+          "isSmart": true,
+          "isWifi": true,
+          "isBluetooth": null,
+          "isVoiceControl": true
+        },
+        "resourcesConf": {
+          "imageSmallSrc": "https://resources.dreo-tech.com/app/preSigned202507/3bbb57ff470d74a84b10c7eb01828ae19.png",
+          "imageFullSrc": "https://resources.dreo-tech.com/app/preSigned202507/37978a5f851a04a78934d73f247c40011.zip",
+          "imageSmallDarkSrc": null,
+          "imageFullDarkSrc": null
+        },
+        "servicesConf": [],
+        "userManuals": [
+          {
+            "url": "https://resources.dreo-tech.com/app/preSigned202507/11713e9c01fe31472ea7d29d3b69a142a6.pdf",
+            "icon": null,
+            "desc": "DR-HHM014S User Manual V1",
+            "lang": "en"
+          },
+          {
+            "url": "https://resources.dreo-tech.com/app/preSigned202509/18113abe9fa6234d34a4a7adbd29cd74a3.pdf",
+            "icon": null,
+            "desc": "DR-HHM014S User Manual-US",
+            "lang": "en"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/pydreo/test_pydreohumidifier.py
+++ b/tests/pydreo/test_pydreohumidifier.py
@@ -35,6 +35,7 @@ class TestPyDreoHumidifier(TestBase):
         _ = humidifier.mode
         _ = humidifier.wrong
         _ = humidifier.water_level
+        _ = humidifier.water_level_percent
         _ = humidifier.worktime
         _ = humidifier.display_light
         _ = humidifier.foglevel
@@ -185,6 +186,42 @@ class TestPyDreoHumidifier(TestBase):
         # Check that water_level is accessible and returns the expected value
         assert humidifier.is_feature_supported("water_level") is True
         assert humidifier.water_level == "ok"
+
+    def test_HHM014S_water_level_percent_property(self):  # pylint: disable=invalid-name
+        """Test that water_level_percent is reported for a DR-HHM014S that sends the raw field."""
+        self.get_devices_file_name = "get_devices_HHM014S_2.json"
+        self.pydreo_manager.load_devices()
+        assert len(self.pydreo_manager.devices) == 1
+        humidifier: PyDreoHumidifier = self.pydreo_manager.devices[0]
+
+        assert humidifier.is_feature_supported("water_level_percent") is True
+        assert humidifier.water_level_percent == 42
+
+    def test_water_level_percent_absent_for_models_without_it(self):
+        """Test that water_level_percent is absent (not an error) for models that don't report the raw field."""
+        self.get_devices_file_name = "get_devices_HHM001S.json"
+        self.pydreo_manager.load_devices()
+        assert len(self.pydreo_manager.devices) == 1
+        humidifier: PyDreoHumidifier = self.pydreo_manager.devices[0]
+
+        assert humidifier.is_feature_supported("water_level_percent") is False
+        assert humidifier.water_level_percent is None
+
+    def test_handle_server_update_water_level_percent(self):
+        """Test handle_server_update processes the numeric water level percentage."""
+        self.get_devices_file_name = "get_devices_HHM014S_2.json"
+        self.pydreo_manager.load_devices()
+        humidifier: PyDreoHumidifier = self.pydreo_manager.devices[0]
+        humidifier.handle_server_update({REPORTED_KEY: {"waterlevel": 42}})
+        assert humidifier.water_level_percent == 42
+
+    def test_water_level_percent_rest_path_out_of_range_value(self):
+        """Test that update_state() passes an out-of-domain waterlevel value through unchanged."""
+        self.get_devices_file_name = "get_devices_HHM014S_2.json"
+        self.pydreo_manager.load_devices()
+        humidifier: PyDreoHumidifier = self.pydreo_manager.devices[0]
+        humidifier.update_state({"waterlevel": {"state": 137, "timestamp": 1735000000}})
+        assert humidifier.water_level_percent == 137
 
     def test_HHM003S(self):  # pylint: disable=invalid-name
         """Load HHM003S (HM713S/813S) and test humidity properties."""


### PR DESCRIPTION
## What

Adds a numeric `water_level_percent` for humidifiers that report it, alongside the existing Ok/Empty `water_empty` status.

Confirmed on a `DR-HHM014S` (HM774S): the device reports a `waterlevel` field (0-100, in ~6% steps) in addition to the `wrong` fault code that already backs `water_empty`. That field isn't read or exposed anywhere today.

## What changed

- `pydreo/pydreohumidifier.py`: new `water_level_percent` property, backed by its own constant (`WATER_LEVEL_PERCENT_KEY = "waterlevel"`) and its own state, wired through the same `update_state()`/`handle_server_update()` paths every other field already uses. Doesn't touch `wrong`/`water_level` or their existing meaning.
- `binary_sensor.py`: the existing `water_empty` entity's attributes gain `water_level_percent` (free, no new entity, matches the pattern already used for `water_level` there).
- `sensor.py`: one new entity, `Water Level Percent`, modeled on the existing `Filter Life` sensor (plain 0-100 measurement, no `device_class`), scoped to humidifiers and gated by `is_feature_supported`. **Ships opt-in** (`entity_registry_enabled_default=False`) — see below for why.
- `strings.json` + all locale files: translation key for the new sensor.
- Tests across all three buckets (`tests/pydreo`, `tests/dreo`, `tests/dreo/integrationtests`), including a new fixture with the `waterlevel` field, and a case for the field being absent/malformed on models that don't report it.

## Why opt-in

I know this repo has moved *away* from a redundant water-level sensor before (`ed2ee9ce`, "The enum sensor with Ok/Empty values was redundant"), and I don't want to reopen that with a percentage sensor most users don't have data for. This is confirmed on exactly one model. Shipping it disabled by default (same as `fixed_conf_settle_pending` in `binary_sensor.py`) means nobody gets a new entity they didn't ask for, but the data's there for anyone whose device reports it, and it can be reconsidered for default-enabled once more models are confirmed. The `water_empty` attribute is always on, at no cost, since it's just an extra key in an existing dict.

## Testing

- Full test suite passes locally (`pytest tests/`), `ruff check` clean.
- Verified against a real `DR-HHM014S` running this patch: `water_level_percent` reads a live value from the device, matches expectations, over an extended test period.

## Caveat

This is single-model evidence. I don't know whether other Dreo humidifiers report the same field under the same key, or with the same granularity. The code degrades safely either way (falls back to `None`/absent, tested), but I'm not claiming it works beyond the one model I could verify.
