### PR TITLE
Add the DR-HCF010S capabilities test #914 was missing

### DIFF
--- a/tests/pydreo/test_pydreoceilingfan.py
+++ b/tests/pydreo/test_pydreoceilingfan.py
@@ -36,6 +36,15 @@ class TestPyDreoCeilingFan(TestBase):
         assert details.device_ranges["atm_brightness_range"] == (1, 100)
         assert details.device_ranges["supports_direct_rgb_color"] is True
 
+    def test_HCF010S_capabilities(self):  # pylint: disable=invalid-name
+        """DR-HCF010S has the CF510S RGBIC ceiling-fan capabilities."""
+        details = SUPPORTED_DEVICES["DR-HCF010S"]
+        assert details.device_type == DreoDeviceType.CEILING_FAN
+        assert details.device_ranges[SPEED_RANGE] == (1, 12)
+        assert details.preset_modes == [("normal", 1), ("natural", 2), ("sleep", 3), ("reverse", 4)]
+        assert details.device_ranges["atm_brightness_range"] == (1, 100)
+        assert details.device_ranges["supports_direct_rgb_color"] is True
+
     def _exercise_all_settable_properties(self, fan: PyDreoCeilingFan):
         """Exercise all writable ceiling-fan properties that are supported by a model."""
         _ = fan.speed_range


### PR DESCRIPTION
#900 paired its DR-HCF008S model entry with a `test_HCF008S_capabilities` assertion. #914 added the DR-HCF010S entry without the matching test, so nothing pins the speed range, preset modes, or RGBIC ranges that entry claims.

Adds `test_HCF010S_capabilities` alongside the existing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPYgF6gwZpehwpvop1N3Xb