### PR TITLE
Fix KeyError crash adding heater climate entity for unmapped oscangle values

### DIFF
--- a/custom_components/dreo/dreoheater.py
+++ b/custom_components/dreo/dreoheater.py
@@ -371,7 +371,7 @@ class DreoHeaterHA(DreoBaseDeviceHA, ClimateEntity):
         elif self.device.oscon is not None and self.device.oscon is True:
             self._attr_swing_mode = SWING_ON
         elif self.device.oscangle is not None:
-            self._attr_swing_mode = ANGLE_OSCANGLE_MAP[self.device.oscangle]
+            self._attr_swing_mode = ANGLE_OSCANGLE_MAP.get(self.device.oscangle, SWING_OFF)
         else:
             self._attr_swing_mode = SWING_OFF
         return self._attr_swing_mode


### PR DESCRIPTION
## Summary
- `DreoHeaterHA.swing_mode` reads `ANGLE_OSCANGLE_MAP[self.device.oscangle]` directly. `ANGLE_OSCANGLE_MAP` only defines keys `0`, `60`, `90`, `120`, but some heaters (observed on a DR-HSH009S) can report other raw `oscangle` values from the cloud API (observed: `110`), which are not in the map.
- When Home Assistant reads `swing_mode` while adding the climate entity, this raises an unhandled `KeyError`, which aborts adding the entity entirely — the climate entity never gets created and stays permanently unavailable until the device happens to report one of the four mapped angles again.
- The sibling `oscangle` property a few lines above already guards the same map with `... if self.device.oscangle in ANGLE_OSCANGLE_MAP else None`; `swing_mode` doesn't have the same guard.

## Fix
Use `ANGLE_OSCANGLE_MAP.get(self.device.oscangle, SWING_OFF)` instead of direct indexing, consistent with how `HEATER_OSCMODE_SWING_MAP` is already read a few lines above via `.get(..., SWING_OFF)`.

## Traceback (from a real device hitting this)
```
Error adding entity climate.<heater>_heater for domain climate with platform dreo
Traceback (most recent call last):
  File ".../homeassistant/helpers/entity_platform.py", line 725, in _async_add_entities
    await self._async_add_entity(
  File ".../homeassistant/helpers/entity_platform.py", line 1104, in _async_add_entity
    await entity.add_to_platform_finish()
  File ".../homeassistant/helpers/entity.py", line 1446, in add_to_platform_finish
    self.async_write_ha_state()
  File ".../homeassistant/helpers/entity.py", line 1061, in async_write_ha_state
    self._async_write_ha_state()
  File ".../homeassistant/helpers/entity.py", line 1213, in _async_write_ha_state
    ) = self.__async_calculate_state()
  File ".../homeassistant/components/climate/__init__.py", line 407, in state_attributes
    data[ClimateEntityStateAttribute.SWING_MODE] = self.swing_mode
  File "custom_components/dreo/dreoheater.py", line 374, in swing_mode
    self._attr_swing_mode = ANGLE_OSCANGLE_MAP[self.device.oscangle]
KeyError: 110
```

## Test plan
- [x] Applied the same one-line change locally against a running Home Assistant instance with a DR-HSH009S reporting `oscangle: 110`.
- [x] Confirmed the previous crash (`Error adding entity ... KeyError: 110`) no longer occurs after a full HA Core restart (module code is cached, so a config-entry reload alone isn't enough to pick up the fix).
- [x] Confirmed the `climate.*` entity is created and reaches state `off` with `swing_mode: "off"` instead of failing to load.