### PR TITLE
Add DR-HAP010S (Air Purifier 530S) support

### DIFF
--- a/SUPPORTED_MODELS.md
+++ b/SUPPORTED_MODELS.md
@@ -67,6 +67,7 @@ This document lists all Dreo device models that have been tested and confirmed t
 - DR-HAP003S
 - DR-HAP005S
 - DR-HAP008S
+- DR-HAP010S (530S)
 
 ## Humidifiers (DR-HHM Series)
 

--- a/custom_components/dreo/pydreo/models.py
+++ b/custom_components/dreo/pydreo/models.py
@@ -487,6 +487,14 @@ SUPPORTED_DEVICES = {
         preset_modes=[("auto", "auto"), ("manual", "manual"), ("sleep", "sleep"), ("turbo", "turbo")],
         device_ranges={SPEED_RANGE: (1, 4)},
     ),
+    # DR-HAP010S (Air Purifier 530S) diagnostics report an empty controlsConf object, so the
+    # speed range and preset modes cannot be auto-detected. Hardcode the fan capabilities
+    # shared by the other empty-controlsConf purifiers so the fan entity is created (issue #906).
+    "DR-HAP010S": DreoDeviceDetails(
+        device_type=DreoDeviceType.AIR_PURIFIER,
+        preset_modes=[("auto", "auto"), ("manual", "manual"), ("sleep", "sleep"), ("turbo", "turbo")],
+        device_ranges={SPEED_RANGE: (1, 4)},
+    ),
     # Heaters
     "DR-HSH017BS": DreoHeaterDeviceDetails(
         device_ranges={ECOLEVEL_RANGE: (41, 85)},

--- a/tests/dreo/integrationtests/test_dreoairpurifier.py
+++ b/tests/dreo/integrationtests/test_dreoairpurifier.py
@@ -322,3 +322,35 @@ class TestDreoAirPurifier(IntegrationTestBase):
             with patch(PATCH_SEND_COMMAND) as mock_send_command:
                 ha_fan.set_percentage(100)
                 mock_send_command.assert_called_once_with(pydreo_ap, {WINDLEVEL_KEY: 4})
+
+    def test_HAP010S(self):  # pylint: disable=invalid-name
+        """Load HAP010S (530S) air purifier with empty controlsConf and test HA fan entity."""
+        with patch(PATCH_SCHEDULE_UPDATE_HA_STATE):
+            self.get_devices_file_name = "get_devices_HAP010S.json"
+            self.pydreo_manager.load_devices()
+
+            pydreo_ap = self.pydreo_manager.devices[0]
+            assert pydreo_ap.model == "DR-HAP010S"
+            assert pydreo_ap.speed_range == (1, 4)
+            assert pydreo_ap.preset_modes == ["auto", "manual", "sleep", "turbo"]
+
+            ha_fan = fan.DreoFanHA(pydreo_ap)
+            # #912 stopped speed_count from crashing on a None speed_range; the hardcoded
+            # range is what makes the entity actually controllable.
+            assert ha_fan.speed_count == 4
+            assert ha_fan.preset_modes == ["auto", "manual", "sleep", "turbo"]
+            assert ha_fan.is_on is True
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.turn_off()
+                mock_send_command.assert_called_once_with(pydreo_ap, {POWERON_KEY: False})
+            pydreo_ap.handle_server_update({REPORTED_KEY: {POWERON_KEY: False}})
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.turn_on()
+                mock_send_command.assert_called_once_with(pydreo_ap, {POWERON_KEY: True})
+            pydreo_ap.handle_server_update({REPORTED_KEY: {POWERON_KEY: True}})
+
+            with patch(PATCH_SEND_COMMAND) as mock_send_command:
+                ha_fan.set_percentage(100)
+                mock_send_command.assert_called_once_with(pydreo_ap, {WINDLEVEL_KEY: 4})

--- a/tests/pydreo/api_responses/get_device_state_HAP010S_1.json
+++ b/tests/pydreo/api_responses/get_device_state_HAP010S_1.json
@@ -1,0 +1,48 @@
+{
+    "code": 0,
+    "msg": "OK",
+    "data": {
+        "mixed": {
+            "poweron": {
+                "state": true,
+                "timestamp": 0
+            },
+            "mode": {
+                "state": "manual",
+                "timestamp": 0
+            },
+            "windlevel": {
+                "state": 3,
+                "timestamp": 0
+            },
+            "pm25": {
+                "state": 12,
+                "timestamp": 0
+            },
+            "lifetime": {
+                "state": 100,
+                "timestamp": 0
+            },
+            "ledalwayson": {
+                "state": true,
+                "timestamp": 0
+            },
+            "childlockon": {
+                "state": false,
+                "timestamp": 0
+            },
+            "muteon": {
+                "state": true,
+                "timestamp": 0
+            },
+            "connected": {
+                "state": true,
+                "timestamp": 0
+            }
+        },
+        "sn": "HAP010S_1",
+        "productId": "**REDACTED**",
+        "region": "us-east-2/emq",
+        "deviceInfo": null
+    }
+}

--- a/tests/pydreo/api_responses/get_devices_HAP010S.json
+++ b/tests/pydreo/api_responses/get_devices_HAP010S.json
@@ -1,0 +1,40 @@
+{
+    "code": 0,
+    "msg": "OK",
+    "data": {
+        "currentPage": 1,
+        "pageSize": 100,
+        "totalNum": 1,
+        "totalPage": 1,
+        "familyRooms": null,
+        "list": [
+            {
+                "deviceId": "1834678463454253100",
+                "sn": "HAP010S_1",
+                "brand": "Dreo",
+                "model": "DR-HAP010S",
+                "productId": "**REDACTED**",
+                "productName": "Air Purifier",
+                "deviceName": "DEBUGTEST - Air Purifier - DR-HAP010S",
+                "shared": false,
+                "series": null,
+                "seriesName": "530S",
+                "type": 0,
+                "owner": true,
+                "familyId": null,
+                "familyName": null,
+                "roomId": null,
+                "roomName": null,
+                "roomNameI18Key": "",
+                "color": "b",
+                "controlsConf": {},
+                "mainConf": {
+                    "isSmart": true,
+                    "isWifi": true,
+                    "isBluetooth": null,
+                    "isVoiceControl": true
+                }
+            }
+        ]
+    }
+}

--- a/tests/pydreo/test_pydreoairpurifier.py
+++ b/tests/pydreo/test_pydreoairpurifier.py
@@ -195,6 +195,16 @@ class TestPyDreoAirPurifier(TestBase):
         assert air_purifier.speed_range == (1, 4)
         assert air_purifier.preset_modes == ["auto", "manual", "sleep", "turbo"]
 
+    def test_HAP010S(self):  # pylint: disable=invalid-name
+        """Test DR-HAP010S (530S) Air Purifier with empty controlsConf."""
+        self.get_devices_file_name = "get_devices_HAP010S.json"
+        self.pydreo_manager.load_devices()
+        air_purifier = self.pydreo_manager.devices[0]
+        assert air_purifier.model == "DR-HAP010S"
+        assert air_purifier.series_name == "530S"
+        assert air_purifier.speed_range == (1, 4)
+        assert air_purifier.preset_modes == ["auto", "manual", "sleep", "turbo"]
+
     def test_air_purifier_preset_mode_variant_mapping(self):
         """Mode variants like auto-regular should still map to the base preset mode."""
         self.get_devices_file_name = "get_devices_HAP003S.json"


### PR DESCRIPTION
Fixes #906

## What the diagnostics show

`DR-HAP010S` comes back from the API with `"controlsConf": {}`, so nothing can be auto-detected — no speed range, no preset modes. That's why the reporter sees the device appear but with no working controls ("It doesn't have a toggle to turn on/off"). Their log also contains the `speed_range is None` `TypeError`, which #912 already fixed on main; this PR is the other half — making the entity actually controllable rather than just crash-free.

## Change

Hardcode the capabilities exactly the way the other empty-`controlsConf` purifiers already do (`DR-HAP006S`, `DR-HAP008S`, `DR-HAP009S`):

```python
"DR-HAP010S": DreoDeviceDetails(
    device_type=DreoDeviceType.AIR_PURIFIER,
    preset_modes=[("auto", "auto"), ("manual", "manual"), ("sleep", "sleep"), ("turbo", "turbo")],
    device_ranges={SPEED_RANGE: (1, 4)},
),
```

Plus the `SUPPORTED_MODELS.md` entry, test fixtures, and pydreo + integration tests mirroring `test_HAP008S`.

## Worth confirming with the reporter

- **Speed count and mode list** are inherited from the sibling models, not observed — the diagnostics contain no `controlsConf` and no device state. If the 530S has a different number of speeds, that's the line to change.
- **No `auto-regular` override** is applied. `DR-HAP006S` and `DR-HAP009S` need one because they reject the plain `auto` command; there's no evidence either way for this model. If @Logikk22 reports `auto` failing with "instruction validate failed", adding `override_fn=_hap009s_override` is the known remedy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPYgF6gwZpehwpvop1N3Xb